### PR TITLE
Bump release version to 5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,13 @@
-# Bio-Formats
+# OME Data Model
 
-[![Build Status](https://travis-ci.org/openmicroscopy/bioformats.png)](http://travis-ci.org/openmicroscopy/bioformats)
+[![Build Status](https://travis-ci.org/ome/ome-model.png)](http://travis-ci.org/ome/ome-model)
 
-Bio-Formats is a standalone Java library for reading and writing life sciences
-image file formats. It is capable of parsing both pixels and metadata for a
-large number of formats, as well as writing to several formats.
-
-
-Purpose
--------
-
-Bio-Formats' primary purpose is to convert proprietary microscopy data into 
-an open standard called the OME data model, particularly into the OME-TIFF 
-file format. See the [statement of purpose](http://www.openmicroscopy.org/site/support/bio-formats/about/index.html) 
-for a thorough explanation and rationale.
-
-
-Supported formats
------------------
-
-Bio-Formats supports [more than a hundred file
-formats](http://www.openmicroscopy.org/site/support/bio-formats/supported-formats.html).
-
-
-For users
----------
-
-[Many software
-packages](http://www.openmicroscopy.org/site/support/bio-formats/users/index.html)
-use Bio-Formats to read and write microscopy formats.
-
-
-For developers
---------------
-
-You can use Bio-Formats to easily [support these formats in your
-software](http://www.openmicroscopy.org/site/support/bio-formats/developers/java-library.html).
-
+OME data model specification, code generator and implementation.
 
 More information
 ----------------
 
-For more information, see the [Bio-Formats web
-site](http://www.openmicroscopy.org/site/products/bio-formats).
-
+For more information, see the [OME Model documentation](http://www.openmicroscopy.org/site/support/ome-model/).
 
 Pull request testing
 --------------------
@@ -51,13 +15,9 @@ Pull request testing
 We welcome pull requests from anyone, but ask that you please verify the
 following before submitting a pull request:
 
- * verify that the branch merges cleanly into ```develop```
- * verify that the branch compiles with the ```clean jars tools``` Ant targets
+ * verify that the branch merges cleanly into ```master```
  * verify that the branch compiles using Maven
  * verify that the branch does not use syntax or API specific to Java 1.8+
- * run the unit tests (```ant test```) and correct any failures
- * test at least one file in each affected format, using the ```showinf```
-   command
  * internal developers only: [run the data
    tests](http://www.openmicroscopy.org/site/support/bio-formats/developers/commit-testing.html)
    against directories corresponding to the affected format(s)

--- a/ome-xml/pom.xml
+++ b/ome-xml/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.openmicroscopy</groupId>
     <artifactId>ome-model</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <version>5.3.0</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.openmicroscopy</groupId>
   <artifactId>ome-model</artifactId>
-  <version>5.3.0-SNAPSHOT</version>
+  <version>5.3.0</version>
   <packaging>pom</packaging>
 
   <name>OME Model</name>

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.openmicroscopy</groupId>
     <artifactId>ome-model</artifactId>
-    <version>5.3.0-SNAPSHOT</version>
+    <version>5.3.0</version>
     <relativePath>..</relativePath>
   </parent>
 
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-xml</artifactId>
-      <version>5.3.0-SNAPSHOT</version>
+      <version>5.3.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
In preparation of the upcoming release to Maven Central, this PR:

- fixes the top-level README
- bumps the release version to 5.3.0

/cc @rleigh-codelibre @dgault @melissalinkert 