### PR TITLE
Add newlines to test generated sources jobs

### DIFF
--- a/xsd-fu/templates-cpp/DummyMetadata.template
+++ b/xsd-fu/templates-cpp/DummyMetadata.template
@@ -23,6 +23,7 @@
       BaseMetadata::index_type
       DummyMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string_dummy(indexes[:-1])}) const
       {
+
         throw MetadataException("DummyMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count",
                                 "intentionally not implemented");
       }

--- a/xsd-fu/templates-java/DummyMetadata.template
+++ b/xsd-fu/templates-java/DummyMetadata.template
@@ -14,6 +14,7 @@
 {% def counter(parent, obj, indexes) %}\
   public int get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])})
   {
+
     return -1;
   }
 {% end %}\


### PR DESCRIPTION
Should cause https://ci.openmicroscopy.org/view/Failing/job/OME-MODEL-merge-generated-sources/ to become unstable.