### PR TITLE
Remove OME artifactory from OME-XML pom

### DIFF
--- a/ome-xml/pom.xml
+++ b/ome-xml/pom.xml
@@ -228,20 +228,4 @@
       </properties>
     </developer>
   </developers>
-
-  <!-- NB: for project parent, in case of partial checkout -->
-  <repositories>
-    <repository>
-      <id>ome.experimental</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.experimental</url>
-    </repository>
-    <repository>
-      <id>ome.releases</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.releases</url>
-    </repository>
-    <repository>
-      <id>ome.snapshots</id>
-      <url>http://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
-    </repository>
-  </repositories>
 </project>


### PR DESCRIPTION
Noticed in https://github.com/openmicroscopy/bioformats/pull/2661#issuecomment-260919988, the `ome-xml` POM still contains unnecessary references to the OME artifactory.