### PR TITLE
Make ROI transforms functional

### DIFF
--- a/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
@@ -123,6 +123,8 @@ namespace ome
          * @param name the element name to check.
          *
          * @returns @c true if valid, @c false if invalid.
+         * @deprecated Always returns true since any element name is
+         * now regarded as being valid.
          */
         virtual bool
         validElementName(const std::string& name) const = 0;
@@ -145,6 +147,20 @@ namespace ome
          */
         virtual common::xml::dom::Element
         asXMLElement (common::xml::dom::Document& document) const = 0;
+
+          /**
+           * Transform the object hierarchy rooted at this element to
+           * XML.  This internal implementation of asXMLelement also
+           * requires an XML element, which must not be null, or may
+           * be instantiated and passed from superclasses.
+           *
+           * @param document XML document for element creation.
+           * @param element XML element for setting model data.
+           * @returns an XML DOM tree root element for this model object.
+           */
+        virtual common::xml::dom::Element
+        asXMLElement (common::xml::dom::Document& document,
+                      common::xml::dom::Element&  element) const = 0;
 
         /**
          * Update the object hierarchy recursively from an XML DOM tree.

--- a/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
@@ -156,9 +156,8 @@ namespace ome
            *
            * @param document XML document for element creation.
            * @param element XML element for setting model data.
-           * @returns an XML DOM tree root element for this model object.
            */
-        virtual common::xml::dom::Element
+        virtual void
         asXMLElement (common::xml::dom::Document& document,
                       common::xml::dom::Element&  element) const = 0;
 

--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -178,12 +178,12 @@ namespace ome
         return false;
       }
 
-      common::xml::dom::Element
+      void
       OriginalMetadataAnnotation::asXMLElementInternal (common::xml::dom::Document& document,
                                                         common::xml::dom::Element&  element) const
       {
 
-        return XMLAnnotation::asXMLElementInternal(document, element);
+        XMLAnnotation::asXMLElementInternal(document, element);
       }
 
       OriginalMetadataAnnotation::metadata_type&

--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -179,13 +179,6 @@ namespace ome
       }
 
       common::xml::dom::Element
-      OriginalMetadataAnnotation::asXMLElement (common::xml::dom::Document& document) const
-      {
-        common::xml::dom::Element nullelem;
-        return asXMLElementInternal(document, nullelem);
-      }
-
-      common::xml::dom::Element
       OriginalMetadataAnnotation::asXMLElementInternal (common::xml::dom::Document& document,
                                                         common::xml::dom::Element&  element) const
       {

--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
@@ -153,7 +153,7 @@ namespace ome
 
       protected:
         // Documented in base class.
-        virtual common::xml::dom::Element
+        virtual void
         asXMLElementInternal (common::xml::dom::Document& document,
                               common::xml::dom::Element&  element) const;
       };

--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
@@ -151,10 +151,6 @@ namespace ome
         void
         setMetadata (const metadata_type& map);
 
-        /// @copydoc ome::xml::model::OMEModelObject::asXMLElement
-        virtual common::xml::dom::Element
-        asXMLElement (common::xml::dom::Document& document) const;
-
       protected:
         // Documented in base class.
         virtual common::xml::dom::Element

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
@@ -74,6 +74,24 @@ namespace ome
         }
 
         common::xml::dom::Element
+        OMEModelObject::asXMLElement (common::xml::dom::Document& document) const
+        {
+          common::xml::dom::Element element;
+          if(elementName() != "OME")
+            element = document.createElementNS(getXMLNamespace(), "${klass.name}");
+          else
+            element = document.getDocumentElement();
+          return asXMLElementInternal(document, element);
+        }
+
+        common::xml::dom::Element
+        OMEModelObject::asXMLElement (common::xml::dom::Document& document,
+                                      common::xml::dom::Element&  element) const
+        {
+          return asXMLElementInternal(document, element);
+        }
+
+        common::xml::dom::Element
         OMEModelObject::asXMLElementInternal (common::xml::dom::Document& /* document */,
                                               common::xml::dom::Element&  element) const
         {

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
@@ -81,21 +81,21 @@ namespace ome
             element = document.createElementNS(getXMLNamespace(), "${klass.name}");
           else
             element = document.getDocumentElement();
-          return asXMLElementInternal(document, element);
+          asXMLElementInternal(document, element);
+          return element;
         }
 
-        common::xml::dom::Element
+        void
         OMEModelObject::asXMLElement (common::xml::dom::Document& document,
                                       common::xml::dom::Element&  element) const
         {
-          return asXMLElementInternal(document, element);
+          asXMLElementInternal(document, element);
         }
 
-        common::xml::dom::Element
+        void
         OMEModelObject::asXMLElementInternal (common::xml::dom::Document& /* document */,
-                                              common::xml::dom::Element&  element) const
+                                              common::xml::dom::Element&  /* element */) const
         {
-          return element;
         }
 
         void

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.h
@@ -90,7 +90,7 @@ namespace ome
           asXMLElement (common::xml::dom::Document& document) const;
 
           /// @copydoc ome::xml::model::OMEModelObject::asXMLElement
-          virtual common::xml::dom::Element
+          virtual void
           asXMLElement (common::xml::dom::Document& document,
                         common::xml::dom::Element&  element) const;
         protected:
@@ -105,9 +105,8 @@ namespace ome
            *
            * @param document XML document for element creation.
            * @param element XML element for setting model data.
-           * @returns an XML DOM tree root element for this model object.
            */
-          virtual common::xml::dom::Element
+          virtual void
           asXMLElementInternal (common::xml::dom::Document& document,
                                 common::xml::dom::Element&  element) const = 0;
 

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.h
@@ -85,12 +85,23 @@ namespace ome
           bool
           validElementName(const std::string& name) const = 0;
 
+          /// @copydoc ome::xml::model::OMEModelObject::asXMLElement
+          virtual common::xml::dom::Element
+          asXMLElement (common::xml::dom::Document& document) const;
+
+          /// @copydoc ome::xml::model::OMEModelObject::asXMLElement
+          virtual common::xml::dom::Element
+          asXMLElement (common::xml::dom::Document& document,
+                        common::xml::dom::Element&  element) const;
         protected:
           /**
            * Transform the object hierarchy rooted at this element to
            * XML.  This internal implementation of asXMLelement also
            * requires an XML element, which must not be null, or may
            * be instantiated and passed from superclasses.
+           *
+           * Concrete model object implementations should override
+           * this method.
            *
            * @param document XML document for element creation.
            * @param element XML element for setting model data.

--- a/specification/src/main/java/ome/specification/XMLMockObjects.java
+++ b/specification/src/main/java/ome/specification/XMLMockObjects.java
@@ -749,7 +749,7 @@ public class XMLMockObjects
       shape.setTheC(new NonNegativeInteger(c));
       shape.setTheZ(new NonNegativeInteger(z));
       shape.setTheT(new NonNegativeInteger(t));
-      //shape.setTransform(createTransform());
+      shape.setTransform(createTransform());
       shape.setFillColor(new ome.xml.model.primitives.Color(100));
       shape.setStrokeColor(new ome.xml.model.primitives.Color(100));
     }
@@ -759,6 +759,9 @@ public class XMLMockObjects
   private AffineTransform createTransform()
   {
     AffineTransform at = new AffineTransform();
+    // simple translation
+    at.setA02(2.0);
+    at.setA12(3.0);
 
     return at;
   }

--- a/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
+++ b/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
@@ -1277,9 +1277,13 @@
         </xsl:for-each>
       </xsl:variable>
 
-      <xsl:attribute name="Transform">
-        <xsl:value-of select="$trans"/>
-      </xsl:attribute>
+      <xsl:choose>
+        <xsl:when test="trans != ''">
+          <xsl:attribute name="Transform">
+            <xsl:value-of select="$trans"/>
+          </xsl:attribute>
+        </xsl:when>
+      </xsl:choose>
       <xsl:for-each select="*">
         <xsl:choose>
           <xsl:when test="name()='Channels'">
@@ -1299,6 +1303,7 @@
       </xsl:for-each>
     </xsl:element>
   </xsl:template>
+
 
   <!-- Rename attributes and link to Pixels -->
   <xsl:template name="maskTansformation">

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -334,11 +334,9 @@ namespace ome
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::validElementName(const std::string& name) const
+      ${klass.name}::validElementName(const std::string& /* name */) const
       {
-        static const std::string expectedTagName("${klass.name}");
-
-        return expectedTagName == name || ${klass.parentName}::validElementName(name);
+        return true;
       }
 {% end source %}\
 
@@ -519,7 +517,7 @@ ${customUpdatePropertyContent[prop.name]}
           }
         else if (${prop.name}_nodeList.size() != 0)
           {
-{% if prop.isComplex() and not klass.isAbstract %}\
+{% if prop.isComplex() %}\
             // Element property ${prop.name} which is complex (has sub-elements)
 {% if prop.minOccurs == 0 or (not lang.hasPrimitiveType(prop.langType) and not prop.isEnumeration) %}\
             common::xml::dom::Element elem(${prop.name}_nodeList.at(0));
@@ -1245,26 +1243,6 @@ ${customUpdatePropertyContent[prop.name]}
 
 {% end %}\
 {% if fu.SOURCE_TYPE == "header" %}\
-        /// @copydoc ${lang.omexml_model_package}::OMEModelObject::asXMLElement
-        virtual common::xml::dom::Element
-        asXMLElement (common::xml::dom::Document& document) const;
-{% end header %}\
-{% if fu.SOURCE_TYPE == "source" %}\
-      common::xml::dom::Element
-      ${klass.name}::asXMLElement (common::xml::dom::Document& document) const
-      {
-{% if klass.name != "OME" %}\
-        common::xml::dom::Element element(document.createElementNS(getXMLNamespace(), "${klass.name}"));
-{% end if %}\
-{% if klass.name == "OME" %}\
-        common::xml::dom::Element element(document.getDocumentElement());
-{% end if %}\
-        return asXMLElementInternal(document, element);
-      }
-{% end source %}\
-
-{% if fu.SOURCE_TYPE == "header" %}\
-
       protected:
         // Documented in base class.
         virtual common::xml::dom::Element
@@ -1309,164 +1287,165 @@ ${customUpdatePropertyContent[prop.name]}
         element.setTextContent(this->impl->value);
 {% end %}\
 {% end %}\
-{% if klass.isAnnotation %}\
         // Ensure any base annotations add their Elements first
-        element = ${klass.parentName}::asXMLElementInternal(document, element);
-{% end if isAnnotation %}\
+        ${klass.parentName}::asXMLElementInternal(document, element);
+
 {% for prop in klass.properties.values() %}\
 {% if not prop.isUnitsEnumeration %}\
-{% if not klass.isAbstract or prop.isAttribute or not prop.isComplex() or (prop.name in fu.ANNOTATION_OVERRIDE) %}\
-        {
 {% choose %}\
 {% when prop.name in customAsXMLElementPropertyContent %}\
 {% if debug %}\
-          // -- BEGIN custom content from ${prop.name} property template --
+        // -- BEGIN custom content from ${prop.name} property template --
 {% end debug %}\
 ${customAsXMLElementPropertyContent[prop.name]}
 {% if debug %}\
-          // -- END custom content from ${prop.name} property template --
+        // -- END custom content from ${prop.name} property template --
 {% end debug %}\
 {% end when %}\
 {% when prop.hasBaseAttribute %}\
-          // Element's text data
+        // Element's text data
 {% if not prop.type == 'base64Binary' %}\
-          ${klass.name}_element.setTextContent(this->impl->${prop.instanceVariableName});
+        ${klass.name}_element.setTextContent(this->impl->${prop.instanceVariableName});
 {% end if not prop.type %}\
 {% if prop.type == 'base64Binary' %}\
-          std::string encodedString = ome::common::base64_encode(this->impl->${prop.instanceVariableName}.begin(),
-                                                                 this->impl->${prop.instanceVariableName}.end(),
+        std::string encodedString = ome::common::base64_encode(this->impl->${prop.instanceVariableName}.begin(),
+                                                               this->impl->${prop.instanceVariableName}.end(),
                                                                  0);
-          element.setTextContent(encodedString);
+        element.setTextContent(encodedString);
 {% end if prop.type %}\
 {% end when %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
-          {
-            // Reference property ${prop.name} which occurs more than once
-            for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
-                 i != this->impl->${prop.instanceVariableName}.end();
-                 ++i)
-              {
-                // Note that this doesn't strictly need to be a
-                // shared_ptr, but keep compatible with the rest of
-                // the API to allow consistency for future
-                // refactoring.
-                ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
-                ome::compat::shared_ptr<${prop.langTypeNS}> is(i->lock());
-                if (is)
-                  {
-                    o->setID(is->getID());
-                    common::xml::dom::Element child(o->asXMLElement(document));
-                    element.appendChild(child);
-                  }
-              }
-          }
+        {
+          // Reference property ${prop.name} which occurs more than once
+          for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
+               i != this->impl->${prop.instanceVariableName}.end();
+               ++i)
+            {
+              // Note that this doesn't strictly need to be a
+              // shared_ptr, but keep compatible with the rest of
+              // the API to allow consistency for future
+              // refactoring.
+              ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
+              ome::compat::shared_ptr<${prop.langTypeNS}> is(i->lock());
+              if (is)
+                {
+                  o->setID(is->getID());
+{% if prop.isAbstractSubstitution %}\
+                  common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), o->get${prop.name}Type()));
+{% end if %}\
+{% if not prop.isAbstractSubstitution %}\
+                  common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
+{% end if %}\
+                  child = o->asXMLElement(document, child);
+                  element.appendChild(child);
+                }
+            }
+        }
 {% end %}\
 {% when prop.isReference %}\
-          {
-            // Reference property ${prop.name}
-            // Note that this doesn't strictly need to be a
-            // shared_ptr, but keep compatible with the rest of the
-            // API to allow consistency for future refactoring.
-            ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
-            ome::compat::shared_ptr<${prop.langTypeNS}> sv(this->impl->${prop.instanceVariableName}.lock());
-            if (sv)
-              {
-                o->setID(sv->getID());
-                common::xml::dom::Element child(o->asXMLElement(document));
-                element.appendChild(child);
-              }
-          }
+        {
+          // Reference property ${prop.name}
+          // Note that this doesn't strictly need to be a
+          // shared_ptr, but keep compatible with the rest of the
+          // API to allow consistency for future refactoring.
+          ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
+          ome::compat::shared_ptr<${prop.langTypeNS}> sv(this->impl->${prop.instanceVariableName}.lock());
+          if (sv)
+            {
+              o->setID(sv->getID());
+{% if prop.isAbstractSubstitution %}\
+              common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), o->get${prop.name}Type()));
+{% end if %}\
+{% if not prop.isAbstractSubstitution %}\
+              common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
+{% end if %}\
+              child = o->asXMLElement(document, child);
+              element.appendChild(child);
+            }
+        }
 {% end %}\
 {% when prop.isBackReference %}\
 {% if debug %}\
-          // *** IGNORING *** Skipped back reference ${prop.name}
+        // *** IGNORING *** Skipped back reference ${prop.name}
 {% end debug %}\
 {% end %}\
 {% when prop.hasUnitsCompanion and prop.isAttribute and prop.maxOccurs == 1%}\
 {% if prop.minOccurs == 1 %}\
+        {
+          // Attribute property ${prop.name} with units companion ${prop.unitsCompanion.name}
+          std::ostringstream os;
+          os.imbue(std::locale::classic());
+          os << this->impl->${prop.instanceVariableName}.getValue();
+          element.setAttribute("${prop.name}", os.str());
+          element.setAttribute("${prop.unitsCompanion.name}",
+                               this->impl->${prop.instanceVariableName}.getUnit());
+        }
+{% end prop.minOccurs == 0 %}\
+{% if prop.minOccurs == 0 %}\
+        if (this->impl->${prop.instanceVariableName})
           {
             // Attribute property ${prop.name} with units companion ${prop.unitsCompanion.name}
             std::ostringstream os;
             os.imbue(std::locale::classic());
-            os << this->impl->${prop.instanceVariableName}.getValue();
+            os << this->impl->${prop.instanceVariableName}->getValue();
             element.setAttribute("${prop.name}", os.str());
             element.setAttribute("${prop.unitsCompanion.name}",
-                                 this->impl->${prop.instanceVariableName}.getUnit());
+                                 this->impl->${prop.instanceVariableName}->getUnit());
           }
-{% end prop.minOccurs == 0 %}\
-{% if prop.minOccurs == 0 %}\
-          if (this->impl->${prop.instanceVariableName})
-            {
-              // Attribute property ${prop.name} with units companion ${prop.unitsCompanion.name}
-              std::ostringstream os;
-              os.imbue(std::locale::classic());
-              os << this->impl->${prop.instanceVariableName}->getValue();
-              element.setAttribute("${prop.name}", os.str());
-              element.setAttribute("${prop.unitsCompanion.name}",
-                                   this->impl->${prop.instanceVariableName}->getUnit());
-            }
 {% end prop.minOccurs == 0 %}\
 {% end when %}\
 {% when prop.maxOccurs == 1 and prop.isAttribute %}\
-          // Attribute property ${prop.name}
-          {
-            std::ostringstream os;
-            os.imbue(std::locale::classic());
+        // Attribute property ${prop.name}
+        {
+          std::ostringstream os;
+          os.imbue(std::locale::classic());
 {% if prop.minOccurs == 1 %}\
 {% if prop.langTypeNS != 'bool' %}\
-          os << this->impl->${prop.instanceVariableName};
+        os << this->impl->${prop.instanceVariableName};
 {% end %}\
 {% if prop.langTypeNS == 'bool' %}\
-          os << std::boolalpha << this->impl->${prop.instanceVariableName};
+        os << std::boolalpha << this->impl->${prop.instanceVariableName};
 {% end %}\
-            element.setAttribute("${prop.name}", os.str());
+          element.setAttribute("${prop.name}", os.str());
 {% end %}\
 {% if prop.minOccurs == 0 %}\
-            if (this->impl->${prop.instanceVariableName})
-              {
-{% if prop.langTypeNS != 'bool' %}\
-                os << *this->impl->${prop.instanceVariableName};
-{% end %}\
-{% if prop.langTypeNS == 'bool' %}\
-                os << std::boolalpha << *this->impl->${prop.instanceVariableName};
-{% end %}\
-                element.setAttribute("${prop.name}", os.str());
-              }
-{% end %}\
-          }
-{% end %}\
-{% when prop.maxOccurs == 1 and prop.isComplex() %}\
-          // Element property ${prop.name} which is complex (has
-          // sub-elements)
-{% if prop.langTypeNS != 'ome::xml::model::primitives::OrderedMultimap' %}\
           if (this->impl->${prop.instanceVariableName})
             {
-              common::xml::dom::Element child(this->impl->${prop.instanceVariableName}->asXMLElement(document));
-              element.appendChild(child);
+{% if prop.langTypeNS != 'bool' %}\
+              os << *this->impl->${prop.instanceVariableName};
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+              os << std::boolalpha << *this->impl->${prop.instanceVariableName};
+{% end %}\
+              element.setAttribute("${prop.name}", os.str());
             }
 {% end %}\
-{% if prop.langTypeNS == 'ome::xml::model::primitives::OrderedMultimap' %}\
-              typedef ome::xml::model::primitives::OrderedMultimap::index<ome::xml::model::primitives::order_index>::type order_index_type;
-{% if prop.minOccurs == 0 %}\
-          if (this->impl->${prop.instanceVariableName})
-            {
-              common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
-              for (order_index_type::const_iterator i = this->impl->${prop.instanceVariableName}->get<0>().begin();
-                   i != this->impl->${prop.instanceVariableName}->get<0>().end();
-                   ++i)
-                {
-                  common::xml::dom::Element pair = document.createElementNS(getXMLNamespace(), "M");
-                  pair.setAttribute("K", i->first);
-                  pair.setTextContent(i->second);
-                  child.appendChild(pair);
-                }
-              element.appendChild(child);
-           }
+        }
 {% end %}\
-{% if prop.minOccurs != 0 %}\
+{% when prop.maxOccurs == 1 and prop.isComplex() %}\
+        // Element property ${prop.name} which is complex (has
+        // sub-elements)
+{% if prop.langTypeNS != 'ome::xml::model::primitives::OrderedMultimap' %}\
+        if (this->impl->${prop.instanceVariableName})
+          {
+{% if prop.isAbstractSubstitution %}\
+            common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), this->impl->${prop.instanceVariableName}->get${prop.name}Type()));
+{% end if %}\
+{% if not prop.isAbstractSubstitution %}\
             common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
-            for (order_index_type::const_iterator i = this->impl->${prop.instanceVariableName}.get<0>().begin();
-                 i != this->impl->${prop.instanceVariableName}.get<0>().end();
+{% end if %}\
+            child = this->impl->${prop.instanceVariableName}->asXMLElement(document, child);
+            element.appendChild(child);
+          }
+{% end %}\
+{% if prop.langTypeNS == 'ome::xml::model::primitives::OrderedMultimap' %}\
+            typedef ome::xml::model::primitives::OrderedMultimap::index<ome::xml::model::primitives::order_index>::type order_index_type;
+{% if prop.minOccurs == 0 %}\
+        if (this->impl->${prop.instanceVariableName})
+          {
+            common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
+            for (order_index_type::const_iterator i = this->impl->${prop.instanceVariableName}->get<0>().begin();
+                 i != this->impl->${prop.instanceVariableName}->get<0>().end();
                  ++i)
               {
                 common::xml::dom::Element pair = document.createElementNS(getXMLNamespace(), "M");
@@ -1475,102 +1454,113 @@ ${customAsXMLElementPropertyContent[prop.name]}
                 child.appendChild(pair);
               }
             element.appendChild(child);
+         }
+{% end %}\
+{% if prop.minOccurs != 0 %}\
+          common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
+          for (order_index_type::const_iterator i = this->impl->${prop.instanceVariableName}.get<0>().begin();
+               i != this->impl->${prop.instanceVariableName}.get<0>().end();
+               ++i)
+            {
+              common::xml::dom::Element pair = document.createElementNS(getXMLNamespace(), "M");
+              pair.setAttribute("K", i->first);
+              pair.setTextContent(i->second);
+              child.appendChild(pair);
+            }
+          element.appendChild(child);
 {% end %}\
 {% end %}\
 {% end %}\
 {% when prop.maxOccurs == 1 %}\
-          // Element property ${prop.name} which is not complex (has no
-          // sub-elements)
-          {
+        // Element property ${prop.name} which is not complex (has no
+        // sub-elements)
+        {
 {% if prop.minOccurs == 1 %}\
-            common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
-            std::ostringstream os;
-            os.imbue(std::locale::classic());
+          common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
+          std::ostringstream os;
+          os.imbue(std::locale::classic());
 {% if prop.langTypeNS != 'bool' %}\
-            os << this->impl->${prop.instanceVariableName};
+          os << this->impl->${prop.instanceVariableName};
 {% end %}\
 {% if prop.langTypeNS == 'bool' %}\
-            os << std::boolalpha << this->impl->${prop.instanceVariableName};
+          os << std::boolalpha << this->impl->${prop.instanceVariableName};
 {% end %}\
-            child.setTextContent(os.str());
-            element.appendChild(child);
+          child.setTextContent(os.str());
+          element.appendChild(child);
 {% end %}\
 {% if prop.minOccurs == 0 %}\
-            if (this->impl->${prop.instanceVariableName})
-              {
-                common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
-                std::ostringstream os;
-                os.imbue(std::locale::classic());
+          if (this->impl->${prop.instanceVariableName})
+            {
+              common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
+              std::ostringstream os;
+              os.imbue(std::locale::classic());
 {% if prop.langTypeNS != 'bool' %}\
-                os << *this->impl->${prop.instanceVariableName};
+              os << *this->impl->${prop.instanceVariableName};
 {% end %}\
 {% if prop.langTypeNS == 'bool' %}\
-                os << std::boolalpha << *this->impl->${prop.instanceVariableName};
+              os << std::boolalpha << *this->impl->${prop.instanceVariableName};
 {% end %}\
-                child.setTextContent(os.str());
-                element.appendChild(child);
-              }
-{% end %}\
-          }
-{% end %}\
-{% when prop.maxOccurs > 1 and prop.isComplex() %}\
-          {
-            // Element property ${prop.name} which is complex (has
-            // sub-elements) and occurs more than once
-            for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
-                 i != this->impl->${prop.instanceVariableName}.end();
-                 ++i)
-              {
-                if (*i)
-                  {
-                    common::xml::dom::Element child((*i)->asXMLElement(document));
-                    element.appendChild(child);
-                  }
-              }
-          }
-{% end %}\
-{% when prop.maxOccurs > 1 %}\
-          {
-            // Element property ${prop.name} which is not complex (has no
-            // sub-elements) which occurs more than once
-            for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
-                 i != this->impl->${prop.instanceVariableName}.end();
-                 ++i)
-              {
-                common::xml::dom::Element this->impl->${prop.instanceVariableName}_element =
-                                                                   document.createElementNS(getXMLNamespace(), "${prop.name}");
-                std::ostringstream os;
-                os.imbue(std::locale::classic());
-{% if prop.langTypeNS != 'bool' %}\
-                os << *i;
-{% end %}\
-{% if prop.langTypeNS == 'bool' %}\
-                os << std::boolalpha << *i;
-{% end %}\
-                this->impl->${prop.instanceVariableName}_element.setTextContent(os.str());
-                common::xml::dom::Element child(this->impl->${prop.instanceVariableName}_element);
-                element.appendChild(child);
-              }
-          }
-{% end %}\
-{% otherwise %}\
-{% if debug %}\
-          // *** WARNING *** Unhandled or skipped property ${prop.name}
-{% end debug %}\
-{% end %}\
+              child.setTextContent(os.str());
+              element.appendChild(child);
+            }
 {% end %}\
         }
 {% end %}\
+{% when prop.maxOccurs > 1 and prop.isComplex() %}\
+        {
+          // Element property ${prop.name} which is complex (has
+          // sub-elements) and occurs more than once
+          for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
+               i != this->impl->${prop.instanceVariableName}.end();
+               ++i)
+            {
+              if (*i)
+                {
+{% if prop.isAbstractSubstitution %}\
+                  common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), (*i)->get${prop.name}Type()));
+{% end if %}\
+{% if not prop.isAbstractSubstitution %}\
+                  common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
+{% end if %}\
+                  child = (*i)->asXMLElement(document, child);
+                  element.appendChild(child);
+                }
+            }
+        }
+{% end %}\
+{% when prop.maxOccurs > 1 %}\
+        {
+          // Element property ${prop.name} which is not complex (has no
+          // sub-elements) which occurs more than once
+          for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
+               i != this->impl->${prop.instanceVariableName}.end();
+               ++i)
+            {
+              common::xml::dom::Element this->impl->${prop.instanceVariableName}_element =
+                                                                 document.createElementNS(getXMLNamespace(), "${prop.name}");
+              std::ostringstream os;
+              os.imbue(std::locale::classic());
+{% if prop.langTypeNS != 'bool' %}\
+              os << *i;
+{% end %}\
+{% if prop.langTypeNS == 'bool' %}\
+              os << std::boolalpha << *i;
+{% end %}\
+              this->impl->${prop.instanceVariableName}_element.setTextContent(os.str());
+              common::xml::dom::Element child(this->impl->${prop.instanceVariableName}_element);
+              element.appendChild(child);
+            }
+        }
+{% end %}\
+{% otherwise %}\
+{% if debug %}\
+        // *** WARNING *** Unhandled or skipped property ${prop.name}
+{% end debug %}\
+{% end %}\
+{% end %}\
 {% end %}\
 {% end for %}\
-{% choose %}\
-{% when klass.isAnnotation %}\
         return element;
-{% end when isAnnotation %}\
-{% otherwise %}\
-        return ${klass.parentName}::asXMLElementInternal(document, element);
-{% end otherwise %}\
-{% end choose %}\
       }
 {% end source %}\
 

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -1345,7 +1345,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% if not prop.isAbstractSubstitution %}\
                   common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
 {% end if %}\
-                  child = o->asXMLElement(document, child);
+                  o->asXMLElement(document, child);
                   element.appendChild(child);
                 }
             }
@@ -1368,7 +1368,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% if not prop.isAbstractSubstitution %}\
               common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
 {% end if %}\
-              child = o->asXMLElement(document, child);
+              o->asXMLElement(document, child);
               element.appendChild(child);
             }
         }
@@ -1443,7 +1443,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% if not prop.isAbstractSubstitution %}\
             common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
 {% end if %}\
-            child = this->impl->${prop.instanceVariableName}->asXMLElement(document, child);
+            this->impl->${prop.instanceVariableName}->asXMLElement(document, child);
             element.appendChild(child);
           }
 {% end %}\
@@ -1531,7 +1531,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% if not prop.isAbstractSubstitution %}\
                   common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
 {% end if %}\
-                  child = (*i)->asXMLElement(document, child);
+                  (*i)->asXMLElement(document, child);
                   element.appendChild(child);
                 }
             }

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -248,6 +248,15 @@ namespace ome
         impl(ome::compat::make_shared<Impl>())
       {
         logger.add_attribute("ClassName", logging::attributes::constant<std::string>("${klass.name}"));
+{% if klass.name == "AffineTransform" %}\
+        // Set to identity
+        setA00(1.0);
+        setA01(0.0);
+        setA02(0.0);
+        setA10(0.0);
+        setA11(1.0);
+        setA12(0.0);
+{% end class is AffineTransform %}\
       }
 
 {% end source %}\

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -1254,12 +1254,12 @@ ${customUpdatePropertyContent[prop.name]}
 {% if fu.SOURCE_TYPE == "header" %}\
       protected:
         // Documented in base class.
-        virtual common::xml::dom::Element
+        virtual void
         asXMLElementInternal (common::xml::dom::Document& document,
                               common::xml::dom::Element&  element) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      common::xml::dom::Element
+      void
       ${klass.name}::asXMLElementInternal (common::xml::dom::Document& document,
                                            common::xml::dom::Element&  element) const
       {
@@ -1569,7 +1569,6 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% end %}\
 {% end %}\
 {% end for %}\
-        return element;
       }
 {% end source %}\
 

--- a/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -203,10 +203,6 @@ ${customContent}\
     }
 {% end %}\
     String tagName = element.getTagName();
-    if (!"${klass.name}".equals(tagName))
-    {
-      LOGGER.debug("Expecting node name of ${klass.name} got {}", tagName);
-    }
 {% for prop in klass.properties.values() %}\
 {% choose %}\
 {% when prop.name in customUpdatePropertyContent %}\
@@ -336,7 +332,7 @@ ${customUpdatePropertyContent[prop.name]}
     }
     else if (${prop.name}_nodeList.size() != 0)
     {
-{% if prop.isComplex() and not klass.isAbstract %}\
+{% if prop.isComplex() %}\
       // Element property ${prop.name} which is complex (has
       // sub-elements)
 {% if prop.langTypeNS != 'List<MapPair>' %}\
@@ -644,7 +640,7 @@ ${customUpdatePropertyContent[prop.name]}
     return asXMLElement(document, null);
   }
 
-  protected Element asXMLElement(Document document, Element ${klass.name}_element)
+  public Element asXMLElement(Document document, Element ${klass.name}_element)
   {
     // Creating XML block for ${klass.name}
     if (${klass.name}_element == null)
@@ -660,10 +656,8 @@ ${customUpdatePropertyContent[prop.name]}
     }
 
 {% end if NOT Object %}\
-{% if klass.isAnnotation %}\
     // Ensure any base annotations add their Elements first
-    ${klass.name}_element = super.asXMLElement(document, ${klass.name}_element);
-{% end if isAnnotation %}\
+    super.asXMLElement(document, ${klass.name}_element);
 
 {% for prop in klass.properties.values() %}\
 {% if not prop.isUnitsEnumeration %}\
@@ -695,14 +689,30 @@ ${customAsXMLElementPropertyContent[prop.name]}
       {
         ${prop.name} o = new ${prop.name}();
         o.setID(${prop.instanceVariableName}_value.getID());
-        ${klass.name}_element.appendChild(o.asXMLElement(document));
+{% if prop.isAbstractSubstitution %}\
+        Element child =
+          document.createElementNS(NAMESPACE, o.getClass().getSimpleName());
+{% end if %}\
+{% if not prop.isAbstractSubstitution %}\
+        Element child =
+          document.createElementNS(NAMESPACE, "${prop.name}");
+{% end if %}\
+        ${klass.name}_element.appendChild(o.asXMLElement(document, child));
       }
 {% end when %}\
 {% when prop.isReference %}\
       // Reference property ${prop.name}
       ${prop.name} o = new ${prop.name}();
       o.setID(${prop.instanceVariableName}.getID());
-      ${klass.name}_element.appendChild(o.asXMLElement(document));
+{% if prop.isAbstractSubstitution %}\
+      Element child =
+        document.createElementNS(NAMESPACE, o.getClass().getSimpleName());
+{% end if %}\
+{% if not prop.isAbstractSubstitution %}\
+      Element child =
+        document.createElementNS(NAMESPACE, "${prop.name}");
+{% end if %}\
+      ${klass.name}_element.appendChild(o.asXMLElement(document, child));
 {% end when %}\
 {% when prop.isBackReference %}\
       // *** IGNORING *** Skipped back reference ${prop.name}
@@ -744,7 +754,15 @@ ${customAsXMLElementPropertyContent[prop.name]}
       // Element property ${prop.name} which is complex (has
       // sub-elements)
 {% if prop.langTypeNS != 'List<MapPair>' %}\
-      ${klass.name}_element.appendChild(${prop.instanceVariableName}.asXMLElement(document));
+{% if prop.isAbstractSubstitution %}\
+      Element child =
+        document.createElementNS(NAMESPACE, ${prop.instanceVariableName}.getClass().getSimpleName());
+{% end if %}\
+{% if not prop.isAbstractSubstitution %}\
+      Element child =
+        document.createElementNS(NAMESPACE, "${prop.name}");
+{% end if %}\
+      ${klass.name}_element.appendChild(${prop.instanceVariableName}.asXMLElement(document, child));
 {% end %}\
 {% if prop.langTypeNS == 'List<MapPair>' %}\
       Element ${prop.instanceVariableName}_child =
@@ -772,7 +790,15 @@ ${customAsXMLElementPropertyContent[prop.name]}
       // sub-elements) and occurs more than once
       for (${prop.langType} ${prop.instanceVariableName}_value : ${prop.instanceVariableName})
       {
-        ${klass.name}_element.appendChild(${prop.instanceVariableName}_value.asXMLElement(document));
+{% if prop.isAbstractSubstitution %}\
+        Element child =
+          document.createElementNS(NAMESPACE, ${prop.instanceVariableName}_value.getClass().getSimpleName());
+{% end if %}\
+{% if not prop.isAbstractSubstitution %}\
+        Element child =
+          document.createElementNS(NAMESPACE, "${prop.name}");
+{% end if %}\
+        ${klass.name}_element.appendChild(${prop.instanceVariableName}_value.asXMLElement(document, child));
       }
 {% end when %}\
 {% when prop.maxOccurs > 1 %}\
@@ -796,13 +822,6 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% end if %}\
 {% end for %}\
 
-{% choose %}\
-{% when klass.isAnnotation %}\
     return ${klass.name}_element;
-{% end when isAnnotation %}\
-{% otherwise %}\
-    return super.asXMLElement(document, ${klass.name}_element);
-{% end otherwise %}\
-{% end choose %}\
   }
 }

--- a/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -128,6 +128,15 @@ public class ${klass.name} extends ${klass.parentName}
 {% if klass.parentName is not None and klass.parentName != 'AbstractOMEModelObject' %}\
     super();
 {% end %}\
+{% if klass.name == "AffineTransform" %}\
+    // Set to identity
+    setA00(1.0);
+    setA01(0.0);
+    setA02(0.0);
+    setA10(0.0);
+    setA11(1.0);
+    setA12(0.0);
+{% end class is AffineTransform %}\
   }
 
   /**

--- a/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -706,7 +706,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
         Element child =
           document.createElementNS(NAMESPACE, "${prop.name}");
 {% end if %}\
-        ${klass.name}_element.appendChild(o.asXMLElement(document, child));
+        o.asXMLElement(document, child);
+        ${klass.name}_element.appendChild(child);
       }
 {% end when %}\
 {% when prop.isReference %}\
@@ -721,7 +722,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
       Element child =
         document.createElementNS(NAMESPACE, "${prop.name}");
 {% end if %}\
-      ${klass.name}_element.appendChild(o.asXMLElement(document, child));
+      o.asXMLElement(document, child);
+      ${klass.name}_element.appendChild(child);
 {% end when %}\
 {% when prop.isBackReference %}\
       // *** IGNORING *** Skipped back reference ${prop.name}
@@ -771,7 +773,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
       Element child =
         document.createElementNS(NAMESPACE, "${prop.name}");
 {% end if %}\
-      ${klass.name}_element.appendChild(${prop.instanceVariableName}.asXMLElement(document, child));
+      ${prop.instanceVariableName}.asXMLElement(document, child);
+      ${klass.name}_element.appendChild(child);
 {% end %}\
 {% if prop.langTypeNS == 'List<MapPair>' %}\
       Element ${prop.instanceVariableName}_child =
@@ -807,7 +810,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
         Element child =
           document.createElementNS(NAMESPACE, "${prop.name}");
 {% end if %}\
-        ${klass.name}_element.appendChild(${prop.instanceVariableName}_value.asXMLElement(document, child));
+        ${prop.instanceVariableName}_value.asXMLElement(document, child);
+        ${klass.name}_element.appendChild(child);
       }
 {% end when %}\
 {% when prop.maxOccurs > 1 %}\


### PR DESCRIPTION
- OMEXMLModelObject template:
  - Remove the assumption that the element name will always match the class name;
    this is incorrect for AffineTransform and Transform.
    - Make the OMEModelObject::asXMLElement(Document, Element) method public
      for both C++ and Java.
    - The caller of asXMLElement sets the element name and passes in the element
    - Don't use return value of asXMLElement (Java) and don't return a value at all (C++)
    - Remove the sanity check that the element name and class name match, since
      it is incorrect; for C++ deprecate the validElementName method and always
      return true, for Java remove the inline check.
  - Handle setting the class name differently for abstract (use derived class
    name) and non-abstract (use property name).  This does mean derived classes
    can't use the property name, since they require the name to specify the
    concrete type to instantiate; that's an assumption made by the implementation
    which we now enforce consistently.
  - Remove broken conditional checking for isAbstract.
  - Initialise AffineTransform instances with the identity matrix; this prevents
    serialisation errors when only some of the "Axy" attributes are set, and
    provides a reasonable default when creating one directly.
- Enable the use of createTransform in XMLMockObjects; also set the
  transform to do a basic translation.
- 2008-09-to-2009-09.xsl transform: Don't create an empty "transform"
  attribute, since it's both invalid and breaks the Bio-Formats unit
  tests.

Note: you might find the [whitespace diff](https://github.com/ome/ome-model/pull/14/files?w=1) easier to review for the templates to ignore indentation changes.

Testing:

- Check C++ and Java builds are green [note: does not use regular jobs]
- Using this [transform sample](https://github.com/rleigh-codelibre/ome-model/blob/9e33f33df8fe3223650868e96f0814fa9300c109/specification/samples/2016-06/ROI.ome.xml), run
  - Java: Run `./tools/showinf ROI.ome.xml -nopix -omexml` and you should see a `<Transform>` element in the output (without the PR, this will be missing)
  - C++: Embed the `ROI.ome.xml` into a TIFF with tiffcomment, then run `ome-files info ROI.ome.tiff --omexml` and again you should see a `<Transform>` element which was previously missing

Other testing:

- Is the transform update correct?  Does it still work with transforms from this era (I can't see any obvious samples.)
- Does altering the serialisation order break anything.  The `asXMLElement` order now matches the `update` order, so should be fine, but I'm unsure why this was done differently for different element types in the first place.