### PR TITLE
OME element implements OMEModel

### DIFF
--- a/ome-xml/src/main/cpp/ome/xml/CMakeLists.txt
+++ b/ome-xml/src/main/cpp/ome/xml/CMakeLists.txt
@@ -59,6 +59,7 @@ set(OME_XML_STATIC_SOURCES
   OMETransformResolver.cpp
   meta/MetadataException.cpp
   meta/OMEXMLMetadataRoot.cpp
+  meta/OMEXMLMetadataModel.cpp
   meta/Convert.cpp
   model/ModelException.cpp
   model/OriginalMetadataAnnotation.cpp
@@ -83,7 +84,9 @@ set(OME_XML_META_STATIC_HEADERS
     meta/Convert.h
     meta/Metadata.h
     meta/MetadataException.h
+    meta/MetadataModel.h
     meta/MetadataRoot.h
+    meta/OMEXMLMetadataModel.h
     meta/OMEXMLMetadataRoot.h)
 
 set(OME_XML_STATIC_HEADERS

--- a/ome-xml/src/main/cpp/ome/xml/meta/Convert.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/meta/Convert.cpp
@@ -1597,6 +1597,7 @@ namespace ome
         MetadataStore *src_store(dynamic_cast<MetadataStore *>(&src));
         if (typeid(src) == typeid(dest) && src_store && skip)
           {
+            dest.setModel(src_store->getModel());
             dest.setRoot(src_store->getRoot());
           }
         else

--- a/ome-xml/src/main/cpp/ome/xml/meta/MetadataModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/meta/MetadataModel.h
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
- * Copyright © 2006 - 2016 Open Microscopy Environment:
+ * Copyright © 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee
@@ -35,13 +35,10 @@
  * #L%
  */
 
-#ifndef OME_XML_OME_OMEXMLMETADATAROOT_H
-#define OME_XML_OME_OMEXMLMETADATAROOT_H
+#ifndef OME_XML_META_METADATAMODEL_H
+#define OME_XML_META_METADATAMODEL_H
 
 #include <ome/compat/cstdint.h>
-
-#include <ome/xml/meta/OMEXMLMetadataModel.h>
-#include <ome/xml/meta/MetadataRoot.h>
 
 namespace ome
 {
@@ -51,37 +48,38 @@ namespace ome
     {
 
       /**
-       * OME-XML metadata root node.
+       * Metadata model interface.  This class provides no
+       * functionality; its purpose is to provide a common base type
+       * for the underlying model implementation used by metadata
+       * storage implementations.
        */
-      class OMEXMLMetadataRoot : public ::ome::xml::meta::OMEXMLMetadataModel,
-				 virtual public ::ome::xml::meta::MetadataRoot
+      class MetadataModel
       {
-      public:
+      protected:
         /// Constructor.
-        OMEXMLMetadataRoot();
-
-	/// Copy constructor.
-	OMEXMLMetadataRoot(const OMEXMLMetadataRoot& copy);
-
-	/// Copy constructor.
-	OMEXMLMetadataRoot(const xml::model::OME& copy);
+        MetadataModel()
+        {}
 
       public:
         /// Destructor.
         virtual
-        ~OMEXMLMetadataRoot();
+        ~MetadataModel()
+        {}
 
       private:
+       /// Copy constructor (deleted).
+        MetadataModel (const MetadataModel&);
+
         /// Assignment operator (deleted).
-        OMEXMLMetadataRoot&
-        operator= (const OMEXMLMetadataRoot&);
+        MetadataModel&
+        operator= (const MetadataModel&);
       };
 
     }
   }
 }
 
-#endif // OME_XML_OME_OMEXMLMETADATAROOT_H
+#endif // OME_XML_META_METADATAMODEL_H
 
 /*
  * Local Variables:

--- a/ome-xml/src/main/cpp/ome/xml/meta/MetadataRoot.h
+++ b/ome-xml/src/main/cpp/ome/xml/meta/MetadataRoot.h
@@ -40,6 +40,8 @@
 
 #include <ome/compat/cstdint.h>
 
+#include <ome/xml/meta/MetadataModel.h>
+
 namespace ome
 {
   namespace xml
@@ -52,11 +54,12 @@ namespace ome
        * functionality; its purpose is to provide a common base type
        * for the root node type of metadata storage implementations.
        */
-      class MetadataRoot
+      class MetadataRoot : virtual public ::ome::xml::meta::MetadataModel
       {
       protected:
         /// Constructor.
-        MetadataRoot()
+        MetadataRoot():
+          MetadataModel()
         {}
 
       public:

--- a/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataModel.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataModel.cpp
@@ -1,7 +1,8 @@
 /*
  * #%L
  * OME-XML C++ library for working with OME-XML metadata structures.
- * Copyright © 2006 - 2016 Open Microscopy Environment:
+ * %%
+ * Copyright © 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee
@@ -35,13 +36,10 @@
  * #L%
  */
 
-#ifndef OME_XML_OME_OMEXMLMETADATAROOT_H
-#define OME_XML_OME_OMEXMLMETADATAROOT_H
-
-#include <ome/compat/cstdint.h>
-
 #include <ome/xml/meta/OMEXMLMetadataModel.h>
-#include <ome/xml/meta/MetadataRoot.h>
+
+using ome::xml::model::OMEModel;
+using ome::xml::meta::MetadataModel;
 
 namespace ome
 {
@@ -50,41 +48,34 @@ namespace ome
     namespace meta
     {
 
-      /**
-       * OME-XML metadata root node.
-       */
-      class OMEXMLMetadataRoot : public ::ome::xml::meta::OMEXMLMetadataModel,
-				 virtual public ::ome::xml::meta::MetadataRoot
+      OMEXMLMetadataModel::OMEXMLMetadataModel():
+        ome::xml::model::OMEModelObject(),
+        ome::xml::model::OMEModel(),
+	MetadataModel(),
+	ome::xml::model::OME()
       {
-      public:
-        /// Constructor.
-        OMEXMLMetadataRoot();
+      }
 
-	/// Copy constructor.
-	OMEXMLMetadataRoot(const OMEXMLMetadataRoot& copy);
+      OMEXMLMetadataModel::~OMEXMLMetadataModel()
+      {
+      }
 
-	/// Copy constructor.
-	OMEXMLMetadataRoot(const xml::model::OME& copy);
+      OMEXMLMetadataModel::OMEXMLMetadataModel(const OMEXMLMetadataModel& copy):
+        ome::xml::model::OMEModelObject(),
+        ome::xml::model::OMEModel(),
+	MetadataModel(),
+	ome::xml::model::OME(copy)
+      {
+      }
 
-      public:
-        /// Destructor.
-        virtual
-        ~OMEXMLMetadataRoot();
-
-      private:
-        /// Assignment operator (deleted).
-        OMEXMLMetadataRoot&
-        operator= (const OMEXMLMetadataRoot&);
-      };
+      OMEXMLMetadataModel::OMEXMLMetadataModel(const ome::xml::model::OME& copy):
+        ome::xml::model::OMEModelObject(),
+        ome::xml::model::OMEModel(),
+	MetadataModel(),
+	ome::xml::model::OME(copy)
+      {
+      }
 
     }
   }
 }
-
-#endif // OME_XML_OME_OMEXMLMETADATAROOT_H
-
-/*
- * Local Variables:
- * mode:C++
- * End:
- */

--- a/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataModel.h
@@ -35,13 +35,13 @@
  * #L%
  */
 
-#ifndef OME_XML_OME_OMEXMLMETADATAROOT_H
-#define OME_XML_OME_OMEXMLMETADATAROOT_H
+#ifndef OME_XML_OME_OMEXMLMETADATAMODEL_H
+#define OME_XML_OME_OMEXMLMETADATAMODEL_H
 
 #include <ome/compat/cstdint.h>
 
-#include <ome/xml/meta/OMEXMLMetadataModel.h>
-#include <ome/xml/meta/MetadataRoot.h>
+#include <ome/xml/meta/MetadataModel.h>
+#include <ome/xml/model/OME.h>
 
 namespace ome
 {
@@ -53,35 +53,35 @@ namespace ome
       /**
        * OME-XML metadata root node.
        */
-      class OMEXMLMetadataRoot : public ::ome::xml::meta::OMEXMLMetadataModel,
-				 virtual public ::ome::xml::meta::MetadataRoot
+      class OMEXMLMetadataModel : public ::ome::xml::model::OME,
+                                  virtual public ::ome::xml::meta::MetadataModel
       {
       public:
         /// Constructor.
-        OMEXMLMetadataRoot();
+        OMEXMLMetadataModel();
 
 	/// Copy constructor.
-	OMEXMLMetadataRoot(const OMEXMLMetadataRoot& copy);
+	OMEXMLMetadataModel(const OMEXMLMetadataModel& copy);
 
 	/// Copy constructor.
-	OMEXMLMetadataRoot(const xml::model::OME& copy);
+	OMEXMLMetadataModel(const xml::model::OME& copy);
+
+      private:
+        /// Assignment operator (deleted).
+        OMEXMLMetadataModel&
+        operator= (const OMEXMLMetadataModel&);
 
       public:
         /// Destructor.
         virtual
-        ~OMEXMLMetadataRoot();
-
-      private:
-        /// Assignment operator (deleted).
-        OMEXMLMetadataRoot&
-        operator= (const OMEXMLMetadataRoot&);
+        ~OMEXMLMetadataModel();
       };
 
     }
   }
 }
 
-#endif // OME_XML_OME_OMEXMLMETADATAROOT_H
+#endif // OME_XML_OME_OMEXMLMETADATAMODEL_H
 
 /*
  * Local Variables:

--- a/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataRoot.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataRoot.cpp
@@ -40,6 +40,7 @@
 
 using ome::xml::model::OME;
 using ome::xml::meta::MetadataRoot;
+using ome::xml::meta::MetadataModel;
 
 namespace ome
 {
@@ -50,8 +51,10 @@ namespace ome
 
       OMEXMLMetadataRoot::OMEXMLMetadataRoot():
         ome::xml::model::OMEModelObject(),
+	ome::xml::model::OMEModel(),
+	MetadataModel(),
 	MetadataRoot(),
-	OME()
+	OMEXMLMetadataModel()
       {
       }
 
@@ -61,15 +64,19 @@ namespace ome
 
       OMEXMLMetadataRoot::OMEXMLMetadataRoot(const OMEXMLMetadataRoot& copy):
         ome::xml::model::OMEModelObject(),
+	ome::xml::model::OMEModel(),
+	MetadataModel(),
 	MetadataRoot(),
-	OME(copy)
+	OMEXMLMetadataModel(copy)
       {
       }
 
       OMEXMLMetadataRoot::OMEXMLMetadataRoot(const xml::model::OME& copy):
         ome::xml::model::OMEModelObject(),
+	ome::xml::model::OMEModel(),
+	MetadataModel(),
 	MetadataRoot(),
-	OME(copy)
+	OMEXMLMetadataModel(copy)
       {
       }
 

--- a/ome-xml/src/main/cpp/ome/xml/model/OMEModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OMEModel.h
@@ -54,6 +54,7 @@ namespace ome
     namespace model
     {
 
+      class OME;
       class Reference;
 
       /**
@@ -76,12 +77,6 @@ namespace ome
         OMEModel ()
         {}
 
-      public:
-        /// Destructor.
-        virtual
-        ~OMEModel ()
-        {}
-
       private:
         /// Copy constructor (deleted).
         OMEModel (const OMEModel&);
@@ -91,6 +86,11 @@ namespace ome
         operator= (const OMEModel&);
 
       public:
+        /// Destructor.
+        virtual
+        ~OMEModel ()
+        {}
+
         /**
          * Add a model object to the model.  Note that the concrete
          * implementation will not add types derived from Reference.

--- a/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
@@ -162,7 +162,7 @@ namespace ome
          */
         virtual void
         update (const common::xml::dom::Element& element,
-                OMEModel&                   model) = 0;
+                OMEModel&                        model) = 0;
 
         /**
          * Link a given OME model object to this model object.

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.cpp
@@ -61,6 +61,14 @@ namespace ome
         {
         }
 
+        OMEModel::OMEModel (const OMEModel& copy):
+          ::ome::xml::model::OMEModel(),
+          logger(ome::common::createLogger("OMEModel")),
+          modelObjects(copy.modelObjects),
+          references(copy.references)
+        {
+        }
+
         OMEModel::~OMEModel ()
         {
         }

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.h
@@ -55,6 +55,9 @@ namespace ome
 
         /**
          * OME model (concrete implementation).
+         *
+         * @deprecated Use the OME class directly, since it implements
+         * ome::xml::model::OMEModel.
          */
         class OMEModel : virtual public ::ome::xml::model::OMEModel
         {
@@ -70,12 +73,15 @@ namespace ome
           /// Constructor.
           OMEModel ();
 
+          /// Copy constructor.
+          OMEModel (const OMEModel& copy);
+
           /// Destructor.
           ~OMEModel ();
 
           /// @copydoc ome::xml::model::OMEModel::addModelObject
           ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
-          addModelObject (const std::string&                                   id,
+          addModelObject (const std::string&                                           id,
                           ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
           // Documented in parent.

--- a/ome-xml/src/main/java/ome/xml/meta/MetadataModel.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataModel.java
@@ -34,64 +34,12 @@
 
 package ome.xml.meta;
 
-import org.w3c.dom.Element;
-
-import ome.xml.model.OME;
-import ome.xml.model.OMEModel;
-import ome.xml.model.enums.EnumerationException;
-
 /**
- * A utility class for constructing and manipulating OME-XML DOMs.
+ * Abstract metadata model node.
  *
- * @author Roger Leigh rleigh at dundee.ac.uk
+ * <p>The <code>MetadataModel</code> interface is implemented by the
+ * model storage implementations.
+ *
+ * @author Roger Leigh r.leigh at dundee.ac.uk
  */
-public class OMEXMLMetadataRoot extends OMEXMLMetadataModel implements MetadataRoot {
-
-  /** Default constructor. */
-  public OMEXMLMetadataRoot()
-  {
-    super();
-  }
-
-  /**
-   * Constructs OME recursively from an XML DOM tree.
-   * @param element Root of the XML DOM tree to construct a model object
-   * graph from.
-   * @throws EnumerationException If there is an error instantiating an
-   * enumeration during model object creation.
-   */
-  public OMEXMLMetadataRoot(Element element)
-    throws EnumerationException
-  {
-    super(element);
-  }
-
-  /**
-   * Constructs OME recursively from an XML DOM tree.
-   * @param element Root of the XML DOM tree to construct a model object
-   * graph from.
-   * @param model Handler for the OME model which keeps track of
-   * instances and references seen during object population
-   * (ignored--now provided directly by this class).
-   * @throws EnumerationException If there is an error instantiating an
-   * enumeration during model object creation.
-   * @deprecated Use {@link OMEXMLMetadataRoot#OMEXMLMetadataRoot(Element) instead}.
-   */
-  @Deprecated
-  public OMEXMLMetadataRoot(Element element, OMEModel model)
-    throws EnumerationException
-  {
-    super(element, model);
-  }
-
-  /**
-   * Construct from existing OME instance.
-   *
-   * @param ome the OME instance to copy.
-   */
-  public OMEXMLMetadataRoot(OME ome)
-  {
-    super(ome);
-  }
-
-}
+public interface MetadataModel { }

--- a/ome-xml/src/main/java/ome/xml/meta/MetadataRoot.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataRoot.java
@@ -42,4 +42,4 @@ package ome.xml.meta;
  *
  * @author Roger Leigh r.leigh at dundee.ac.uk
  */
-public interface MetadataRoot { }
+public interface MetadataRoot extends MetadataModel { }

--- a/ome-xml/src/main/java/ome/xml/meta/OMEXMLMetadataModel.java
+++ b/ome-xml/src/main/java/ome/xml/meta/OMEXMLMetadataModel.java
@@ -45,10 +45,10 @@ import ome.xml.model.enums.EnumerationException;
  *
  * @author Roger Leigh rleigh at dundee.ac.uk
  */
-public class OMEXMLMetadataRoot extends OMEXMLMetadataModel implements MetadataRoot {
+public class OMEXMLMetadataModel extends OME implements MetadataModel {
 
   /** Default constructor. */
-  public OMEXMLMetadataRoot()
+  public OMEXMLMetadataModel()
   {
     super();
   }
@@ -60,7 +60,7 @@ public class OMEXMLMetadataRoot extends OMEXMLMetadataModel implements MetadataR
    * @throws EnumerationException If there is an error instantiating an
    * enumeration during model object creation.
    */
-  public OMEXMLMetadataRoot(Element element)
+  public OMEXMLMetadataModel(Element element)
     throws EnumerationException
   {
     super(element);
@@ -75,10 +75,10 @@ public class OMEXMLMetadataRoot extends OMEXMLMetadataModel implements MetadataR
    * (ignored--now provided directly by this class).
    * @throws EnumerationException If there is an error instantiating an
    * enumeration during model object creation.
-   * @deprecated Use {@link OMEXMLMetadataRoot#OMEXMLMetadataRoot(Element) instead}.
+   * @deprecated Use {@link OMEXMLMetadataModel#OMEXMLMetadataModel(Element) instead}.
    */
   @Deprecated
-  public OMEXMLMetadataRoot(Element element, OMEModel model)
+  public OMEXMLMetadataModel(Element element, OMEModel model)
     throws EnumerationException
   {
     super(element, model);
@@ -89,7 +89,7 @@ public class OMEXMLMetadataRoot extends OMEXMLMetadataModel implements MetadataR
    *
    * @param ome the OME instance to copy.
    */
-  public OMEXMLMetadataRoot(OME ome)
+  public OMEXMLMetadataModel(OME ome)
   {
     super(ome);
   }

--- a/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
@@ -46,7 +46,9 @@ import org.slf4j.LoggerFactory;
 /**
  * @author callan
  *
+ * @deprecated Use the ome.xml.model.OME class directly.
  */
+@Deprecated
 public class OMEModelImpl implements OMEModel {
 
   private Map<String, OMEModelObject> modelObjects = 

--- a/ome-xml/src/test/cpp/model.cpp
+++ b/ome-xml/src/test/cpp/model.cpp
@@ -161,20 +161,18 @@ TEST_P(ModelTest, Update)
 {
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
-  ome::xml::model::detail::OMEModel model;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
-  root->update(docroot, model);
+  model->update(docroot);
 }
 
 TEST_P(ModelTest, CreateXML)
 {
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
-  ome::xml::model::detail::OMEModel model;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
-  root->update(docroot, model);
+  model->update(docroot);
 
   // Dump as XML string.
   std::string omexml(meta.dumpXML());
@@ -187,10 +185,9 @@ TEST_P(ModelTest, CreateXMLRoundTrip)
 {
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
-  ome::xml::model::detail::OMEModel model;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
-  root->update(docroot, model);
+  model->update(docroot);
 
   // Dump as XML string.
   std::string omexml(meta.dumpXML());
@@ -203,10 +200,9 @@ TEST_P(ModelTest, CreateXMLRoundTrip)
   // Read into OME model objects.
   ome::common::xml::dom::Document doc2(ome::xml::createDocument(omexml));
   ome::xml::meta::OMEXMLMetadata meta2;
-  ome::xml::model::detail::OMEModel model2;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root2(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
+  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model2(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
   ome::common::xml::dom::Element docroot2(doc2.getDocumentElement());
-  root2->update(docroot2, model2);
+  model2->update(docroot2);
 
   // Dump as XML string.
   std::string omexml2(meta2.dumpXML());

--- a/specification/src/main/java/ome/specification/XMLMockObjects.java
+++ b/specification/src/main/java/ome/specification/XMLMockObjects.java
@@ -80,6 +80,7 @@ import ome.xml.model.OMEModelObject;
 import ome.xml.model.Objective;
 import ome.xml.model.ObjectiveSettings;
 import ome.xml.model.OME;
+import ome.xml.model.OMEModel;
 import ome.xml.model.Pixels;
 import ome.xml.model.Plane;
 import ome.xml.model.Plate;
@@ -802,6 +803,13 @@ public class XMLMockObjects
    * @return See above.
    */
   public OME getRoot() { return ome; }
+
+  /**
+   * Returns the root of the XML file.
+   *
+   * @return See above.
+   */
+  public OMEModel getModel() { return ome; }
 
   /**
    * Creates a project.

--- a/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -276,6 +276,7 @@
 #include <ome/xml/meta/BaseMetadata.h>
 #include <ome/xml/meta/Metadata.h>
 #include <ome/xml/meta/MetadataException.h>
+#include <ome/xml/meta/MetadataModel.h>
 {% end header%}\
 {% if fu.SOURCE_TYPE == "source" %}\
 #include <ome/xml/meta/AggregateMetadata.h>
@@ -340,6 +341,26 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
+        createModel();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      AggregateMetadata::createModel()
+      {
+        for (delegate_list_type::iterator i = delegates.begin();
+             i != delegates.end();
+             ++i)
+          {
+            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            if (store)
+              store->createModel();
+          }
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        void
         createRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
@@ -359,16 +380,54 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         /**
+         * @copydoc MetadataStore::getModel()
+         * @note Unsupported by AggregateMetadata, which will throw an
+         * exception if called.
+         * @throws MetadataException always.
+         */
+        ome::compat::shared_ptr<MetadataModel>
+        getModel();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      ome::compat::shared_ptr<MetadataModel>
+      AggregateMetadata::getModel()
+      {
+        throw MetadataException("AggregateMetadata", "getModel",
+                                "unsupported");
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        /**
+         * @copydoc MetadataStore::setModel()
+         * @note Unsupported by AggregateMetadata, which will throw an
+         * exception if called.
+         * @throws MetadataException always.
+         */
+        void
+        setModel(ome::compat::shared_ptr<MetadataModel> model);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      AggregateMetadata::setModel(ome::compat::shared_ptr<MetadataModel> /* model */)
+      {
+        throw MetadataException("AggregateMetadata", "setModel",
+                                "unsupported");
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        /**
          * @copydoc MetadataStore::getRoot()
          * @note Unsupported by AggregateMetadata, which will throw an
          * exception if called.
          * @throws MetadataException always.
          */
-        ome::compat::shared_ptr<MetadataRoot>&
+        ome::compat::shared_ptr<MetadataRoot>
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>&
+      ome::compat::shared_ptr<MetadataRoot>
       AggregateMetadata::getRoot()
       {
         throw MetadataException("AggregateMetadata", "getRoot",
@@ -384,11 +443,11 @@ namespace ome
          * @throws MetadataException always.
          */
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
+        setRoot(ome::compat::shared_ptr<MetadataRoot> root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      AggregateMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& /* root */)
+      AggregateMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> /* root */)
       {
         throw MetadataException("AggregateMetadata", "setRoot",
                                 "unsupported");

--- a/xsd-fu/templates-cpp/DummyMetadata.template
+++ b/xsd-fu/templates-cpp/DummyMetadata.template
@@ -206,6 +206,7 @@
 
 #include <ome/xml/meta/Metadata.h>
 #include <ome/xml/meta/MetadataException.h>
+#include <ome/xml/meta/MetadataModel.h>
 {% end header%}\
 {% if fu.SOURCE_TYPE == "source" %}\
 #include <ome/xml/meta/DummyMetadata.h>
@@ -257,6 +258,18 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
+        createModel();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      DummyMetadata::createModel()
+      {
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        void
         createRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
@@ -268,11 +281,37 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>&
+        ome::compat::shared_ptr<MetadataModel>
+        getModel();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      ome::compat::shared_ptr<MetadataModel>
+      DummyMetadata::getModel()
+      {
+        throw MetadataException("DummyMetadata", "getModel",
+                                "intentionally not implemented");
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        void
+        setModel(ome::compat::shared_ptr<MetadataModel> model);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      DummyMetadata::setModel(ome::compat::shared_ptr<MetadataModel> /* model */)
+      {
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        ome::compat::shared_ptr<MetadataRoot>
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>&
+      ome::compat::shared_ptr<MetadataRoot>
       DummyMetadata::getRoot()
       {
         throw MetadataException("DummyMetadata", "getRoot",
@@ -283,11 +322,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
+        setRoot(ome::compat::shared_ptr<MetadataRoot> root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      DummyMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& /* root */)
+      DummyMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> /* root */)
       {
       }
 {% end source %}\

--- a/xsd-fu/templates-cpp/FilterMetadata.template
+++ b/xsd-fu/templates-cpp/FilterMetadata.template
@@ -160,6 +160,7 @@
 #ifndef ${fu.GUARD}
 #define ${fu.GUARD}
 
+#include <ome/xml/meta/MetadataModel.h>
 #include <ome/xml/meta/MetadataStore.h>
 {% end header%}\
 {% if fu.SOURCE_TYPE == "source" %}\
@@ -227,6 +228,19 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
+        createModel();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      FilterMetadata::createModel()
+      {
+        store->createModel();
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        void
         createRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
@@ -239,11 +253,37 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>&
+        ome::compat::shared_ptr<MetadataModel>
+        getModel();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      ome::compat::shared_ptr<MetadataModel>
+      FilterMetadata::getModel()
+      {
+        return store->getModel();
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        void
+        setModel(ome::compat::shared_ptr<MetadataModel> model);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      FilterMetadata::setModel(ome::compat::shared_ptr<MetadataModel> model)
+      {
+        store->setModel(model);
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        ome::compat::shared_ptr<MetadataRoot>
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>&
+      ome::compat::shared_ptr<MetadataRoot>
       FilterMetadata::getRoot()
       {
         return store->getRoot();
@@ -253,11 +293,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
+        setRoot(ome::compat::shared_ptr<MetadataRoot> root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      FilterMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& root)
+      FilterMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> root)
       {
         store->setRoot(root);
       }

--- a/xsd-fu/templates-cpp/MetadataStore.template
+++ b/xsd-fu/templates-cpp/MetadataStore.template
@@ -114,6 +114,7 @@
 #include <ome/compat/memory.h>
 
 #include <ome/xml/meta/BaseMetadata.h>
+#include <ome/xml/meta/MetadataModel.h>
 #include <ome/xml/meta/MetadataRoot.h>
 #include <ome/xml/model/AffineTransform.h>
 
@@ -206,11 +207,44 @@ namespace ome
 
       public:
         /**
-         * Create root node.  The action taken here is specific to the
-         * concrete metadata implementation.
+         * Create underlying data model.  The action taken here is
+         * specific to the concrete metadata implementation.
+         */
+        virtual void
+        createModel() = 0;
+
+        /**
+         * Create root node within the underlying data model.  The
+         * action taken here is specific to the concrete metadata
+         * implementation.
          */
         virtual void
         createRoot() = 0;
+
+        /**
+         * Get the underlying model storing the metadata.  Note that
+         * the model type will be specific to the concrete metadata
+         * implementation.
+         *
+         * @returns a pointer to the model.
+         *
+         * @todo should this be a reference or shared_ptr?
+         */
+        virtual ome::compat::shared_ptr<MetadataModel>
+        getModel() = 0;
+
+        /**
+         * Set the underlying model storing the metadata.  Note that
+         * the model type will be specific to the concrete metadata
+         * implementation.  An exception will be thrown if the model
+         * node is of an incompatible type.
+         *
+         * @param model a pointer to the model.
+         *
+         * @todo should this be a reference or shared_ptr?
+         */
+        virtual void
+        setModel(ome::compat::shared_ptr<MetadataModel> model) = 0;
 
         /**
          * Get the root node of the metadata.  Note that the root node
@@ -221,7 +255,7 @@ namespace ome
          *
          * @todo should this be a reference or shared_ptr?
          */
-        virtual ome::compat::shared_ptr<MetadataRoot>&
+        virtual ome::compat::shared_ptr<MetadataRoot>
         getRoot() = 0;
 
         /**
@@ -235,7 +269,7 @@ namespace ome
          * @todo should this be a reference or shared_ptr?
          */
         virtual void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root) = 0;
+        setRoot(ome::compat::shared_ptr<MetadataRoot> root) = 0;
 
 {% if debug %}\
         // -- Entity storage (manual definitions) --

--- a/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -26,11 +26,11 @@
         // Parents: ${repr(parents[obj.name])}
 {% if obj.isReference %}\
         // ${obj.name} is a reference
-        return ${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, obj.name, func=accessor_string_complex)[:-1] + [{'accessor':"sizeOfLinked%sList()" % obj.name.replace('Ref', '')}], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
+        return ${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, obj.name, func=accessor_string_complex)[:-1] + [{'accessor':"sizeOfLinked%sList()" % obj.name.replace('Ref', '')}], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
 {% end %}\
 {% if not obj.isReference %}\
         // ${obj.name} is not a reference
-        return ${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, obj.name, func=accessor_string_complex)[:-1] + [{'accessor':"sizeOf%sList()" % obj.name.replace('Ref', '')}], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
+        return ${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, obj.name, func=accessor_string_complex)[:-1] + [{'accessor':"sizeOf%sList()" % obj.name.replace('Ref', '')}], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
 {% end %}\
       }
 {% end source %}\
@@ -78,9 +78,9 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference and prop.maxOccurs > 1 %}\
         // ${parent} is abstract, is reference and occurs more than once
-        // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
+        // ${obj.name} o = (${obj.name}) model.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
@@ -89,7 +89,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
@@ -98,7 +98,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract and not a reference
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -122,7 +122,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
+        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -131,7 +131,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}().lock());
+        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
@@ -140,14 +140,14 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% otherwise %}\
         // ${prop.name} is not a reference
 {% if prop.minOccurs == 0 %}\
-        ${prop.retType[' const']} ret = ${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->get${prop.methodName}();
+        ${prop.retType[' const']} ret = ${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->get${prop.methodName}();
         if (ret)
           return *ret;
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                 "Internal metadata store inconsistency: null object");
 {% end %}\
 {% if prop.minOccurs == 1 %}\
-        return ${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->get${prop.methodName}();
+        return ${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->get${prop.methodName}();
 {% end %}\
 {% end %}\
 {% end %}\
@@ -199,7 +199,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         // ${prop.name} is abstract and is a reference
         ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
         ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(o_base, ref);
@@ -211,7 +211,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when v['level'] == 2 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
@@ -221,7 +221,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
@@ -231,7 +231,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
@@ -271,7 +271,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         // ${prop.name} is reference and occurs more than once
         ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
         ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(modelObject, ref);
@@ -282,7 +282,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
@@ -292,7 +292,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(root);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
@@ -489,6 +489,7 @@ ${customContent[obj.name][prop.name]}
 #define ${fu.GUARD}
 
 #include <ome/xml/meta/Metadata.h>
+#include <ome/xml/meta/MetadataModel.h>
 #include <ome/xml/meta/MetadataException.h>
 #include <ome/xml/meta/OMEXMLMetadataRoot.h>
 #include <ome/xml/model/detail/OMEModel.h>
@@ -562,12 +563,8 @@ namespace ome
       class OMEXMLMetadata : virtual public Metadata
       {
       private:
-        /// OME-XML root node.
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> root; // OME
-        /// Generic root node.
-        ome::compat::shared_ptr<MetadataRoot> genericRoot; // OME
-        /// OME-XML model.
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModel> model;
+        /// OME-XML model and root node.
+        ome::compat::shared_ptr<OMEXMLMetadataRoot> model; // OME
 
       public:
 {% end header %}\
@@ -577,10 +574,9 @@ namespace ome
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       OMEXMLMetadata::OMEXMLMetadata():
-        root(),
         model()
       {
-        createRoot();
+        createModel();
       }
 {% end source %}\
 
@@ -598,27 +594,79 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
+        createModel();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      OMEXMLMetadata::createModel()
+      {
+        ome::compat::shared_ptr<MetadataModel> newmodel(ome::compat::make_shared<OMEXMLMetadataRoot>());
+        setModel(newmodel);
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        ome::compat::shared_ptr<MetadataModel>
+        getModel();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      ome::compat::shared_ptr<MetadataModel>
+      OMEXMLMetadata::getModel()
+      {
+        return ome::compat::dynamic_pointer_cast<MetadataModel>(this->model);
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+{% if debug %}\
+        // @copydoc only needed due to doxygen bug; should
+        // automatically inherit base method documentation.
+{% end debug %}\
+        /**
+         * @copydoc ::${lang.metadata_package}::MetadataStore::setModel()
+         */
+        void
+        setModel(ome::compat::shared_ptr<MetadataModel> model);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      OMEXMLMetadata::setModel(ome::compat::shared_ptr<MetadataModel> model)
+      {
+        ome::compat::shared_ptr<OMEXMLMetadataRoot> newmodel =
+          ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(model);
+
+        if (!newmodel)
+          throw MetadataException("OMEXMLMetadata", "setModel",
+                                  "model must be of type OMEXMLMetadataRoot");
+
+        this->model = newmodel;
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in base class.
+        void
         createRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
       OMEXMLMetadata::createRoot()
       {
-        ome::compat::shared_ptr<MetadataRoot> newroot(ome::compat::make_shared<OMEXMLMetadataRoot>());
-        setRoot(newroot);
+        createModel();
       }
 {% end source %}\
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>&
+        ome::compat::shared_ptr<MetadataRoot>
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>&
+      ome::compat::shared_ptr<MetadataRoot>
       OMEXMLMetadata::getRoot()
       {
-        return this->genericRoot;
+        return ome::compat::dynamic_pointer_cast<MetadataRoot>(this->model);
       }
 {% end source %}\
 
@@ -631,22 +679,20 @@ namespace ome
          * @copydoc ::${lang.metadata_package}::MetadataStore::setRoot()
          */
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot>& root);
+        setRoot(ome::compat::shared_ptr<MetadataRoot> root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      OMEXMLMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot>& root)
+      OMEXMLMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> root)
       {
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> newroot =
+        ome::compat::shared_ptr<OMEXMLMetadataRoot> newmodel =
           ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
 
-        if (!newroot)
+        if (!newmodel)
           throw MetadataException("OMEXMLMetadata", "setRoot",
                                   "root must be of type OMEXMLMetadataRoot");
 
-        this->root = newroot;
-        this->genericRoot = ome::compat::static_pointer_cast<MetadataRoot>(this->root);
-        model = ome::compat::make_shared< ::${lang.omexml_model_package}::detail::OMEModel>();
+        this->model = newmodel;
       }
 {% end source %}\
 
@@ -681,7 +727,7 @@ namespace ome
             URL_OME_TIFF " "));
         doc.getDocumentElement().appendChild(comment);
 
-        ome::common::xml::dom::Element ome = root->asXMLElement(doc);
+        ome::common::xml::dom::Element ome = model->asXMLElement(doc);
 
         std::string text;
         ome::common::xml::dom::writeDocument(doc, text);
@@ -721,7 +767,7 @@ namespace ome
       OMEXMLMetadata::get${abstractClass}Type(${indexes_string(v)}) const
       {
 {% for k, v in indexes[abstractClass].items() %}\
-        return ${safe_accessor([{'accessor':'root'}]+accessor(abstractClass, k, abstractClass, func=accessor_string_complex), "get%sType()" % abstractClass)}->get${abstractClass}Type();
+        return ${safe_accessor([{'accessor':'model'}]+accessor(abstractClass, k, abstractClass, func=accessor_string_complex), "get%sType()" % abstractClass)}->get${abstractClass}Type();
 {% end %}\
       }
 {% end source %}\
@@ -742,7 +788,7 @@ namespace ome
       {
         const char * const sa_method("getBooleanAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getBooleanAnnotationAnnotationCount [getBooleanAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getBooleanAnnotation(booleanAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getBooleanAnnotation(booleanAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -757,7 +803,7 @@ namespace ome
       {
         const char * const sa_method("getCommentAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getCommentAnnotationAnnotationCount [getCommentAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getCommentAnnotation(commentAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getCommentAnnotation(commentAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -772,7 +818,7 @@ namespace ome
       {
         const char * const sa_method("getDoubleAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getDoubleAnnotationAnnotationCount [getDoubleAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getDoubleAnnotation(doubleAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getDoubleAnnotation(doubleAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -787,7 +833,7 @@ namespace ome
       {
         const char * const sa_method("getFileAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getFileAnnotationAnnotationCount [getFileAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getFileAnnotation(fileAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getFileAnnotation(fileAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -802,7 +848,7 @@ namespace ome
       {
         const char * const sa_method("getListAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getListAnnotationAnnotationCount [getListAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getListAnnotation(listAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getListAnnotation(listAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -817,7 +863,7 @@ namespace ome
       {
         const char * const sa_method("getLongAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getLongAnnotationAnnotationCount [getLongAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getLongAnnotation(longAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getLongAnnotation(longAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -832,7 +878,7 @@ namespace ome
       {
         const char * const sa_method("getMapAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getMapAnnotationAnnotationCount [getMapAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -847,7 +893,7 @@ namespace ome
       {
         const char * const sa_method("getTagAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getTagAnnotationAnnotationCount [getTagAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTagAnnotation(tagAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getTagAnnotation(tagAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -862,7 +908,7 @@ namespace ome
       {
         const char * const sa_method("getTermAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getTermAnnotationAnnotationCount [getTermAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTermAnnotation(termAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getTermAnnotation(termAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -877,7 +923,7 @@ namespace ome
       {
         const char * const sa_method("getTimestampAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getTimestampAnnotationAnnotationCount [getTimestampAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTimestampAnnotation(timestampAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getTimestampAnnotation(timestampAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -892,7 +938,7 @@ namespace ome
       {
         const char * const sa_method("getXMLAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getXMLAnnotationAnnotationCount [getXMLAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getXMLAnnotation(xmlAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getXMLAnnotation(xmlAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -919,12 +965,12 @@ namespace ome
       void
       OMEXMLMetadata::set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
       {
-        if (root->sizeOfImageList() == imageIndex)
+        if (model->sizeOfImageList() == imageIndex)
           {
             ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(ome::compat::make_shared< ::${lang.omexml_model_package}::Image>());
-            root->addImage(newImage);
+            model->addImage(newImage);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = model->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
             ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(ome::compat::make_shared< ::${lang.omexml_model_package}::Pixels>());
@@ -960,7 +1006,7 @@ namespace ome
         const char * const pixels_method("get${o.name}Value [getPixels]");
         const char * const tiffdata_method("get${o.name}Value [getTiffData]");
         const char * const uuid_method("get${o.name}Value [getUUID]");
-        return safe_fetch(safe_fetch(safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getTiffData(tiffDataIndex), tiffdata_method)->getUUID(), uuid_method)->getValue();
+        return safe_fetch(safe_fetch(safe_fetch(safe_fetch(model->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getTiffData(tiffDataIndex), tiffdata_method)->getUUID(), uuid_method)->getValue();
       }
 {% end source %}\
 
@@ -992,9 +1038,9 @@ ${counter(k, o, v)}\
       const std::string&
       OMEXMLMetadata::getUUID() const
       {
-        ome::compat::shared_ptr<const std::string> uuid = root->getUUID();
+        ome::compat::shared_ptr<const std::string> uuid = model->getUUID();
         if (uuid)
-          return *root->getUUID();
+          return *model->getUUID();
         else
           throw MetadataException("OMEXMLMetadata", "getUUID",
                                   "Internal metadata store inconsistency: null object");
@@ -1012,7 +1058,7 @@ ${counter(k, o, v)}\
       {
         const char * const sa_method("getMapAnnotationValue [getStructuredAnnotations]");
         const char * const annotation_method("getMapAnnotationValue [getMapAnnotation]");
-        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->getValue();
+        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->getValue();
       }
 {% end source %}\
 
@@ -1027,7 +1073,7 @@ ${counter(k, o, v)}\
       OMEXMLMetadata::getGenericExcitationSourceMap(index_type instrumentIndex,
                                                     index_type lightSourceIndex) const
       {
-        return *safe_fetch(safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(root, "getGenericExcitationSourceMap [root]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->getMap(), "getGenericExcitationSourceMap [getMap()]");
+        return *safe_fetch(safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(model, "getGenericExcitationSourceMap [model]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->getMap(), "getGenericExcitationSourceMap [getMap()]");
       }
 {% end source %}\
 
@@ -1040,7 +1086,7 @@ ${counter(k, o, v)}\
       const ome::xml::model::primitives::OrderedMultimap&
       OMEXMLMetadata::getImagingEnvironmentMap(index_type imageIndex) const
       {
-        return *safe_fetch(safe_fetch(safe_fetch(safe_fetch(root, "getImagingEnvironmentMap [root]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->getMap(), "getImagingEnvironmentMap [getMap()]");
+        return *safe_fetch(safe_fetch(safe_fetch(safe_fetch(model, "getImagingEnvironmentMap [model]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->getMap(), "getImagingEnvironmentMap [getMap()]");
       }
 {% end source %}\
 
@@ -1148,7 +1194,7 @@ ${getter(k, o, prop, v)}\
       OMEXMLMetadata::setUUID(const std::string& uuid)
       {
         ome::compat::shared_ptr<std::string> newString(ome::compat::make_shared<std::string>(uuid));
-        root->setUUID(newString);
+        model->setUUID(newString);
       }
 {% end source %}\
 
@@ -1165,7 +1211,7 @@ ${getter(k, o, prop, v)}\
       {
         const char * const sa_method("getCommentAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getMapAnnotationAnnotationCount [getMapAnnotation]");
-        safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->setValue(value);
+        safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->setValue(value);
       }
 {% end source %}\
 
@@ -1183,7 +1229,7 @@ ${getter(k, o, prop, v)}\
                                                     index_type                                          lightSourceIndex)
       {
         ome::compat::shared_ptr<ome::xml::model::primitives::OrderedMultimap> map(ome::compat::make_shared<ome::xml::model::primitives::OrderedMultimap>(value));
-        safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(root, "getGenericExcitationSourceMap [root]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->setMap(map);
+        safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(model, "getGenericExcitationSourceMap [model]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->setMap(map);
       }
 {% end source %}\
 
@@ -1199,7 +1245,7 @@ ${getter(k, o, prop, v)}\
                                                index_type                                          imageIndex)
       {
         ome::compat::shared_ptr<ome::xml::model::primitives::OrderedMultimap> map(ome::compat::make_shared<ome::xml::model::primitives::OrderedMultimap>(value));
-        safe_fetch(safe_fetch(safe_fetch(root, "getImagingEnvironmentMap [root]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->setMap(map);
+        safe_fetch(safe_fetch(safe_fetch(model, "getImagingEnvironmentMap [model]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->setMap(map);
       }
 {% end source %}\
 

--- a/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -26,11 +26,11 @@
         // Parents: ${repr(parents[obj.name])}
 {% if obj.isReference %}\
         // ${obj.name} is a reference
-        return ${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, obj.name, func=accessor_string_complex)[:-1] + [{'accessor':"sizeOfLinked%sList()" % obj.name.replace('Ref', '')}], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
+        return ${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, obj.name, func=accessor_string_complex)[:-1] + [{'accessor':"sizeOfLinked%sList()" % obj.name.replace('Ref', '')}], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
 {% end %}\
 {% if not obj.isReference %}\
         // ${obj.name} is not a reference
-        return ${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, obj.name, func=accessor_string_complex)[:-1] + [{'accessor':"sizeOf%sList()" % obj.name.replace('Ref', '')}], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
+        return ${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, obj.name, func=accessor_string_complex)[:-1] + [{'accessor':"sizeOf%sList()" % obj.name.replace('Ref', '')}], getCounterMethod(is_multi_path[o.name], parent, obj.name))};
 {% end %}\
       }
 {% end source %}\
@@ -78,9 +78,9 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference and prop.maxOccurs > 1 %}\
         // ${parent} is abstract, is reference and occurs more than once
-        // ${obj.name} o = (${obj.name}) model.${".".join(accessor(obj.name, parent, prop)[:-1])};
+        // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
@@ -89,7 +89,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
@@ -98,7 +98,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract and not a reference
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -122,7 +122,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
+        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -131,7 +131,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}().lock());
+        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
@@ -140,14 +140,14 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% otherwise %}\
         // ${prop.name} is not a reference
 {% if prop.minOccurs == 0 %}\
-        ${prop.retType[' const']} ret = ${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->get${prop.methodName}();
+        ${prop.retType[' const']} ret = ${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->get${prop.methodName}();
         if (ret)
           return *ret;
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                 "Internal metadata store inconsistency: null object");
 {% end %}\
 {% if prop.minOccurs == 1 %}\
-        return ${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->get${prop.methodName}();
+        return ${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->get${prop.methodName}();
 {% end %}\
 {% end %}\
 {% end %}\
@@ -199,10 +199,10 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         // ${prop.name} is abstract and is a reference
         ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
         ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
-        model->addReference(o_base, ref);
+        root->addReference(o_base, ref);
         // ${parent} is abstract
 {% end %}\
 {% when is_abstract(parent) %}\
@@ -211,7 +211,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when v['level'] == 2 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
@@ -221,7 +221,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
@@ -231,7 +231,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
@@ -250,7 +250,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
         ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
-        model->addModelObject(${prop.argumentName}, o${i + 1}_base);
+        root->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
         ome::compat::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(ome::compat::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
@@ -271,10 +271,10 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         // ${prop.name} is reference and occurs more than once
         ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'model'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
         ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
-        model->addReference(modelObject, ref);
+        root->addReference(modelObject, ref);
 {% end %}\
 {% otherwise %}\
         // ${prop.name} is not a reference
@@ -282,7 +282,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
@@ -292,7 +292,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->model);
+        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
@@ -310,7 +310,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
         ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
-        model->addModelObject(${prop.argumentName}, o${i + 1}_base);
+        root->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
         ome::compat::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(ome::compat::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
@@ -564,7 +564,7 @@ namespace ome
       {
       private:
         /// OME-XML model and root node.
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> model; // OME
+        ome::compat::shared_ptr<OMEXMLMetadataRoot> root; // OME
 
       public:
 {% end header %}\
@@ -574,7 +574,7 @@ namespace ome
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       OMEXMLMetadata::OMEXMLMetadata():
-        model()
+        root()
       {
         createModel();
       }
@@ -614,7 +614,7 @@ namespace ome
       ome::compat::shared_ptr<MetadataModel>
       OMEXMLMetadata::getModel()
       {
-        return ome::compat::dynamic_pointer_cast<MetadataModel>(this->model);
+        return ome::compat::dynamic_pointer_cast<MetadataModel>(this->root);
       }
 {% end source %}\
 
@@ -640,7 +640,7 @@ namespace ome
           throw MetadataException("OMEXMLMetadata", "setModel",
                                   "model must be of type OMEXMLMetadataRoot");
 
-        this->model = newmodel;
+        this->root = newmodel;
       }
 {% end source %}\
 
@@ -666,7 +666,7 @@ namespace ome
       ome::compat::shared_ptr<MetadataRoot>
       OMEXMLMetadata::getRoot()
       {
-        return ome::compat::dynamic_pointer_cast<MetadataRoot>(this->model);
+        return ome::compat::dynamic_pointer_cast<MetadataRoot>(this->root);
       }
 {% end source %}\
 
@@ -685,14 +685,14 @@ namespace ome
       void
       OMEXMLMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> root)
       {
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> newmodel =
+        ome::compat::shared_ptr<OMEXMLMetadataRoot> newroot =
           ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
 
-        if (!newmodel)
+        if (!newroot)
           throw MetadataException("OMEXMLMetadata", "setRoot",
                                   "root must be of type OMEXMLMetadataRoot");
 
-        this->model = newmodel;
+        this->root = newroot;
       }
 {% end source %}\
 
@@ -727,7 +727,7 @@ namespace ome
             URL_OME_TIFF " "));
         doc.getDocumentElement().appendChild(comment);
 
-        ome::common::xml::dom::Element ome = model->asXMLElement(doc);
+        ome::common::xml::dom::Element ome = root->asXMLElement(doc);
 
         std::string text;
         ome::common::xml::dom::writeDocument(doc, text);
@@ -751,7 +751,7 @@ namespace ome
       OMEXMLMetadata::index_type
       OMEXMLMetadata::resolveReferences()
       {
-        return model->resolveReferences();
+        return root->resolveReferences();
       }
 {% end source %}\
 
@@ -767,7 +767,7 @@ namespace ome
       OMEXMLMetadata::get${abstractClass}Type(${indexes_string(v)}) const
       {
 {% for k, v in indexes[abstractClass].items() %}\
-        return ${safe_accessor([{'accessor':'model'}]+accessor(abstractClass, k, abstractClass, func=accessor_string_complex), "get%sType()" % abstractClass)}->get${abstractClass}Type();
+        return ${safe_accessor([{'accessor':'root'}]+accessor(abstractClass, k, abstractClass, func=accessor_string_complex), "get%sType()" % abstractClass)}->get${abstractClass}Type();
 {% end %}\
       }
 {% end source %}\
@@ -788,7 +788,7 @@ namespace ome
       {
         const char * const sa_method("getBooleanAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getBooleanAnnotationAnnotationCount [getBooleanAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getBooleanAnnotation(booleanAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getBooleanAnnotation(booleanAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -803,7 +803,7 @@ namespace ome
       {
         const char * const sa_method("getCommentAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getCommentAnnotationAnnotationCount [getCommentAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getCommentAnnotation(commentAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getCommentAnnotation(commentAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -818,7 +818,7 @@ namespace ome
       {
         const char * const sa_method("getDoubleAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getDoubleAnnotationAnnotationCount [getDoubleAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getDoubleAnnotation(doubleAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getDoubleAnnotation(doubleAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -833,7 +833,7 @@ namespace ome
       {
         const char * const sa_method("getFileAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getFileAnnotationAnnotationCount [getFileAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getFileAnnotation(fileAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getFileAnnotation(fileAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -848,7 +848,7 @@ namespace ome
       {
         const char * const sa_method("getListAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getListAnnotationAnnotationCount [getListAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getListAnnotation(listAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getListAnnotation(listAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -863,7 +863,7 @@ namespace ome
       {
         const char * const sa_method("getLongAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getLongAnnotationAnnotationCount [getLongAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getLongAnnotation(longAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getLongAnnotation(longAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -878,7 +878,7 @@ namespace ome
       {
         const char * const sa_method("getMapAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getMapAnnotationAnnotationCount [getMapAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -893,7 +893,7 @@ namespace ome
       {
         const char * const sa_method("getTagAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getTagAnnotationAnnotationCount [getTagAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getTagAnnotation(tagAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTagAnnotation(tagAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -908,7 +908,7 @@ namespace ome
       {
         const char * const sa_method("getTermAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getTermAnnotationAnnotationCount [getTermAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getTermAnnotation(termAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTermAnnotation(termAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -923,7 +923,7 @@ namespace ome
       {
         const char * const sa_method("getTimestampAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getTimestampAnnotationAnnotationCount [getTimestampAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getTimestampAnnotation(timestampAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getTimestampAnnotation(timestampAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -938,7 +938,7 @@ namespace ome
       {
         const char * const sa_method("getXMLAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getXMLAnnotationAnnotationCount [getXMLAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getXMLAnnotation(xmlAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getXMLAnnotation(xmlAnnotationIndex), annotation_method)->sizeOfLinkedAnnotationList();
       }
 {% end source %}\
 
@@ -965,12 +965,12 @@ namespace ome
       void
       OMEXMLMetadata::set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
       {
-        if (model->sizeOfImageList() == imageIndex)
+        if (root->sizeOfImageList() == imageIndex)
           {
             ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(ome::compat::make_shared< ::${lang.omexml_model_package}::Image>());
-            model->addImage(newImage);
+            root->addImage(newImage);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = model->getImage(imageIndex);
+        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
             ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(ome::compat::make_shared< ::${lang.omexml_model_package}::Pixels>());
@@ -1006,7 +1006,7 @@ namespace ome
         const char * const pixels_method("get${o.name}Value [getPixels]");
         const char * const tiffdata_method("get${o.name}Value [getTiffData]");
         const char * const uuid_method("get${o.name}Value [getUUID]");
-        return safe_fetch(safe_fetch(safe_fetch(safe_fetch(model->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getTiffData(tiffDataIndex), tiffdata_method)->getUUID(), uuid_method)->getValue();
+        return safe_fetch(safe_fetch(safe_fetch(safe_fetch(root->getImage(imageIndex), image_method)->getPixels(), pixels_method)->getTiffData(tiffDataIndex), tiffdata_method)->getUUID(), uuid_method)->getValue();
       }
 {% end source %}\
 
@@ -1038,9 +1038,9 @@ ${counter(k, o, v)}\
       const std::string&
       OMEXMLMetadata::getUUID() const
       {
-        ome::compat::shared_ptr<const std::string> uuid = model->getUUID();
+        ome::compat::shared_ptr<const std::string> uuid = root->getUUID();
         if (uuid)
-          return *model->getUUID();
+          return *root->getUUID();
         else
           throw MetadataException("OMEXMLMetadata", "getUUID",
                                   "Internal metadata store inconsistency: null object");
@@ -1058,7 +1058,7 @@ ${counter(k, o, v)}\
       {
         const char * const sa_method("getMapAnnotationValue [getStructuredAnnotations]");
         const char * const annotation_method("getMapAnnotationValue [getMapAnnotation]");
-        return safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->getValue();
+        return safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->getValue();
       }
 {% end source %}\
 
@@ -1073,7 +1073,7 @@ ${counter(k, o, v)}\
       OMEXMLMetadata::getGenericExcitationSourceMap(index_type instrumentIndex,
                                                     index_type lightSourceIndex) const
       {
-        return *safe_fetch(safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(model, "getGenericExcitationSourceMap [model]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->getMap(), "getGenericExcitationSourceMap [getMap()]");
+        return *safe_fetch(safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(root, "getGenericExcitationSourceMap [root]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->getMap(), "getGenericExcitationSourceMap [getMap()]");
       }
 {% end source %}\
 
@@ -1086,7 +1086,7 @@ ${counter(k, o, v)}\
       const ome::xml::model::primitives::OrderedMultimap&
       OMEXMLMetadata::getImagingEnvironmentMap(index_type imageIndex) const
       {
-        return *safe_fetch(safe_fetch(safe_fetch(safe_fetch(model, "getImagingEnvironmentMap [model]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->getMap(), "getImagingEnvironmentMap [getMap()]");
+        return *safe_fetch(safe_fetch(safe_fetch(safe_fetch(root, "getImagingEnvironmentMap [root]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->getMap(), "getImagingEnvironmentMap [getMap()]");
       }
 {% end source %}\
 
@@ -1194,7 +1194,7 @@ ${getter(k, o, prop, v)}\
       OMEXMLMetadata::setUUID(const std::string& uuid)
       {
         ome::compat::shared_ptr<std::string> newString(ome::compat::make_shared<std::string>(uuid));
-        model->setUUID(newString);
+        root->setUUID(newString);
       }
 {% end source %}\
 
@@ -1211,7 +1211,7 @@ ${getter(k, o, prop, v)}\
       {
         const char * const sa_method("getCommentAnnotationAnnotationCount [getStructuredAnnotations]");
         const char * const annotation_method("getMapAnnotationAnnotationCount [getMapAnnotation]");
-        safe_fetch(safe_fetch(model->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->setValue(value);
+        safe_fetch(safe_fetch(root->getStructuredAnnotations(), sa_method)->getMapAnnotation(mapAnnotationIndex), annotation_method)->setValue(value);
       }
 {% end source %}\
 
@@ -1229,7 +1229,7 @@ ${getter(k, o, prop, v)}\
                                                     index_type                                          lightSourceIndex)
       {
         ome::compat::shared_ptr<ome::xml::model::primitives::OrderedMultimap> map(ome::compat::make_shared<ome::xml::model::primitives::OrderedMultimap>(value));
-        safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(model, "getGenericExcitationSourceMap [model]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->setMap(map);
+        safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(root, "getGenericExcitationSourceMap [root]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->setMap(map);
       }
 {% end source %}\
 
@@ -1245,7 +1245,7 @@ ${getter(k, o, prop, v)}\
                                                index_type                                          imageIndex)
       {
         ome::compat::shared_ptr<ome::xml::model::primitives::OrderedMultimap> map(ome::compat::make_shared<ome::xml::model::primitives::OrderedMultimap>(value));
-        safe_fetch(safe_fetch(safe_fetch(model, "getImagingEnvironmentMap [model]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->setMap(map);
+        safe_fetch(safe_fetch(safe_fetch(root, "getImagingEnvironmentMap [root]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->setMap(map);
       }
 {% end source %}\
 

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -60,6 +60,7 @@
 #include <ome/common/xml/dom/Node.h>
 #include <ome/common/xml/dom/NodeList.h>
 
+#include <ome/xml/model/OMEModel.h>
 #include <ome/xml/model/primitives/Quantity.h>
 
 {% for include in klass.header_dependencies %}\
@@ -106,7 +107,12 @@ namespace ome
        * ${klass.name} model object.
        */
 {% if klass.parentName is not None %}\
+{% if klass.name != "OME" %}\
       class ${klass.name} : public ${klass.parentName}
+{% end if %}\
+{% if klass.name == "OME" %}\
+      class ${klass.name} : public ${klass.parentName}, virtual public OMEModel
+{% end if %}\
 {% end has parentName %}\
 {% if klass.parentName is None %}\
       class ${klass.name}
@@ -128,6 +134,15 @@ namespace ome
         ${prop[0]} ${prop[1]};
 {% end has instance type %}\
 {% end for %}\
+{% if klass.name == "OME" %}\
+
+        // OMEModel data
+
+        /// Mapping of id to model object.
+        object_map_type modelObjects;
+        /// Mapping of model object to reference.
+        reference_map_type references;
+{% end if %}\
 {% end has instanceVariables %}\
 
         /// Default constructor.
@@ -135,7 +150,7 @@ namespace ome
         Impl():
 {% for prop in klass.instanceVariables %}\
 {% if prop[0] is not None %}\
-{% if prop == klass.instanceVariables[-1] %}\
+{% if prop == klass.instanceVariables[-1] and klass.name != "OME" %}\
 {% if prop[2] is not None %}\
           ${prop[1]}(${prop[2]})
 {% end has default %}\
@@ -143,7 +158,7 @@ namespace ome
           ${prop[1]}()
 {% end no default %}\
 {% end last member %}\
-{% if prop != klass.instanceVariables[-1] %}\
+{% if prop != klass.instanceVariables[-1] or klass.name == "OME"%}\
 {% if prop[2] is not None %}\
           ${prop[1]}(${prop[2]}),
 {% end has default %}\
@@ -153,6 +168,10 @@ namespace ome
 {% end not last member %}\
 {% end has instance type %}\
 {% end for %}\
+{% if klass.name == "OME" %}\
+          modelObjects(),
+          references()
+{% end if %}\
 {% end has instanceVariables %}\
 {% if len(klass.instanceVariables) == 0 %}\
         Impl()
@@ -165,7 +184,7 @@ namespace ome
         Impl(const Impl& copy):
 {% for prop in klass.instanceVariables %}\
 {% if prop[0] is not None %}\
-{% if prop == klass.instanceVariables[-1] %}\
+{% if prop == klass.instanceVariables[-1] and klass.name != "OME" %}\
 {% if prop[2] is not None %}\
           ${prop[1]}(copy.${prop[1]})
 {% end has default %}\
@@ -173,16 +192,21 @@ namespace ome
           ${prop[1]}(copy.${prop[1]})
 {% end no default %}\
 {% end last member %}\
-{% if prop != klass.instanceVariables[-1] %}\
+{% if prop != klass.instanceVariables[-1] or klass.name == "OME" %}\
 {% if prop[2] is not None %}\
           ${prop[1]}(copy.${prop[1]}),
 {% end has default %}\
-{% if prop[2] is None %}\
+{% if prop[2] is None and klass.name != "OME" %}\
           ${prop[1]}(copy.${prop[1]}),
 {% end no default %}\
 {% end not last member %}\
 {% end has instance type %}\
 {% end for %}\
+{% if klass.name == "OME" %}\
+          // Shallow copy at present.
+          modelObjects(copy.modelObjects),
+          references(copy.references)
+{% end if %}\
 {% end has instanceVariables %}\
 {% if len(klass.instanceVariables) == 0 %}\
         Impl(const Impl& /* copy */)
@@ -242,6 +266,9 @@ namespace ome
 {% if fu.SOURCE_TYPE == "source" %}\
       ${klass.name}::${klass.name}():
         ${lang.omexml_model_package}::OMEModelObject(),
+{% if klass.name == "OME" %}\
+        ${lang.omexml_model_package}::OMEModel(),
+{% end if %}\
 {% if klass.parentName is not None %}\
         ${klass.parentName}(),
 {% end has parent %}\
@@ -262,6 +289,9 @@ namespace ome
 {% if fu.SOURCE_TYPE == "source" %}\
       ${klass.name}::${klass.name} (const ${klass.name}& copy):
         ${lang.omexml_model_package}::OMEModelObject(),
+{% if klass.name == "OME" %}\
+        ${lang.omexml_model_package}::OMEModel(),
+{% end if %}\
 {% if klass.parentName is not None %}\
         ${klass.parentName}(copy),
 {% end has parent %}\
@@ -312,6 +342,198 @@ namespace ome
       }
 {% end source %}\
 
+{% if klass.name == "OME" %}\
+{% if fu.SOURCE_TYPE == "header" %}\
+        /// @copydoc ome::xml::model::OMEModel::addModelObject
+        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        addModelObject (const std::string&                                           id,
+                        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+      OME::addModelObject(const std::string&                                           id,
+                          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+      {
+        // Don't store references.
+        if (ome::compat::dynamic_pointer_cast<Reference>(object))
+          return object;
+
+        object_map_type::iterator i = this->impl->modelObjects.find(id);
+        if (i != this->impl->modelObjects.end())
+          i->second = object;
+        else
+          this->impl->modelObjects.insert(std::make_pair(id, object));
+
+        return object;
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in parent.
+        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        removeModelObject (const std::string& id);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+      OME::removeModelObject(const std::string& id)
+      {
+        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+
+        object_map_type::iterator i = this->impl->modelObjects.find(id);
+        if (i != this->impl->modelObjects.end())
+          {
+            ret = i->second;
+            this->impl->modelObjects.erase(i);
+          }
+
+        return ret;
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in parent.
+        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        getModelObject (const std::string& id) const;
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+      OME::getModelObject(const std::string& id) const
+      {
+        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+
+        object_map_type::const_iterator i = this->impl->modelObjects.find(id);
+        if (i != this->impl->modelObjects.end())
+          ret = i->second;
+
+        return ret;
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in parent.
+        const object_map_type&
+        getModelObjects () const;
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      const OMEModel::object_map_type&
+      OME::getModelObjects () const
+      {
+        return this->impl->modelObjects;
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        /// @copydoc ome::xml::model::OMEModel::addReference
+        bool
+        addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                      ome::compat::shared_ptr<Reference>&                          b);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      bool
+      OME::addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                         ome::compat::shared_ptr<Reference>&                          b)
+      {
+        reference_map_type::iterator i = this->impl->references.find(a);
+
+        if (i == this->impl->references.end())
+          {
+            std::pair<reference_map_type::iterator,bool> r =
+              this->impl->references.insert(std::make_pair(a, reference_map_type::value_type::second_type()));
+            i = r.first;
+          }
+        i->second.push_back(b);
+        return true;
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in parent.
+        const reference_map_type&
+        getReferences () const;
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      const OMEModel::reference_map_type&
+      OME::getReferences () const
+      {
+        return this->impl->references;
+      }
+{% end source %}\
+
+{% if fu.SOURCE_TYPE == "header" %}\
+        // Documented in parent.
+        size_type
+        resolveReferences ();
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      OMEModel::size_type
+      OME::resolveReferences ()
+      {
+        size_type unhandledReferences = 0;
+
+        for (reference_map_type::iterator i = this->impl->references.begin();
+             i != this->impl->references.end();
+             ++i)
+          {
+            const ome::compat::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
+
+            if (!a)
+              {
+                const reference_list_type& references(i->second);
+
+                if (references.empty())
+                  {
+                    BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+                      << "No references to null object; continuing";
+                  }
+                else
+                  {
+                    BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+                      << "Null reference to " << references.size()
+                      << " objects; continuing";
+                  }
+                unhandledReferences += references.size();
+              }
+            else
+              {
+                reference_list_type& references(i->second);
+
+                for (reference_list_type::iterator ref = references.begin();
+                     ref != references.end();
+                     ++ref)
+                  {
+                    if (!(*ref))
+                      {
+                        BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+                          << typeid(*a).name() << "@" << a
+                          << " reference to null object; continuing";
+                      }
+                    else
+                      {
+                        const std::string& referenceID = (*ref)->getID();
+
+                        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
+                        if (!b)
+                          {
+                            BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+                              << typeid(*a).name() << "@" << a
+                              << " reference to " << referenceID
+                              << " missing from object hierarchy";
+                            unhandledReferences++;
+                          }
+                        else
+                          {
+                            ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> aw(ome::compat::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
+                            aw->link(*ref, b);
+                          }
+                      }
+                  }
+              }
+          }
+        return unhandledReferences;
+      }
+{% end source %}\
+{% end if %}\
+
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in superclass.
         const std::string&
@@ -355,6 +577,32 @@ namespace ome
 
 ${customContent}\
 {% end custom content %}\
+{% if klass.name == "OME" %}\
+{% if fu.SOURCE_TYPE == "header" %}\
+        /**
+         * Update the object hierarchy recursively from an XML DOM tree.
+         *
+         * @note No properties are removed, only added or updated.
+         *
+         * @param element root of the XML DOM tree to from which to
+         * construct the model object graph.
+         * @throws EnumerationException if there is an error
+         * instantiating an enumeration during model object creation,
+         * or ModelException if there are any consistency or validity
+         * errors found during processing.
+         */
+        void
+        update(const common::xml::dom::Element& element);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      void
+      ${klass.name}::update(const common::xml::dom::Element& element)
+      {
+        update(element, *this);
+      }
+{% end source %}\
+
+{% end OME %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         // -- OMEModelObject API methods --
 

--- a/xsd-fu/templates-java/AggregateMetadata.template
+++ b/xsd-fu/templates-java/AggregateMetadata.template
@@ -272,6 +272,19 @@ public class AggregateMetadata implements IMetadata
 
   // -- MetadataStore API methods --
 
+  /* @see MetadataStore#createModel() */
+  public void createModel()
+  {
+    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    {
+      Object o = iter.next();
+      if (o instanceof MetadataStore)
+      {
+        ((MetadataStore) o).createModel();
+      }
+    }
+  }
+
   /* @see MetadataStore#createRoot() */
   public void createRoot()
   {
@@ -283,6 +296,24 @@ public class AggregateMetadata implements IMetadata
         ((MetadataStore) o).createRoot();
       }
     }
+  }
+
+  /**
+   * Unsupported with an AggregateMetadata.
+   * @throws RuntimeException Always.
+   */
+  public MetadataModel getModel()
+  {
+    throw new RuntimeException("Unsupported by AggregateMetadata");
+  }
+
+  /**
+   * Unsupported with an AggregateMetadata.
+   * @throws RuntimeException Always.
+   */
+  public void setModel(MetadataModel model)
+  {
+    throw new RuntimeException("Unsupported by AggregateMetadata");
   }
 
   /**

--- a/xsd-fu/templates-java/DummyMetadata.template
+++ b/xsd-fu/templates-java/DummyMetadata.template
@@ -175,7 +175,20 @@ public class DummyMetadata implements IMetadata
 {
   // -- MetadataStore API methods --
 
+  public void createModel()
+  {
+  }
+
   public void createRoot()
+  {
+  }
+
+  public MetadataModel getModel()
+  {
+    return null;
+  }
+
+  public void setModel(MetadataModel model)
   {
   }
 

--- a/xsd-fu/templates-java/FilterMetadata.template
+++ b/xsd-fu/templates-java/FilterMetadata.template
@@ -190,10 +190,28 @@ public class FilterMetadata implements MetadataStore
 
   // -- MetadataStore API methods --
 
+  /* @see MetadataStore#createModel() */
+  public void createModel()
+  {
+    store.createModel();
+  }
+
   /* @see MetadataStore#createRoot() */
   public void createRoot()
   {
     store.createRoot();
+  }
+
+  /* @see MetadataStore#getModel() */
+  public MetadataModel getModel()
+  {
+    return store.getModel();
+  }
+
+  /* @see MetadataStore#setModel(MetadataModel) */
+  public void setModel(MetadataModel model)
+  {
+    store.setModel(model);
   }
 
   /* @see MetadataStore#getRoot() */

--- a/xsd-fu/templates-java/MetadataStore.template
+++ b/xsd-fu/templates-java/MetadataStore.template
@@ -166,6 +166,13 @@ import ${lang.units_package}.unit.Unit;
  */
 public interface MetadataStore extends BaseMetadata
 {
+
+  /**
+   * Create underlying data model.  The action taken here is specific
+   * to the concrete metadata implementation.
+   */
+  void createModel();
+
   /**
    * Create root node.  The action taken here is specific to the
    * concrete metadata implementation.
@@ -190,6 +197,25 @@ public interface MetadataStore extends BaseMetadata
    * @param root the root node.
    */
   void setRoot(MetadataRoot root);
+
+  /**
+   * Get the underlying model storing the metadata.  Note that the
+   * model type will be specific to the concrete metadata
+   * implementation.
+   *
+   * @return the model node.
+   */
+  MetadataModel getModel();
+
+  /**
+   * Set the underlying model storing the metadata. Set the model node
+   * of the metadata.  Note that the model type will be specific to
+   * the concrete metadata implementation.  An exception will be
+   * thrown if the model node is of an incompatible type.
+   *
+   * @param model the model node.
+   */
+  void setModel(MetadataModel model);
 
   // -- Entity storage (manual definitions) --
 

--- a/xsd-fu/templates-java/OMEXMLMetadataImpl.template
+++ b/xsd-fu/templates-java/OMEXMLMetadataImpl.template
@@ -96,13 +96,13 @@
     ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
     ${prop.instanceVariableName}_reference.setID(${prop.argumentName});
     model.addReference(
-      root.${".".join(accessor(obj.name, parent, prop)[:-1])},
+      model.${".".join(accessor(obj.name, parent, prop)[:-1])},
       ${prop.instanceVariableName}_reference);
     // ${parent} is abstract
 {% end %}\
 {% when is_abstract(parent) %}\
     // ${parent} is abstract and not a reference
-    OME o0 = root;
+    OME o0 = this.model;
 {% for i, v in enumerate(accessor(obj.name, parent, prop, accessor_string_complex)[:-1]) %}\
 {% choose %}\
 {% when v['level'] == 2 %}\
@@ -143,7 +143,7 @@
 {% end %}\
 {% otherwise %}\
     // ${prop.name} is not a reference
-    OME o0 = root;
+    OME o0 = this.model;
 {% for i, v in enumerate(accessor(obj.name, parent, prop, accessor_string_complex)) %}\
 {% choose %}\
 {% when v['max_occurs'] > 1 %}\
@@ -196,7 +196,7 @@ ${customContent[obj.name][prop.name]}
 
   def join_accessors(name, parent, prop=None, accessorIndex=None, additionalJoins=None):
     results = dict()
-    to_return = "root"
+    to_return = "model"
     o = model.getObjectByName(parent)
     results = accessor(name, parent, prop, accessor_string_complex)
     if accessorIndex is not None:
@@ -324,33 +324,48 @@ import ${lang.units_package}.unit.Unit;
  */
 public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 {
-  private OMEXMLMetadataRoot root; // OME
-
-  private OMEModel model;
+  /** OME-XML model and root node. */
+  private OMEXMLMetadataRoot model; // OME
 
   public OMEXMLMetadataImpl()
   {
-    createRoot();
+    createModel();
+  }
+
+  public void createModel()
+  {
+    model = new OMEXMLMetadataRoot();
   }
 
   public void createRoot()
   {
-    root = new OMEXMLMetadataRoot();
-    model = new OMEModelImpl();
+    createModel();
   }
 
   public MetadataRoot getRoot()
   {
-    return root;
+    return model;
+  }
+
+  public void setModel(MetadataModel model)
+  {
+    if (model instanceof OMEXMLMetadataRoot)
+      this.model = (OMEXMLMetadataRoot) model;
+    else
+      throw new IllegalArgumentException("Expecting OMEXMLMetadataRoot class or subclass.");
+  }
+
+  public MetadataModel getModel()
+  {
+    return model;
   }
 
   public void setRoot(MetadataRoot root)
   {
     if (root instanceof OMEXMLMetadataRoot)
-      this.root = (OMEXMLMetadataRoot) root;
+      this.model = (OMEXMLMetadataRoot) root;
     else
       throw new IllegalArgumentException("Expecting OMEXMLMetadataRoot class or subclass.");
-    model = new OMEModelImpl();
   }
 
   public String dumpXML()
@@ -367,55 +382,55 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
   // -- Entity counting (manual definitions) --
 
   public int getBooleanAnnotationAnnotationCount(int booleanAnnotationIndex) {
-    return root.getStructuredAnnotations().getBooleanAnnotation(booleanAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getBooleanAnnotation(booleanAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getCommentAnnotationAnnotationCount(int commentAnnotationIndex) {
-    return root.getStructuredAnnotations().getCommentAnnotation(commentAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getCommentAnnotation(commentAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getDoubleAnnotationAnnotationCount(int doubleAnnotationIndex) {
-    return root.getStructuredAnnotations().getDoubleAnnotation(doubleAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getDoubleAnnotation(doubleAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getFileAnnotationAnnotationCount(int fileAnnotationIndex) {
-    return root.getStructuredAnnotations().getFileAnnotation(fileAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getFileAnnotation(fileAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getListAnnotationAnnotationCount(int listAnnotationIndex) {
-    return root.getStructuredAnnotations().getListAnnotation(listAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getListAnnotation(listAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getLongAnnotationAnnotationCount(int longAnnotationIndex) {
-    return root.getStructuredAnnotations().getLongAnnotation(longAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getLongAnnotation(longAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getMapAnnotationAnnotationCount(int mapAnnotationIndex) {
-    return root.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getTagAnnotationAnnotationCount(int tagAnnotationIndex) {
-    return root.getStructuredAnnotations().getTagAnnotation(tagAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getTagAnnotation(tagAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getTermAnnotationAnnotationCount(int termAnnotationIndex) {
-    return root.getStructuredAnnotations().getTermAnnotation(termAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getTermAnnotation(termAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getTimestampAnnotationAnnotationCount(int timestampAnnotationIndex)
   {
-    return root.getStructuredAnnotations().getTimestampAnnotation(timestampAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getTimestampAnnotation(timestampAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getXMLAnnotationAnnotationCount(int xmlAnnotationIndex) {
-    return root.getStructuredAnnotations().getXMLAnnotation(xmlAnnotationIndex).sizeOfLinkedAnnotationList();
+    return model.getStructuredAnnotations().getXMLAnnotation(xmlAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
 {% for abstractClass in model.opts.lang.getSubstitutionTypes() %}\
 {% for k, v in indexes[abstractClass].items() %}\
   public String get${abstractClass}Type(${indexes_string(v)})
   {
-    ${abstractClass} o = (${abstractClass}) root.${".".join(basic_accessor(abstractClass))};
+    ${abstractClass} o = (${abstractClass}) model.${".".join(basic_accessor(abstractClass))};
     String className = o.getClass().getName();
     return className.substring(
       className.lastIndexOf('.') + 1, className.length());
@@ -432,7 +447,7 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
   // ${repr(indexes[o.name])}
   public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
   {
-    OME o0 = root;
+    OME o0 = this.model;
     if (o0.sizeOfImageList() == imageIndex)
     {
       o0.addImage(new Image());
@@ -458,7 +473,7 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 
   public ${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])})
   {
-    return root.getImage(imageIndex).getPixels().getTiffData(tiffDataIndex).getUUID().getValue();
+    return model.getImage(imageIndex).getPixels().getTiffData(tiffDataIndex).getUUID().getValue();
   }
 
 {% end %}\
@@ -479,26 +494,26 @@ ${counter(k, o, v)}\
   /** Gets the UUID associated with this collection of metadata. */
   public String getUUID()
   {
-    return root.getUUID();
+    return model.getUUID();
   }
 
   /** Gets the Map value associated with this annotation */
   public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
   {
-    return root.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).getValue();
+    return model.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).getValue();
   }
 
   /** Gets the Map value associated with this generic light source */
   public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
   {
-    GenericExcitationSource o = (GenericExcitationSource) root.getInstrument(instrumentIndex).getLightSource(lightSourceIndex);
+    GenericExcitationSource o = (GenericExcitationSource) model.getInstrument(instrumentIndex).getLightSource(lightSourceIndex);
     return o.getMap();
   }
 
   /** Gets the Map value associated with this imaging environment */
   public List<MapPair> getImagingEnvironmentMap(int imageIndex)
   {
-    return root.getImage(imageIndex).getImagingEnvironment().getMap();
+    return model.getImage(imageIndex).getImagingEnvironment().getMap();
   }
 
   // -- Entity retrieval (code generated definitions) --
@@ -583,13 +598,13 @@ ${getter(k, o, prop, v)}\
   /** Sets the UUID associated with this collection of metadata. */
   public void setUUID(String uuid)
   {
-    root.setUUID(uuid);
+    model.setUUID(uuid);
   }
 
   /** Sets the Map value associated with this annotation */
   public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
   {
-    OME o0 = root;
+    OME o0 = this.model;
     if (o0.getStructuredAnnotations() == null)
     {
       o0.setStructuredAnnotations(new StructuredAnnotations());
@@ -606,7 +621,7 @@ ${getter(k, o, prop, v)}\
   /** Sets the Map value associated with this generic light source */
   public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
   {
-    OME o0 = root;
+    OME o0 = this.model;
     if (o0.sizeOfInstrumentList() == instrumentIndex)
     {
       o0.addInstrument(new Instrument());
@@ -623,7 +638,7 @@ ${getter(k, o, prop, v)}\
   /** Sets the Map value associated with this imaging environment */
   public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
   {
-    OME o0 = root;
+    OME o0 = this.model;
     if (o0.sizeOfImageList() == imageIndex)
     {
       o0.addImage(new Image());

--- a/xsd-fu/templates-java/OMEXMLMetadataImpl.template
+++ b/xsd-fu/templates-java/OMEXMLMetadataImpl.template
@@ -95,14 +95,14 @@
     // ${prop.name} is abstract and is a reference
     ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
     ${prop.instanceVariableName}_reference.setID(${prop.argumentName});
-    model.addReference(
-      model.${".".join(accessor(obj.name, parent, prop)[:-1])},
+    root.addReference(
+      root.${".".join(accessor(obj.name, parent, prop)[:-1])},
       ${prop.instanceVariableName}_reference);
     // ${parent} is abstract
 {% end %}\
 {% when is_abstract(parent) %}\
     // ${parent} is abstract and not a reference
-    OME o0 = this.model;
+    OME o0 = this.root;
 {% for i, v in enumerate(accessor(obj.name, parent, prop, accessor_string_complex)[:-1]) %}\
 {% choose %}\
 {% when v['level'] == 2 %}\
@@ -127,7 +127,7 @@
     ${v['name']} o${i + 1} = o${i}.${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
-    model.addModelObject(${prop.argumentName}, o${i + 1});
+    root.addModelObject(${prop.argumentName}, o${i + 1});
 {% end %}\
     ((${obj.name})o${i + 1}).set${prop.methodName}(${prop.argumentName});
 {% end %}\
@@ -137,13 +137,13 @@
     // ${prop.name} is reference and occurs more than once
     ${prop.name} ${prop.instanceVariableName}_reference = new ${prop.name}();
     ${prop.instanceVariableName}_reference.setID(${prop.argumentName});
-    model.addReference(
+    root.addReference(
       ${join_accessors(obj.name, parent, prop)},
       ${prop.instanceVariableName}_reference);
 {% end %}\
 {% otherwise %}\
     // ${prop.name} is not a reference
-    OME o0 = this.model;
+    OME o0 = this.root;
 {% for i, v in enumerate(accessor(obj.name, parent, prop, accessor_string_complex)) %}\
 {% choose %}\
 {% when v['max_occurs'] > 1 %}\
@@ -167,7 +167,7 @@
 {% end %}\
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
-    model.addModelObject(${prop.argumentName}, o${i + 1});
+    root.addModelObject(${prop.argumentName}, o${i + 1});
 {% end %}\
     o${i + 1}.set${prop.methodName}(${prop.argumentName});
 {% end %}\
@@ -196,7 +196,7 @@ ${customContent[obj.name][prop.name]}
 
   def join_accessors(name, parent, prop=None, accessorIndex=None, additionalJoins=None):
     results = dict()
-    to_return = "model"
+    to_return = "root"
     o = model.getObjectByName(parent)
     results = accessor(name, parent, prop, accessor_string_complex)
     if accessorIndex is not None:
@@ -325,7 +325,7 @@ import ${lang.units_package}.unit.Unit;
 public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 {
   /** OME-XML model and root node. */
-  private OMEXMLMetadataRoot model; // OME
+  private OMEXMLMetadataRoot root; // OME
 
   public OMEXMLMetadataImpl()
   {
@@ -334,7 +334,7 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 
   public void createModel()
   {
-    model = new OMEXMLMetadataRoot();
+    root = new OMEXMLMetadataRoot();
   }
 
   public void createRoot()
@@ -344,26 +344,26 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 
   public MetadataRoot getRoot()
   {
-    return model;
+    return root;
   }
 
   public void setModel(MetadataModel model)
   {
     if (model instanceof OMEXMLMetadataRoot)
-      this.model = (OMEXMLMetadataRoot) model;
+      this.root = (OMEXMLMetadataRoot) model;
     else
       throw new IllegalArgumentException("Expecting OMEXMLMetadataRoot class or subclass.");
   }
 
   public MetadataModel getModel()
   {
-    return model;
+    return root;
   }
 
   public void setRoot(MetadataRoot root)
   {
     if (root instanceof OMEXMLMetadataRoot)
-      this.model = (OMEXMLMetadataRoot) root;
+      this.root = (OMEXMLMetadataRoot) root;
     else
       throw new IllegalArgumentException("Expecting OMEXMLMetadataRoot class or subclass.");
   }
@@ -376,61 +376,61 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 
   public int resolveReferences()
   {
-    return model.resolveReferences();
+    return root.resolveReferences();
   }
 
   // -- Entity counting (manual definitions) --
 
   public int getBooleanAnnotationAnnotationCount(int booleanAnnotationIndex) {
-    return model.getStructuredAnnotations().getBooleanAnnotation(booleanAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getBooleanAnnotation(booleanAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getCommentAnnotationAnnotationCount(int commentAnnotationIndex) {
-    return model.getStructuredAnnotations().getCommentAnnotation(commentAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getCommentAnnotation(commentAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getDoubleAnnotationAnnotationCount(int doubleAnnotationIndex) {
-    return model.getStructuredAnnotations().getDoubleAnnotation(doubleAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getDoubleAnnotation(doubleAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getFileAnnotationAnnotationCount(int fileAnnotationIndex) {
-    return model.getStructuredAnnotations().getFileAnnotation(fileAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getFileAnnotation(fileAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getListAnnotationAnnotationCount(int listAnnotationIndex) {
-    return model.getStructuredAnnotations().getListAnnotation(listAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getListAnnotation(listAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getLongAnnotationAnnotationCount(int longAnnotationIndex) {
-    return model.getStructuredAnnotations().getLongAnnotation(longAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getLongAnnotation(longAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getMapAnnotationAnnotationCount(int mapAnnotationIndex) {
-    return model.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getTagAnnotationAnnotationCount(int tagAnnotationIndex) {
-    return model.getStructuredAnnotations().getTagAnnotation(tagAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getTagAnnotation(tagAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getTermAnnotationAnnotationCount(int termAnnotationIndex) {
-    return model.getStructuredAnnotations().getTermAnnotation(termAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getTermAnnotation(termAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getTimestampAnnotationAnnotationCount(int timestampAnnotationIndex)
   {
-    return model.getStructuredAnnotations().getTimestampAnnotation(timestampAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getTimestampAnnotation(timestampAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
   public int getXMLAnnotationAnnotationCount(int xmlAnnotationIndex) {
-    return model.getStructuredAnnotations().getXMLAnnotation(xmlAnnotationIndex).sizeOfLinkedAnnotationList();
+    return root.getStructuredAnnotations().getXMLAnnotation(xmlAnnotationIndex).sizeOfLinkedAnnotationList();
   }
 
 {% for abstractClass in model.opts.lang.getSubstitutionTypes() %}\
 {% for k, v in indexes[abstractClass].items() %}\
   public String get${abstractClass}Type(${indexes_string(v)})
   {
-    ${abstractClass} o = (${abstractClass}) model.${".".join(basic_accessor(abstractClass))};
+    ${abstractClass} o = (${abstractClass}) root.${".".join(basic_accessor(abstractClass))};
     String className = o.getClass().getName();
     return className.substring(
       className.lastIndexOf('.') + 1, className.length());
@@ -447,7 +447,7 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
   // ${repr(indexes[o.name])}
   public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
   {
-    OME o0 = this.model;
+    OME o0 = this.root;
     if (o0.sizeOfImageList() == imageIndex)
     {
       o0.addImage(new Image());
@@ -473,7 +473,7 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 
   public ${o.langBaseType} get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])})
   {
-    return model.getImage(imageIndex).getPixels().getTiffData(tiffDataIndex).getUUID().getValue();
+    return root.getImage(imageIndex).getPixels().getTiffData(tiffDataIndex).getUUID().getValue();
   }
 
 {% end %}\
@@ -494,26 +494,26 @@ ${counter(k, o, v)}\
   /** Gets the UUID associated with this collection of metadata. */
   public String getUUID()
   {
-    return model.getUUID();
+    return root.getUUID();
   }
 
   /** Gets the Map value associated with this annotation */
   public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
   {
-    return model.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).getValue();
+    return root.getStructuredAnnotations().getMapAnnotation(mapAnnotationIndex).getValue();
   }
 
   /** Gets the Map value associated with this generic light source */
   public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
   {
-    GenericExcitationSource o = (GenericExcitationSource) model.getInstrument(instrumentIndex).getLightSource(lightSourceIndex);
+    GenericExcitationSource o = (GenericExcitationSource) root.getInstrument(instrumentIndex).getLightSource(lightSourceIndex);
     return o.getMap();
   }
 
   /** Gets the Map value associated with this imaging environment */
   public List<MapPair> getImagingEnvironmentMap(int imageIndex)
   {
-    return model.getImage(imageIndex).getImagingEnvironment().getMap();
+    return root.getImage(imageIndex).getImagingEnvironment().getMap();
   }
 
   // -- Entity retrieval (code generated definitions) --
@@ -598,13 +598,13 @@ ${getter(k, o, prop, v)}\
   /** Sets the UUID associated with this collection of metadata. */
   public void setUUID(String uuid)
   {
-    model.setUUID(uuid);
+    root.setUUID(uuid);
   }
 
   /** Sets the Map value associated with this annotation */
   public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
   {
-    OME o0 = this.model;
+    OME o0 = this.root;
     if (o0.getStructuredAnnotations() == null)
     {
       o0.setStructuredAnnotations(new StructuredAnnotations());
@@ -621,7 +621,7 @@ ${getter(k, o, prop, v)}\
   /** Sets the Map value associated with this generic light source */
   public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
   {
-    OME o0 = this.model;
+    OME o0 = this.root;
     if (o0.sizeOfInstrumentList() == instrumentIndex)
     {
       o0.addInstrument(new Instrument());
@@ -638,7 +638,7 @@ ${getter(k, o, prop, v)}\
   /** Sets the Map value associated with this imaging environment */
   public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
   {
-    OME o0 = this.model;
+    OME o0 = this.root;
     if (o0.sizeOfImageList() == imageIndex)
     {
       o0.addImage(new Image());

--- a/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -56,6 +56,11 @@ package ${lang.omexml_model_package};
 
 import java.util.ArrayList;
 import java.util.List;
+{% if klass.name == "OME" %}\
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+{% end if %}\
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,7 +93,12 @@ import ${lang.omexml_model_package}.primitives.*;
 public abstract class ${klass.name} extends ${klass.parentName}
 {% end %}\
 {% when not klass.isAbstract %}\
+{% if klass.name != "OME" %}\
 public class ${klass.name} extends ${klass.parentName}
+{% end if %}\
+{% if klass.name == "OME" %}\
+public class ${klass.name} extends ${klass.parentName} implements OMEModel
+{% end if %}\
 {% end %}\
 {% end %}\
 {
@@ -119,6 +129,15 @@ public class ${klass.name} extends ${klass.parentName}
 {% end %}\
 {% end %}\
 {% end %}\
+{% if klass.name == "OME" %}\
+
+  // OMEModel fields
+  private Map<String, OMEModelObject> modelObjects =
+    new HashMap<String, OMEModelObject>();
+
+  private Map<OMEModelObject, List<Reference>> references =
+    new HashMap<OMEModelObject, List<Reference>>();
+{% end if %}\
 
   // -- Constructors --
 
@@ -130,6 +149,7 @@ public class ${klass.name} extends ${klass.parentName}
 {% end %}\
   }
 
+{% if klass.name == "OME" %}\
   /**
    * Constructs ${klass.name} recursively from an XML DOM tree.
    * @param element Root of the XML DOM tree to construct a model object
@@ -139,6 +159,28 @@ public class ${klass.name} extends ${klass.parentName}
    * @throws EnumerationException If there is an error instantiating an
    * enumeration during model object creation.
    */
+  public ${klass.name}(Element element)
+    throws EnumerationException
+  {
+    update(element);
+  }
+
+{% end if%}\
+  /**
+   * Constructs ${klass.name} recursively from an XML DOM tree.
+   * @param element Root of the XML DOM tree to construct a model object
+   * graph from.
+   * @param model Handler for the OME model which keeps track of instances
+   * and references seen during object population.
+   * @throws EnumerationException If there is an error instantiating an
+   * enumeration during model object creation.
+{% if klass.name == "OME" %}\
+   * @deprecated Use {@link #${klass.name}(Element)}.
+{% end if%}\
+   */
+{% if klass.name == "OME" %}\
+  @Deprecated
+{% end if%}\
   public ${klass.name}(Element element, OMEModel model)
     throws EnumerationException
   {
@@ -175,8 +217,114 @@ public class ${klass.name} extends ${klass.parentName}
 {% end %}\
   }
 
-  // -- Custom content from ${klass.name} specific template --
+{% if klass.name == "OME" %}\
+  /* (non-Javadoc)
+   * @see ome.xml.model.OMEModel#removeModelObject(java.lang.String)
+   */
+  @Override
+  public OMEModelObject removeModelObject(String id) {
+    return modelObjects.remove(id);
+  }
 
+  /* (non-Javadoc)
+   * @see ome.xml.model.OMEModel#addModelObject(java.lang.String, ome.xml.model.OMEModelObject)
+   */
+  @Override
+  public OMEModelObject addModelObject(String id, OMEModelObject object) {
+    if (Reference.class.isAssignableFrom(object.getClass())) {
+      return object;
+    }
+    return modelObjects.put(id, object);
+  }
+
+  /* (non-Javadoc)
+   * @see ome.xml.model.OMEModel#getModelObject(java.lang.String)
+   */
+  @Override
+  public OMEModelObject getModelObject(String id) {
+    return modelObjects.get(id);
+  }
+
+  /* (non-Javadoc)
+   * @see ome.xml.model.OMEModel#getModelObjects()
+   */
+  @Override
+  public Map<String, OMEModelObject> getModelObjects() {
+    return modelObjects;
+  }
+
+  /* (non-Javadoc)
+   * @see ome.xml.model.OMEModel#addReference(java.lang.String, ome.xml.model.Reference)
+   */
+  @Override
+  public boolean addReference(OMEModelObject a, Reference b) {
+    List<Reference> bList = references.get(a);
+    if (bList == null) {
+      bList = new ArrayList<Reference>();
+      references.put(a, bList);
+    }
+    return bList.add(b);
+  }
+
+  /* (non-Javadoc)
+   * @see ome.xml.model.OMEModel#getReferences()
+   */
+  @Override
+  public Map<OMEModelObject, List<Reference>> getReferences() {
+    return references;
+  }
+
+  /* (non-Javadoc)
+   * @see ome.xml.model.OMEModel#resolveReferences()
+   */
+  @Override
+  public int resolveReferences() {
+    int unhandledReferences = 0;
+    for (Entry<OMEModelObject, List<Reference>> entry : references.entrySet())
+    {
+      OMEModelObject a = entry.getKey();
+      if (a == null) {
+        List<Reference> references = entry.getValue();
+        if (references == null) {
+          LOGGER.error("Null reference to null object, continuing.");
+          continue;
+        }
+        LOGGER.error("Null reference to {} objects, continuing.",
+                     references.size());
+        unhandledReferences += references.size();
+        continue;
+      }
+      for (Reference reference : entry.getValue()) {
+        String referenceID = reference.getID();
+        OMEModelObject b = getModelObject(referenceID);
+        if (b == null) {
+          LOGGER.warn("{} reference to {} missing from object hierarchy.",
+                      a, referenceID);
+          unhandledReferences++;
+          continue;
+        }
+        a.link(reference, b);
+      }
+    }
+    return unhandledReferences;
+  }
+
+  /**
+   * Updates ${klass.name} recursively from an XML DOM tree. <b>NOTE:</b> No
+   * properties are removed, only added or updated.
+   * @param element Root of the XML DOM tree to construct a model object
+   * graph from.
+   * @throws EnumerationException If there is an error instantiating an
+   * enumeration during model object creation.
+   */
+  public void update(Element element)
+    throws EnumerationException
+  {
+    update(element, this);
+  }
+{% end if %}\
+
+  // -- Custom content from ${klass.name} specific template --
 ${customContent}\
 
   // -- OMEModelObject API methods --

--- a/xsd-fu/xsd-fu
+++ b/xsd-fu/xsd-fu
@@ -756,6 +756,8 @@ def validateMetadataConverter():
     for match in combinedDiff:
         if match == 'setRoot' or match == 'getRoot':
             continue
+        if match == 'setModel' or match == 'getModel':
+            continue
         if match in retrieveSet:
             print("MetadataValidation: %s is present in MetadataRetrieve but missing from %s" % (match, opts.lang.getConverterName()), file=sys.stderr)
         else:


### PR DESCRIPTION
This is part 1 of the proposed refactoring in https://docs.google.com/document/d/1bzczgG2QyujCsCvR2kSAGl5hj-NJuIikgFAC3fDkqvs/edit# and https://trello.com/c/hnpxmvhe/52-extended-annotation-support-pt-i

- OME implements OMEModel
- OMEModelImpl (Java) and detail::OMEModel (C++) are no longer used and are deprecated; OME implements OMEModel directly, and OMEModelObject indirectly
- MetadataRoot replaced by MetadataModel
- OMEXMLMetadataRoot replaced by OMEXMLMetadataModel

Testing:

- Check generated source changes
- Check builds remain green
- Check bioformats build with and without https://github.com/openmicroscopy/bioformats/pull/2712
- Check ome-files-cpp build with and without https://github.com/rleigh-codelibre/ome-files-cpp/tree/ome-model-base (this is PR https://github.com/ome/ome-files-cpp/pull/40)

The latter two points check that there is no API break when building without the branch, and that the new API additions work when building with the branch,