### PR TITLE
build: Change cmake project name to ome-model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/cmake/BioFormatsCommon.cmake")
 include(cmake/Version.cmake)
 ome_project_version("OME XML C++" "${CMAKE_CURRENT_SOURCE_DIR}")
 
-project(ome-xml
+project(ome-model
         VERSION "${OME_VERSION_MAJOR}.${OME_VERSION_MINOR}.${OME_VERSION_PATCH}"
         LANGUAGES CXX)
 

--- a/docs/doxygen/CMakeLists.txt
+++ b/docs/doxygen/CMakeLists.txt
@@ -55,6 +55,6 @@ if(BUILD_DOXYGEN)
   add_custom_target(doc DEPENDS doc-api)
 
   install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/ome-xml/"
-          DESTINATION "${CMAKE_INSTALL_DOCDIR}/api"
+          DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/doc/ome-xml/api"
           COMPONENT "development")
 endif(BUILD_DOXYGEN)


### PR DESCRIPTION
This is to match the maven project name and give the sphinx manual
the correct name.

See https://github.com/ome/ome-cmake-superbuild/pull/109 for testing instructions.