### PR TITLE
Fix intermittent hyperlinks

### DIFF
--- a/docs/sphinx/developers/id-and-lsid.rst
+++ b/docs/sphinx/developers/id-and-lsid.rst
@@ -14,12 +14,7 @@ concept. It was designed to allow the naming or identifying of data and
 associated metadata that can be stored in multiple, distributed data
 stores.
 
-For further information see
-`http://en.wikipedia.org/wiki/LSID <http://en.wikipedia.org/wiki/LSID>`_.
-
-The full specification document is available at
-`http://www.omg.org/cgi-bin/doc?dtc/04-10-08 <http://www.omg.org/cgi-bin/doc?dtc/04-10-08>`_
-[pdf].
+For further information see https://en.wikipedia.org/wiki/LSID.
 
 The format of a valid LSID is:
 

--- a/docs/sphinx/developers/ome-units.rst
+++ b/docs/sphinx/developers/ome-units.rst
@@ -169,7 +169,7 @@ And from this are derived the following units:
 -  **°R** - degree Rankine
 
 The degree sign and word was dropped from kelvin in 1968. 
-http://en.wikipedia.org/wiki/Kelvin
+https://en.wikipedia.org/wiki/Kelvin
 
 All temperature units are freely convertible.
 

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -303,7 +303,7 @@ entire multidimensional image series in one master OME-TIFF file.
 
 Alternatively, a collection of multiple OME-TIFF files may be used. Using
 the TiffData attributes outlined above together with
-`UUID <http://en.wikipedia.org/wiki/Universally_Unique_Identifier>`_
+`UUID <https://en.wikipedia.org/wiki/Universally_Unique_Identifier>`_
 elements and attributes, the OME-XML metadata block can unambiguously
 define which dimensional positions correspond to which IFDs from which
 files. Each OME-TIFF need not contain the same number of images.

--- a/docs/sphinx/ome-tiff/tools.rst
+++ b/docs/sphinx/ome-tiff/tools.rst
@@ -48,7 +48,7 @@ the ``xmllint`` program:
     $ xmllint --format file.xml
 
 Here is a Perl script that uses
-`XML::LibXML <https://www.xml.com/pub/a/2001/11/14/xml-libxml.html>`_ to
+`XML::LibXML <http://search.cpan.org/dist/XML-LibXML/LibXML.pod>`_ to
 "pretty print" an XML document with appropriate whitespace:
 
 ::

--- a/docs/sphinx/ome-tiff/tools.rst
+++ b/docs/sphinx/ome-tiff/tools.rst
@@ -48,7 +48,7 @@ the ``xmllint`` program:
     $ xmllint --format file.xml
 
 Here is a Perl script that uses
-`XML::LibXML <http://www.xml.com/pub/a/2001/11/14/xml-libxml.html>`_ to
+`XML::LibXML <https://www.xml.com/pub/a/2001/11/14/xml-libxml.html>`_ to
 "pretty print" an XML document with appropriate whitespace:
 
 ::

--- a/docs/sphinx/ome-xml/index.rst
+++ b/docs/sphinx/ome-xml/index.rst
@@ -10,11 +10,11 @@ in many cases, never recorded at all).
 
 The term "OME-XML" applies to two interrelated but distinct things:
 
-#. A `data model <http://en.wikipedia.org/wiki/Data_model>`_ for
+#. A `data model <https://en.wikipedia.org/wiki/Data_model>`_ for
    representing microscopy metadata, for use with microscopy file
-   formats, expressed as an `XML <http://en.wikipedia.org/wiki/XML>`_
+   formats, expressed as an `XML <https://en.wikipedia.org/wiki/XML>`_
    schema.
-#. A `file format <http://en.wikipedia.org/wiki/File_format>`_ for
+#. A `file format <https://en.wikipedia.org/wiki/File_format>`_ for
    storing microscopy information (both pixels and metadata) using the
    OME-XML data model.
 


### PR DESCRIPTION
The model docs jobs have been failing the linkcheck step regularly in the last few days. This PR tries to mitigate the issue by:

- removing the link to the full specification documentation for LSID. The PDF is now restricted to members only and not public
- using HTTPS instead of HTTP in a few places