### PR TITLE
Basic C++11 features

### DIFF
--- a/ome-xml/src/main/cpp/ome/xml/OMETransformResolver.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/OMETransformResolver.cpp
@@ -281,7 +281,7 @@ namespace ome
     };
 
     OMETransformResolver::OMETransformResolver():
-      impl(ome::compat::make_shared<OMETransformResolverImpl>())
+      impl(std::make_shared<OMETransformResolverImpl>())
     {
       // Hack to force module registration when static linking.
       register_module_paths();
@@ -290,7 +290,7 @@ namespace ome
     }
 
     OMETransformResolver::OMETransformResolver(const boost::filesystem::path& transformdir):
-      impl(ome::compat::make_shared<OMETransformResolverImpl>())
+      impl(std::make_shared<OMETransformResolverImpl>())
     {
       impl->fill_graph(transformdir);
     }

--- a/ome-xml/src/main/cpp/ome/xml/OMETransformResolver.h
+++ b/ome-xml/src/main/cpp/ome/xml/OMETransformResolver.h
@@ -39,6 +39,7 @@
 #ifndef OME_XML_MODEL_OMETRANSFORMRESOLVER_H
 #define OME_XML_MODEL_OMETRANSFORMRESOLVER_H
 
+#include <cstdint>
 #include <memory>
 #include <ostream>
 #include <set>
@@ -46,8 +47,6 @@
 #include <utility>
 
 #include <boost/filesystem.hpp>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/ome-xml/src/main/cpp/ome/xml/OMETransformResolver.h
+++ b/ome-xml/src/main/cpp/ome/xml/OMETransformResolver.h
@@ -39,6 +39,7 @@
 #ifndef OME_XML_MODEL_OMETRANSFORMRESOLVER_H
 #define OME_XML_MODEL_OMETRANSFORMRESOLVER_H
 
+#include <memory>
 #include <ostream>
 #include <set>
 #include <string>
@@ -47,7 +48,6 @@
 #include <boost/filesystem.hpp>
 
 #include <ome/compat/cstdint.h>
-#include <ome/compat/memory.h>
 
 namespace ome
 {
@@ -253,7 +253,7 @@ namespace ome
 
     private:
       /// Private implementation details.
-      ome::compat::shared_ptr<OMETransformResolverImpl> impl;
+      std::shared_ptr<OMETransformResolverImpl> impl;
     };
 
     /**

--- a/ome-xml/src/main/cpp/ome/xml/meta/BaseMetadata.h
+++ b/ome-xml/src/main/cpp/ome/xml/meta/BaseMetadata.h
@@ -39,9 +39,8 @@
 #define OME_XML_META_BASEMETADATA_H
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/ome-xml/src/main/cpp/ome/xml/meta/MetadataModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/meta/MetadataModel.h
@@ -38,7 +38,7 @@
 #ifndef OME_XML_META_METADATAMODEL_H
 #define OME_XML_META_METADATAMODEL_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 namespace ome
 {

--- a/ome-xml/src/main/cpp/ome/xml/meta/MetadataRoot.h
+++ b/ome-xml/src/main/cpp/ome/xml/meta/MetadataRoot.h
@@ -38,7 +38,7 @@
 #ifndef OME_XML_META_METADATAROOT_H
 #define OME_XML_META_METADATAROOT_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 #include <ome/xml/meta/MetadataModel.h>
 

--- a/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataModel.h
@@ -38,7 +38,7 @@
 #ifndef OME_XML_OME_OMEXMLMETADATAMODEL_H
 #define OME_XML_OME_OMEXMLMETADATAMODEL_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 #include <ome/xml/meta/MetadataModel.h>
 #include <ome/xml/model/OME.h>

--- a/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataRoot.h
+++ b/ome-xml/src/main/cpp/ome/xml/meta/OMEXMLMetadataRoot.h
@@ -38,7 +38,7 @@
 #ifndef OME_XML_OME_OMEXMLMETADATAROOT_H
 #define OME_XML_OME_OMEXMLMETADATAROOT_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 #include <ome/xml/meta/OMEXMLMetadataModel.h>
 #include <ome/xml/meta/MetadataRoot.h>

--- a/ome-xml/src/main/cpp/ome/xml/model/OMEModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OMEModel.h
@@ -63,9 +63,9 @@ namespace ome
       {
       public:
         /// A list of Reference objects.
-        typedef std::vector<std::shared_ptr<Reference> > reference_list_type;
+        typedef std::vector<std::shared_ptr<Reference>> reference_list_type;
         /// A map of string model object identifiers to model objects.
-        typedef std::map<std::string, std::shared_ptr<OMEModelObject> > object_map_type;
+        typedef std::map<std::string, std::shared_ptr<OMEModelObject>> object_map_type;
         /// A map of model objects to list of Reference objects.
         typedef std::map<std::shared_ptr<OMEModelObject>, reference_list_type> reference_map_type;
         /// Size type for reference map.

--- a/ome-xml/src/main/cpp/ome/xml/model/OMEModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OMEModel.h
@@ -40,10 +40,9 @@
 #define OME_XML_MODEL_OMEMODEL_H
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
-
-#include <ome/compat/memory.h>
 
 #include <ome/xml/model/OMEModelObject.h>
 
@@ -64,11 +63,11 @@ namespace ome
       {
       public:
         /// A list of Reference objects.
-        typedef std::vector<ome::compat::shared_ptr<Reference> > reference_list_type;
+        typedef std::vector<std::shared_ptr<Reference> > reference_list_type;
         /// A map of string model object identifiers to model objects.
-        typedef std::map<std::string, ome::compat::shared_ptr<OMEModelObject> > object_map_type;
+        typedef std::map<std::string, std::shared_ptr<OMEModelObject> > object_map_type;
         /// A map of model objects to list of Reference objects.
-        typedef std::map<ome::compat::shared_ptr<OMEModelObject>, reference_list_type> reference_map_type;
+        typedef std::map<std::shared_ptr<OMEModelObject>, reference_list_type> reference_map_type;
         /// Size type for reference map.
         typedef reference_map_type::size_type size_type;
 
@@ -105,9 +104,9 @@ namespace ome
          * Should it be possible to insert null objects?
          */
         virtual
-        ome::compat::shared_ptr<OMEModelObject>
-        addModelObject (const std::string&                       id,
-                        ome::compat::shared_ptr<OMEModelObject>& object) = 0;
+        std::shared_ptr<OMEModelObject>
+        addModelObject (const std::string&               id,
+                        std::shared_ptr<OMEModelObject>& object) = 0;
 
         /**
          * Remove a model object from the model.
@@ -118,7 +117,7 @@ namespace ome
          * not exist.
          */
         virtual
-        ome::compat::shared_ptr<OMEModelObject>
+        std::shared_ptr<OMEModelObject>
         removeModelObject (const std::string& id) = 0;
 
         /**
@@ -132,7 +131,7 @@ namespace ome
          * @todo: Would a const reference be better for the return?
          */
         virtual
-        ome::compat::shared_ptr<OMEModelObject>
+        std::shared_ptr<OMEModelObject>
         getModelObject (const std::string& id) const = 0;
 
         /**
@@ -161,8 +160,8 @@ namespace ome
          */
         virtual
         bool
-        addReference (ome::compat::shared_ptr<OMEModelObject>& a,
-                      ome::compat::shared_ptr<Reference>&      b) = 0;
+        addReference (std::shared_ptr<OMEModelObject>& a,
+                      std::shared_ptr<Reference>&      b) = 0;
 
         /**
          * Retrieve all references from the model.

--- a/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
@@ -88,7 +88,7 @@ namespace ome
             Ptr<T>, // value type
             boost::multi_index::indexed_by<
               boost::multi_index::random_access<>, // insertion order
-              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T> >, std::owner_less<Ptr<T> > > // sorted order
+              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T>>, std::owner_less<Ptr<T>>> // sorted order
               >
             > type;
         };

--- a/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OMEModelObject.h
@@ -41,6 +41,7 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -49,8 +50,6 @@
 #include <boost/multi_index/indexed_by.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/random_access_index.hpp>
-
-#include <ome/compat/memory.h>
 
 #include <ome/common/xml/dom/Element.h>
 #include <ome/common/xml/dom/Document.h>
@@ -74,7 +73,7 @@ namespace ome
        * could just be Object, since it's really an
        * ome::xml::model::Object.
        */
-      class OMEModelObject : public ome::compat::enable_shared_from_this<OMEModelObject>
+      class OMEModelObject : public std::enable_shared_from_this<OMEModelObject>
       {
       protected:
         /**
@@ -89,7 +88,7 @@ namespace ome
             Ptr<T>, // value type
             boost::multi_index::indexed_by<
               boost::multi_index::random_access<>, // insertion order
-              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T> >, ome::compat::owner_less<Ptr<T> > > // sorted order
+              boost::multi_index::ordered_unique<boost::multi_index::identity<Ptr<T> >, std::owner_less<Ptr<T> > > // sorted order
               >
             > type;
         };
@@ -201,8 +200,8 @@ namespace ome
          * to all generated model objects implementing this interface.
          */
         virtual bool
-        link (ome::compat::shared_ptr<Reference>&      reference,
-              ome::compat::shared_ptr<OMEModelObject>& object) = 0;
+        link (std::shared_ptr<Reference>&      reference,
+              std::shared_ptr<OMEModelObject>& object) = 0;
 
         /**
          * Get the XML namespace for this model object.

--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -165,8 +165,8 @@ namespace ome
     }
 
       bool
-      OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                          reference,
-                                        std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+      OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                         reference,
+                                        std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
       {
         if (XMLAnnotation::link(reference, object))
           {

--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.cpp
@@ -165,8 +165,8 @@ namespace ome
     }
 
       bool
-      OriginalMetadataAnnotation::link (ome::compat::shared_ptr<Reference>&                          reference,
-                                        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+      OriginalMetadataAnnotation::link (std::shared_ptr<Reference>&                          reference,
+                                        std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
       {
         if (XMLAnnotation::link(reference, object))
           {

--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
@@ -39,10 +39,9 @@
 #ifndef OME_XML_MODEL_ORIGINALMETADATAANNOTATION_H
 #define OME_XML_MODEL_ORIGINALMETADATAANNOTATION_H
 
+#include <memory>
 #include <string>
 #include <utility>
-
-#include <ome/compat/memory.h>
 
 #include <ome/common/xml/dom/Document.h>
 #include <ome/common/xml/dom/Element.h>
@@ -124,8 +123,8 @@ namespace ome
       public:
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
-        link (ome::compat::shared_ptr<Reference>&                          reference,
-              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+        link (std::shared_ptr<Reference>&                          reference,
+              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
         /**
          * Get the key-value pair mappings.

--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
@@ -123,8 +123,8 @@ namespace ome
       public:
         /// @copydoc ome::xml::model::OMEModelObject::link
         bool
-        link (std::shared_ptr<Reference>&                          reference,
-              std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+        link (std::shared_ptr<Reference>&                         reference,
+              std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
         /**
          * Get the key-value pair mappings.

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.cpp
@@ -149,15 +149,13 @@ namespace ome
         {
           size_type unhandledReferences = 0;
 
-          for (reference_map_type::iterator i = references.begin();
-               i != references.end();
-               ++i)
+          for (auto& i : references)
             {
-              const std::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
+              const std::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i.first);
 
               if (!a)
                 {
-                  const reference_list_type& references(i->second);
+                  const reference_list_type& references(i.second);
 
                   if (references.empty())
                     {
@@ -174,13 +172,11 @@ namespace ome
                 }
               else
                 {
-                  reference_list_type& references(i->second);
+                  reference_list_type& references(i.second);
 
-                  for (reference_list_type::iterator ref = references.begin();
-                       ref != references.end();
-                       ++ref)
+                  for (auto& ref : references)
                     {
-                      if (!(*ref))
+                      if (!ref)
                         {
                           BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
                             << typeid(*a).name() << "@" << a
@@ -188,7 +184,7 @@ namespace ome
                         }
                       else
                         {
-                          const std::string& referenceID = (*ref)->getID();
+                          const std::string& referenceID = ref->getID();
 
                           std::shared_ptr<::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                           if (!b)
@@ -202,7 +198,7 @@ namespace ome
                           else
                             {
                               std::shared_ptr<::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast<::ome::xml::model::OMEModelObject>(a));
-                              aw->link(*ref, b);
+                              aw->link(ref, b);
                             }
                         }
                     }

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.cpp
@@ -72,9 +72,9 @@ namespace ome
         {
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
-        OMEModel::addModelObject(const std::string&                                   id,
-                                 std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
+        OMEModel::addModelObject(const std::string&                                  id,
+                                 std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
         {
           // Don't store references.
           if (std::dynamic_pointer_cast<Reference>(object))
@@ -89,10 +89,10 @@ namespace ome
           return object;
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
         OMEModel::removeModelObject(const std::string& id)
         {
-          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          std::shared_ptr<::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -104,10 +104,10 @@ namespace ome
           return ret;
         }
 
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
         OMEModel::getModelObject(const std::string& id) const
         {
-          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          std::shared_ptr<::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::const_iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -123,8 +123,8 @@ namespace ome
         }
 
         bool
-        OMEModel::addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                                std::shared_ptr<Reference>&                          b)
+        OMEModel::addReference (std::shared_ptr<::ome::xml::model::OMEModelObject>& a,
+                                std::shared_ptr<Reference>&                         b)
         {
           reference_map_type::iterator i = references.find(a);
 
@@ -190,7 +190,7 @@ namespace ome
                         {
                           const std::string& referenceID = (*ref)->getID();
 
-                          std::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
+                          std::shared_ptr<::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                           if (!b)
                             {
                               BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
@@ -201,7 +201,7 @@ namespace ome
                             }
                           else
                             {
-                              std::shared_ptr< ::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
+                              std::shared_ptr<::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast<::ome::xml::model::OMEModelObject>(a));
                               aw->link(*ref, b);
                             }
                         }

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.cpp
@@ -37,9 +37,8 @@
  */
 
 #include <map>
+#include <memory>
 #include <string>
-
-#include <ome/compat/memory.h>
 
 #include <ome/xml/model/detail/OMEModel.h>
 #include <ome/xml/model/Reference.h>
@@ -73,12 +72,12 @@ namespace ome
         {
         }
 
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::addModelObject(const std::string&                                   id,
-                                 ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+                                 std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
         {
           // Don't store references.
-          if (ome::compat::dynamic_pointer_cast<Reference>(object))
+          if (std::dynamic_pointer_cast<Reference>(object))
             return object;
 
           object_map_type::iterator i = modelObjects.find(id);
@@ -90,10 +89,10 @@ namespace ome
           return object;
         }
 
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::removeModelObject(const std::string& id)
         {
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -105,10 +104,10 @@ namespace ome
           return ret;
         }
 
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         OMEModel::getModelObject(const std::string& id) const
         {
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+          std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
 
           object_map_type::const_iterator i = modelObjects.find(id);
           if (i != modelObjects.end())
@@ -124,8 +123,8 @@ namespace ome
         }
 
         bool
-        OMEModel::addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                                    ome::compat::shared_ptr<Reference>&                      b)
+        OMEModel::addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                                std::shared_ptr<Reference>&                          b)
         {
           reference_map_type::iterator i = references.find(a);
 
@@ -154,7 +153,7 @@ namespace ome
                i != references.end();
                ++i)
             {
-              const ome::compat::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
+              const std::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
 
               if (!a)
                 {
@@ -191,7 +190,7 @@ namespace ome
                         {
                           const std::string& referenceID = (*ref)->getID();
 
-                          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
+                          std::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                           if (!b)
                             {
                               BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
@@ -202,7 +201,7 @@ namespace ome
                             }
                           else
                             {
-                              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> aw(ome::compat::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
+                              std::shared_ptr< ::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
                               aw->link(*ref, b);
                             }
                         }

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.h
@@ -80,16 +80,16 @@ namespace ome
           ~OMEModel ();
 
           /// @copydoc ome::xml::model::OMEModel::addModelObject
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
-          addModelObject (const std::string&                                           id,
-                          std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+          std::shared_ptr<::ome::xml::model::OMEModelObject>
+          addModelObject (const std::string&                                  id,
+                          std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
           // Documented in parent.
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr<::ome::xml::model::OMEModelObject>
           removeModelObject (const std::string& id);
 
           // Documented in parent.
-          std::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr<::ome::xml::model::OMEModelObject>
           getModelObject (const std::string& id) const;
 
           // Documented in parent.
@@ -98,8 +98,8 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModel::addReference
           bool
-          addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                        std::shared_ptr<Reference>&                          b);
+          addReference (std::shared_ptr<::ome::xml::model::OMEModelObject>& a,
+                        std::shared_ptr<Reference>&                         b);
 
           // Documented in parent.
           const reference_map_type&

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModel.h
@@ -80,16 +80,16 @@ namespace ome
           ~OMEModel ();
 
           /// @copydoc ome::xml::model::OMEModel::addModelObject
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr< ::ome::xml::model::OMEModelObject>
           addModelObject (const std::string&                                           id,
-                          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+                          std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
           // Documented in parent.
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr< ::ome::xml::model::OMEModelObject>
           removeModelObject (const std::string& id);
 
           // Documented in parent.
-          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+          std::shared_ptr< ::ome::xml::model::OMEModelObject>
           getModelObject (const std::string& id) const;
 
           // Documented in parent.
@@ -98,8 +98,8 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModel::addReference
           bool
-          addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                        ome::compat::shared_ptr<Reference>&                          b);
+          addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                        std::shared_ptr<Reference>&                          b);
 
           // Documented in parent.
           const reference_map_type&

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
@@ -105,8 +105,8 @@ namespace ome
         }
 
         bool
-        OMEModelObject::link (std::shared_ptr<Reference>&                          /* reference */,
-                              std::shared_ptr< ::ome::xml::model::OMEModelObject>& /* object */)
+        OMEModelObject::link (std::shared_ptr<Reference>&                         /* reference */,
+                              std::shared_ptr<::ome::xml::model::OMEModelObject>& /* object */)
         {
           return false;
         }

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
@@ -105,8 +105,8 @@ namespace ome
         }
 
         bool
-        OMEModelObject::link (ome::compat::shared_ptr<Reference>&                          /* reference */,
-                              ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& /* object */)
+        OMEModelObject::link (std::shared_ptr<Reference>&                          /* reference */,
+                              std::shared_ptr< ::ome::xml::model::OMEModelObject>& /* object */)
         {
           return false;
         }

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
@@ -120,9 +120,7 @@ namespace ome
 
           common::xml::dom::NodeList children(parent->getChildNodes());
           // TODO: correct type for iteration.
-          for (common::xml::dom::NodeList::iterator pos = children.begin();
-               pos != children.end();
-               ++pos)
+          for (auto& pos : children)
             {
               try
                 {
@@ -130,9 +128,9 @@ namespace ome
                   // class would throw; but this avoids the need to
                   // throw and catch many std::logic_error exceptions
                   // during document processing.
-                  if (dynamic_cast<const xercesc::DOMElement *>(pos->get()))
+                  if (dynamic_cast<const xercesc::DOMElement *>(pos.get()))
                     {
-                      common::xml::dom::Element child(pos->get(), false);
+                      common::xml::dom::Element child(pos.get(), false);
                       if (child && name == stripNamespacePrefix(common::xml::String(child->getNodeName())))
                         {
                           ret.push_back(child);

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.h
@@ -118,8 +118,8 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModelObject::link
           virtual bool
-          link (std::shared_ptr<Reference>&                          reference,
-                std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+          link (std::shared_ptr<Reference>&                         reference,
+                std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 
           /**
            * Retrieve all the children of an element that have a given

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.h
@@ -118,8 +118,8 @@ namespace ome
 
           /// @copydoc ome::xml::model::OMEModelObject::link
           virtual bool
-          link (ome::compat::shared_ptr<Reference>&                          reference,
-                ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+          link (std::shared_ptr<Reference>&                          reference,
+                std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 
           /**
            * Retrieve all the children of an element that have a given
@@ -159,7 +159,7 @@ namespace ome
           {
           private:
             /// The element to compare other elements with.
-            const ome::compat::shared_ptr<const T>& cmp;
+            const std::shared_ptr<const T>& cmp;
 
           public:
             /**
@@ -167,7 +167,7 @@ namespace ome
              *
              * @param cmp the element to compare other elements with.
              */
-            compare_element(const ome::compat::shared_ptr<const T>& cmp):
+            compare_element(const std::shared_ptr<const T>& cmp):
               cmp(cmp)
             {}
 
@@ -179,7 +179,7 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const ome::compat::shared_ptr<T>& element)
+            operator () (const std::shared_ptr<T>& element)
             {
               return cmp && element && cmp == element;
             }
@@ -191,7 +191,7 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const ome::compat::shared_ptr<const T>& element)
+            operator () (const std::shared_ptr<const T>& element)
             {
               return cmp && element && cmp == element;
             }
@@ -203,9 +203,9 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const ome::compat::weak_ptr<T>& element)
+            operator () (const std::weak_ptr<T>& element)
             {
-              ome::compat::shared_ptr<const T> shared_element(element);
+              std::shared_ptr<const T> shared_element(element);
               return cmp && shared_element && cmp == shared_element;
             }
 
@@ -216,9 +216,9 @@ namespace ome
              * @returns @c true if the elements are the same, otherwise @c false.
              */
             bool
-            operator () (const ome::compat::weak_ptr<const T>& element)
+            operator () (const std::weak_ptr<const T>& element)
             {
-              ome::compat::shared_ptr<const T> shared_element(element);
+              std::shared_ptr<const T> shared_element(element);
               return cmp && shared_element && cmp == shared_element;
             }
           };
@@ -236,7 +236,7 @@ namespace ome
           template<class C, typename T>
           bool
           contains(const C&                  container,
-                   const ome::compat::shared_ptr<T>& element)
+                   const std::shared_ptr<T>& element)
           {
             return (std::find_if(container.begin(),
                                  container.end(),

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/Parse.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/Parse.h
@@ -73,7 +73,7 @@ namespace ome
 
         /// Type trait for shared_ptr.
         template <class T>
-        struct is_shared_ptr<std::shared_ptr<T> >
+        struct is_shared_ptr<std::shared_ptr<T>>
           : boost::true_type {};
 
         /**

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/Parse.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/Parse.h
@@ -39,10 +39,12 @@
 #ifndef OME_XML_MODEL_DETAIL_PARSE_H
 #define OME_XML_MODEL_DETAIL_PARSE_H
 
+#include <sstream>
+#include <type_traits>
+
 #include <ome/xml/model/OMEModelObject.h>
 
 #include <boost/mpl/bool.hpp>
-#include <boost/type_traits.hpp>
 
 namespace ome
 {
@@ -163,9 +165,9 @@ namespace ome
          * @throws a ModelException on failure.
          */
         template<typename T>
-        inline typename boost::disable_if_c<
-          is_shared_ptr<T>::value,
-          typename boost::remove_const<typename boost::remove_reference<T>::type>::type
+        inline typename std::enable_if<
+          !is_shared_ptr<T>::value,
+          typename std::remove_const<typename boost::remove_reference<T>::type>::type
           >::type
         parse_value(const std::string& text,
                     const std::string& klass,
@@ -188,9 +190,9 @@ namespace ome
          * @throws a ModelException on failure.
          */
         template<typename T>
-        inline typename boost::enable_if_c<
+        inline typename std::enable_if<
           is_shared_ptr<T>::value,
-          typename boost::remove_const<typename boost::remove_reference<T>::type>::type
+          typename std::remove_const<typename boost::remove_reference<T>::type>::type
           >::type
         parse_value(const std::string& text,
                     const std::string& klass,
@@ -243,9 +245,9 @@ namespace ome
          * @throws a ModelException on failure.
          */
         template<typename T>
-        inline typename boost::disable_if_c<
-          is_shared_ptr<T>::value,
-          typename boost::remove_const<typename boost::remove_reference<T>::type>::type
+        inline typename std::enable_if<
+          !is_shared_ptr<T>::value,
+          typename std::remove_const<typename boost::remove_reference<T>::type>::type
           >::type
         parse_quantity(const std::string& text,
                        const std::string& unit,
@@ -272,9 +274,9 @@ namespace ome
          * @throws a ModelException on failure.
          */
         template<typename T>
-        inline typename boost::enable_if_c<
+        inline typename std::enable_if<
           is_shared_ptr<T>::value,
-          typename boost::remove_const<typename boost::remove_reference<T>::type>::type
+          typename std::remove_const<typename boost::remove_reference<T>::type>::type
           >::type
         parse_quantity(const std::string& text,
                        const std::string& unit,

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/Parse.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/Parse.h
@@ -73,7 +73,7 @@ namespace ome
 
         /// Type trait for shared_ptr.
         template <class T>
-        struct is_shared_ptr<ome::compat::shared_ptr<T> >
+        struct is_shared_ptr<std::shared_ptr<T> >
           : boost::true_type {};
 
         /**
@@ -198,7 +198,7 @@ namespace ome
         {
           typedef typename boost::remove_const<typename boost::remove_reference<T>::type>::type raw_type;
 
-          raw_type attr(ome::compat::make_shared<typename raw_type::element_type>());
+          raw_type attr(std::make_shared<typename raw_type::element_type>());
           parse_value(text, *attr, klass, property);
           return attr;
         }
@@ -286,7 +286,7 @@ namespace ome
           typename raw_type::element_type::value_type v;
           parse_value(text, v, klass, property);
           typename raw_type::element_type::unit_type u(unit);
-          raw_type attr(ome::compat::make_shared<typename raw_type::element_type>(v, u));
+          raw_type attr(std::make_shared<typename raw_type::element_type>(v, u));
           return attr;
         }
 

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/Color.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/Color.h
@@ -39,10 +39,9 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_COLOR_H
 #define OME_XML_MODEL_PRIMITIVES_COLOR_H
 
+#include <cstdint>
 #include <limits>
 #include <string>
-
-#include <ome/compat/cstdint.h>
 
 #ifdef _MSC_VER
 #pragma push_macro("min")

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/ConstrainedNumeric.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/ConstrainedNumeric.h
@@ -129,7 +129,7 @@ namespace ome
                                            boost::multipliable2<ConstrainedNumeric<N, C, E>, N,
                                            boost::multipliable<ConstrainedNumeric<N, C, E>,
                                            boost::incrementable<ConstrainedNumeric<N, C, E>,
-                                           boost::decrementable<ConstrainedNumeric<N, C, E> > > > > > > > > > > > > > >
+                                           boost::decrementable<ConstrainedNumeric<N, C, E>>>>>>>>>>>>>>>
         {
         public:
           /// The type to constrain.

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/ConstrainedNumeric.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/ConstrainedNumeric.h
@@ -39,14 +39,13 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_CONSTRAINEDNUMERIC_H
 #define OME_XML_MODEL_PRIMITIVES_CONSTRAINEDNUMERIC_H
 
+#include <cstdint>
 #include <limits>
 #include <string>
 #include <sstream>
 
 #include <boost/format.hpp>
 #include <boost/operators.hpp>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeFloat.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeFloat.h
@@ -54,7 +54,7 @@ namespace ome
         /**
          * Double-precision floating point value greater than or equal to zero.
          */
-        typedef ConstrainedNumeric<double, NonNegativeFloatConstraint<double> > NonNegativeFloat;
+        typedef ConstrainedNumeric<double, NonNegativeFloatConstraint<double>> NonNegativeFloat;
 
       }
     }

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeInteger.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeInteger.h
@@ -56,7 +56,7 @@ namespace ome
         /**
          * Integer (signed 32-bit) value greater than or equal to zero.
          */
-        typedef ConstrainedNumeric<int32_t, NonNegativeIntegerConstraint<int32_t> > NonNegativeInteger;
+        typedef ConstrainedNumeric<int32_t, NonNegativeIntegerConstraint<int32_t>> NonNegativeInteger;
 
       }
     }

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeInteger.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeInteger.h
@@ -39,7 +39,7 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_NONNEGATIVEINTEGER_H
 #define OME_XML_MODEL_PRIMITIVES_NONNEGATIVEINTEGER_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 #include <ome/xml/model/primitives/ConstrainedNumeric.h>
 #include <ome/xml/model/primitives/NumericConstraints.h>

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeLong.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeLong.h
@@ -56,7 +56,7 @@ namespace ome
         /**
          * Long integer (signed 64-bit) value greater than or equal to zero.
          */
-        typedef ConstrainedNumeric<int64_t, NonNegativeIntegerConstraint<int64_t> > NonNegativeLong;
+        typedef ConstrainedNumeric<int64_t, NonNegativeIntegerConstraint<int64_t>> NonNegativeLong;
 
       }
     }

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeLong.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/NonNegativeLong.h
@@ -39,7 +39,7 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_NONNEGATIVELONG_H
 #define OME_XML_MODEL_PRIMITIVES_NONNEGATIVELONG_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 #include <ome/xml/model/primitives/ConstrainedNumeric.h>
 #include <ome/xml/model/primitives/NumericConstraints.h>

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/PercentFraction.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/PercentFraction.h
@@ -55,7 +55,7 @@ namespace ome
          * Double-precision floating point value between 0.0 minimum
          * and 1.0 maximum.
          */
-        typedef ConstrainedNumeric<float, PercentFractionConstraint<float> > PercentFraction;
+        typedef ConstrainedNumeric<float, PercentFractionConstraint<float>> PercentFraction;
 
       }
     }

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveFloat.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveFloat.h
@@ -55,7 +55,7 @@ namespace ome
          * Double-precision floating point value greater than zero.
          * This value does not include zero.
          */
-        typedef ConstrainedNumeric<double, PositiveFloatConstraint<double> > PositiveFloat;
+        typedef ConstrainedNumeric<double, PositiveFloatConstraint<double>> PositiveFloat;
 
       }
     }

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveInteger.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveInteger.h
@@ -57,7 +57,7 @@ namespace ome
          * Integer (signed 32-bit) value greater than zero.  This
          * value does not include zero.
          */
-        typedef ConstrainedNumeric<int32_t, PositiveIntegerConstraint<int32_t> > PositiveInteger;
+        typedef ConstrainedNumeric<int32_t, PositiveIntegerConstraint<int32_t>> PositiveInteger;
 
       }
     }

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveInteger.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveInteger.h
@@ -39,7 +39,7 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_POSITIVEINTEGER_H
 #define OME_XML_MODEL_PRIMITIVES_POSITIVEINTEGER_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 #include <ome/xml/model/primitives/ConstrainedNumeric.h>
 #include <ome/xml/model/primitives/NumericConstraints.h>

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveLong.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveLong.h
@@ -57,7 +57,7 @@ namespace ome
          * Long integer (signed 64-bit) value greater than zero.  This
          * value does not include zero.
          */
-        typedef ConstrainedNumeric<int64_t, PositiveIntegerConstraint<int64_t> > PositiveLong;
+        typedef ConstrainedNumeric<int64_t, PositiveIntegerConstraint<int64_t>> PositiveLong;
 
       }
     }

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveLong.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/PositiveLong.h
@@ -39,7 +39,7 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_POSITIVELONG_H
 #define OME_XML_MODEL_PRIMITIVES_POSITIVELONG_H
 
-#include <ome/compat/cstdint.h>
+#include <cstdint>
 
 #include <ome/xml/model/primitives/ConstrainedNumeric.h>
 #include <ome/xml/model/primitives/NumericConstraints.h>

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/Quantity.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/Quantity.h
@@ -61,7 +61,7 @@ namespace ome
                                  boost::dividable2<Quantity<Unit, Value>, Value,
                                  boost::multipliable2<Quantity<Unit, Value>, Value,
                                  boost::incrementable<Quantity<Unit, Value>,
-                                 boost::decrementable<Quantity<Unit, Value> > > > > > > > >
+                                 boost::decrementable<Quantity<Unit, Value>>>>>>>>>
         {
         public:
           /// The type of a unit.

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/Timestamp.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/Timestamp.h
@@ -39,13 +39,12 @@
 #ifndef OME_XML_MODEL_PRIMITIVES_TIMESTAMP_H
 #define OME_XML_MODEL_PRIMITIVES_TIMESTAMP_H
 
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <stdexcept>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-
-#include <ome/compat/cstdint.h>
 
 namespace ome
 {

--- a/ome-xml/src/main/cpp/ome/xml/model/primitives/Timestamp.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/primitives/Timestamp.h
@@ -167,10 +167,8 @@ namespace ome
                                   // Check that the next 4 characters are only numeric
                                   std::string inchars(4, ' ');
                                   is.read(&inchars[0], 4);
-                                  for (std::string::const_iterator i = inchars.begin();
-                                       i != inchars.end();
-                                       ++i)
-                                    if (*i < '0' || *i > '9')
+                                  for (const auto& i : inchars)
+                                    if (i < '0' || i > '9')
                                       is.setstate(std::ios::failbit);
 
                                   if (is)

--- a/ome-xml/src/test/cpp/color.cpp
+++ b/ome-xml/src/test/cpp/color.cpp
@@ -254,18 +254,18 @@ TEST_P(ColorTest, StreamOutput)
   ASSERT_EQ(os.str(), params.str);
 }
 
-ColorTestParameters params[] =
+const std::vector<ColorTestParameters> params =
   {
-    ColorTestParameters(255,   0,   0, 255, 0xFF0000FFU,  -16776961,  "-16776961"), // Red
-    ColorTestParameters(  0, 255,   0, 255, 0x00FF00FFU,   16711935,   "16711935"), // Green
-    ColorTestParameters(  0,   0, 255, 255, 0x0000FFFFU,      65535,      "65535"), // Blue
-    ColorTestParameters(  0, 255, 255, 255, 0x00FFFFFFU,   16777215,   "16777215"), // Cyan
-    ColorTestParameters(255,   0, 255, 255, 0xFF00FFFFU,  -16711681,  "-16711681"), // Magenta
-    ColorTestParameters(255, 255,   0, 255, 0xFFFF00FFU,     -65281,     "-65281"), // Yellow
-    ColorTestParameters(  0,   0,   0, 255, 0x000000FFU,        255,        "255"), // Black
-    ColorTestParameters(255, 255, 255, 255, 0xFFFFFFFFU,         -1,         "-1"), // White
-    ColorTestParameters(  0,   0,   0, 127, 0x0000007FU,        127,        "127"), // Transparent black
-    ColorTestParameters(127, 127, 127, 127, 0x7F7F7F7FU, 2139062143, "2139062143"), // Grey
+    { 255,   0,   0, 255, 0xFF0000FFU,  -16776961,  "-16776961" }, // Red
+    {   0, 255,   0, 255, 0x00FF00FFU,   16711935,   "16711935" }, // Green
+    {   0,   0, 255, 255, 0x0000FFFFU,      65535,      "65535" }, // Blue
+    {   0, 255, 255, 255, 0x00FFFFFFU,   16777215,   "16777215" }, // Cyan
+    { 255,   0, 255, 255, 0xFF00FFFFU,  -16711681,  "-16711681" }, // Magenta
+    { 255, 255,   0, 255, 0xFFFF00FFU,     -65281,     "-65281" }, // Yellow
+    {   0,   0,   0, 255, 0x000000FFU,        255,        "255" }, // Black
+    { 255, 255, 255, 255, 0xFFFFFFFFU,         -1,         "-1" }, // White
+    {   0,   0,   0, 127, 0x0000007FU,        127,        "127" }, // Transparent black
+    { 127, 127, 127, 127, 0x7F7F7F7FU, 2139062143, "2139062143" }  // Grey
   };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;

--- a/ome-xml/src/test/cpp/constrained-numeric.h
+++ b/ome-xml/src/test/cpp/constrained-numeric.h
@@ -385,7 +385,7 @@ TYPED_TEST_P(NumericTest, OperatorEqual)
        i != this->ops.end();
        ++i)
     if (i->op == EQUAL)
-      compare_test<CompareEqual<TypeParam> >(*this, *i);
+      compare_test<CompareEqual<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorNotEqual)
@@ -394,7 +394,7 @@ TYPED_TEST_P(NumericTest, OperatorNotEqual)
        i != this->ops.end();
        ++i)
     if (i->op == NOT_EQUAL)
-      compare_test<CompareNotEqual<TypeParam> >(*this, *i);
+      compare_test<CompareNotEqual<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorLess)
@@ -403,7 +403,7 @@ TYPED_TEST_P(NumericTest, OperatorLess)
        i != this->ops.end();
        ++i)
     if (i->op == LESS)
-      compare_test<CompareLess<TypeParam> >(*this, *i);
+      compare_test<CompareLess<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorLessOrEqual)
@@ -412,7 +412,7 @@ TYPED_TEST_P(NumericTest, OperatorLessOrEqual)
        i != this->ops.end();
        ++i)
     if (i->op == LESS_OR_EQUAL)
-      compare_test<CompareLessOrEqual<TypeParam> >(*this, *i);
+      compare_test<CompareLessOrEqual<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorGreater)
@@ -421,7 +421,7 @@ TYPED_TEST_P(NumericTest, OperatorGreater)
        i != this->ops.end();
        ++i)
     if (i->op == GREATER)
-      compare_test<CompareGreater<TypeParam> >(*this, *i);
+      compare_test<CompareGreater<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorGreaterOrEqual)
@@ -430,7 +430,7 @@ TYPED_TEST_P(NumericTest, OperatorGreaterOrEqual)
        i != this->ops.end();
        ++i)
     if (i->op == GREATER_OR_EQUAL)
-      compare_test<CompareGreaterOrEqual<TypeParam> >(*this, *i);
+      compare_test<CompareGreaterOrEqual<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorAdd)
@@ -439,7 +439,7 @@ TYPED_TEST_P(NumericTest, OperatorAdd)
        i != this->ops.end();
        ++i)
     if (i->op == ADD)
-      operation_test<OperationAdd<TypeParam> >(*this, *i);
+      operation_test<OperationAdd<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorAddAssign)
@@ -448,7 +448,7 @@ TYPED_TEST_P(NumericTest, OperatorAddAssign)
        i != this->ops.end();
        ++i)
     if (i->op == ADD_ASSIGN)
-      operation_test<OperationAddAssign<TypeParam> >(*this, *i);
+      operation_test<OperationAddAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorSubtract)
@@ -457,7 +457,7 @@ TYPED_TEST_P(NumericTest, OperatorSubtract)
        i != this->ops.end();
        ++i)
     if (i->op == SUBTRACT)
-      operation_test<OperationSubtract<TypeParam> >(*this, *i);
+      operation_test<OperationSubtract<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorSubtractAssign)
@@ -466,7 +466,7 @@ TYPED_TEST_P(NumericTest, OperatorSubtractAssign)
        i != this->ops.end();
        ++i)
     if (i->op == SUBTRACT_ASSIGN)
-      operation_test<OperationSubtractAssign<TypeParam> >(*this, *i);
+      operation_test<OperationSubtractAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorMultiply)
@@ -475,7 +475,7 @@ TYPED_TEST_P(NumericTest, OperatorMultiply)
        i != this->ops.end();
        ++i)
     if (i->op == MULTIPLY)
-      operation_test<OperationMultiply<TypeParam> >(*this, *i);
+      operation_test<OperationMultiply<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorMultiplyAssign)
@@ -484,7 +484,7 @@ TYPED_TEST_P(NumericTest, OperatorMultiplyAssign)
        i != this->ops.end();
        ++i)
     if (i->op == MULTIPLY_ASSIGN)
-      operation_test<OperationMultiplyAssign<TypeParam> >(*this, *i);
+      operation_test<OperationMultiplyAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDivide)
@@ -493,7 +493,7 @@ TYPED_TEST_P(NumericTest, OperatorDivide)
        i != this->ops.end();
        ++i)
     if (i->op == DIVIDE)
-      operation_test<OperationDivide<TypeParam> >(*this, *i);
+      operation_test<OperationDivide<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDivideAssign)
@@ -502,7 +502,7 @@ TYPED_TEST_P(NumericTest, OperatorDivideAssign)
        i != this->ops.end();
        ++i)
     if (i->op == DIVIDE_ASSIGN)
-      operation_test<OperationDivideAssign<TypeParam> >(*this, *i);
+      operation_test<OperationDivideAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorModulo)
@@ -511,7 +511,7 @@ TYPED_TEST_P(NumericTest, OperatorModulo)
        i != this->ops.end();
        ++i)
     if (i->op == MODULO)
-      operation_test<OperationModulo<TypeParam> >(*this, *i);
+      operation_test<OperationModulo<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorModuloAssign)
@@ -520,7 +520,7 @@ TYPED_TEST_P(NumericTest, OperatorModuloAssign)
        i != this->ops.end();
        ++i)
     if (i->op == MODULO_ASSIGN)
-      operation_test<OperationModuloAssign<TypeParam> >(*this, *i);
+      operation_test<OperationModuloAssign<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorIncrement)
@@ -529,7 +529,7 @@ TYPED_TEST_P(NumericTest, OperatorIncrement)
        i != this->ops.end();
        ++i)
     if (i->op == INCREMENT)
-      operation_test<OperationIncrement<TypeParam> >(*this, *i);
+      operation_test<OperationIncrement<TypeParam>>(*this, *i);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDecrement)
@@ -538,7 +538,7 @@ TYPED_TEST_P(NumericTest, OperatorDecrement)
        i != this->ops.end();
        ++i)
     if (i->op == DECREMENT)
-      operation_test<OperationDecrement<TypeParam> >(*this, *i);
+      operation_test<OperationDecrement<TypeParam>>(*this, *i);
 }
 
 REGISTER_TYPED_TEST_CASE_P(NumericTest,

--- a/ome-xml/src/test/cpp/constrained-numeric.h
+++ b/ome-xml/src/test/cpp/constrained-numeric.h
@@ -341,204 +341,166 @@ TYPED_TEST_P(NumericTest, DefaultConstruct)
 
 TYPED_TEST_P(NumericTest, Stream)
 {
-  for (typename std::vector<typename TestFixture::test_str>::const_iterator i = this->strings.begin();
-       i != this->strings.end();
-       ++i)
+  for (const auto& string : this->strings)
     {
-      if (i->v1pass)
-        ASSERT_NO_THROW(TypeParam(i->v1));
+      if (string.v1pass)
+        ASSERT_NO_THROW(TypeParam(string.v1));
       else
-        ASSERT_THROW(TypeParam(i->v1), std::invalid_argument);
+        ASSERT_THROW(TypeParam(string.v1), std::invalid_argument);
 
-      if (i->v2pass)
-        ASSERT_NO_THROW(TypeParam(i->v2));
+      if (string.v2pass)
+        ASSERT_NO_THROW(TypeParam(string.v2));
       else
-        ASSERT_THROW(TypeParam(i->v2), std::invalid_argument);
+        ASSERT_THROW(TypeParam(string.v2), std::invalid_argument);
 
-      if (!i->v1pass || !i->v2pass) // deliberate failure
+      if (!string.v1pass || !string.v2pass) // deliberate failure
         continue;
 
-      TypeParam v1(i->v1);
-      TypeParam v2(i->v2);
+      TypeParam v1(string.v1);
+      TypeParam v2(string.v2);
 
       CompareEqual<TypeParam> c;
 
       ASSERT_TRUE(c.compare(v1, v2));
       ASSERT_TRUE(c.compare(v2, v2));
-      ASSERT_TRUE(c.compare(v1, i->v2));
-      ASSERT_TRUE(c.compare(v2, i->v2));
+      ASSERT_TRUE(c.compare(v1, string.v2));
+      ASSERT_TRUE(c.compare(v2, string.v2));
 
-      std::istringstream is(i->v1);
+      std::istringstream is(string.v1);
       TypeParam v3(TestFixture::safedefault);
       ASSERT_NO_THROW(is >> v3);
-      ASSERT_TRUE(c.compare(i->v2, v3));
+      ASSERT_TRUE(c.compare(string.v2, v3));
 
       std::ostringstream os;
       ASSERT_NO_THROW(os << v1);
-      ASSERT_EQ(i->v1, os.str());
+      ASSERT_EQ(string.v1, os.str());
     }
 }
 
 TYPED_TEST_P(NumericTest, OperatorEqual)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == EQUAL)
-      compare_test<CompareEqual<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == EQUAL)
+      compare_test<CompareEqual<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorNotEqual)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == NOT_EQUAL)
-      compare_test<CompareNotEqual<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == NOT_EQUAL)
+      compare_test<CompareNotEqual<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorLess)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == LESS)
-      compare_test<CompareLess<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == LESS)
+      compare_test<CompareLess<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorLessOrEqual)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == LESS_OR_EQUAL)
-      compare_test<CompareLessOrEqual<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == LESS_OR_EQUAL)
+      compare_test<CompareLessOrEqual<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorGreater)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == GREATER)
-      compare_test<CompareGreater<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == GREATER)
+      compare_test<CompareGreater<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorGreaterOrEqual)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == GREATER_OR_EQUAL)
-      compare_test<CompareGreaterOrEqual<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == GREATER_OR_EQUAL)
+      compare_test<CompareGreaterOrEqual<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorAdd)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == ADD)
-      operation_test<OperationAdd<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == ADD)
+      operation_test<OperationAdd<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorAddAssign)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == ADD_ASSIGN)
-      operation_test<OperationAddAssign<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == ADD_ASSIGN)
+      operation_test<OperationAddAssign<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorSubtract)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == SUBTRACT)
-      operation_test<OperationSubtract<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == SUBTRACT)
+      operation_test<OperationSubtract<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorSubtractAssign)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == SUBTRACT_ASSIGN)
-      operation_test<OperationSubtractAssign<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == SUBTRACT_ASSIGN)
+      operation_test<OperationSubtractAssign<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorMultiply)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == MULTIPLY)
-      operation_test<OperationMultiply<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == MULTIPLY)
+      operation_test<OperationMultiply<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorMultiplyAssign)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == MULTIPLY_ASSIGN)
-      operation_test<OperationMultiplyAssign<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == MULTIPLY_ASSIGN)
+      operation_test<OperationMultiplyAssign<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDivide)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == DIVIDE)
-      operation_test<OperationDivide<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == DIVIDE)
+      operation_test<OperationDivide<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDivideAssign)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == DIVIDE_ASSIGN)
-      operation_test<OperationDivideAssign<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == DIVIDE_ASSIGN)
+      operation_test<OperationDivideAssign<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorModulo)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == MODULO)
-      operation_test<OperationModulo<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == MODULO)
+      operation_test<OperationModulo<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorModuloAssign)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == MODULO_ASSIGN)
-      operation_test<OperationModuloAssign<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == MODULO_ASSIGN)
+      operation_test<OperationModuloAssign<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorIncrement)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == INCREMENT)
-      operation_test<OperationIncrement<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == INCREMENT)
+      operation_test<OperationIncrement<TypeParam>>(*this, op);
 }
 
 TYPED_TEST_P(NumericTest, OperatorDecrement)
 {
-  for (typename std::vector<typename TestFixture::test_op>::const_iterator i = this->ops.begin();
-       i != this->ops.end();
-       ++i)
-    if (i->op == DECREMENT)
-      operation_test<OperationDecrement<TypeParam>>(*this, *i);
+  for (const auto& op : this->ops)
+    if (op.op == DECREMENT)
+      operation_test<OperationDecrement<TypeParam>>(*this, op);
 }
 
 REGISTER_TYPED_TEST_CASE_P(NumericTest,

--- a/ome-xml/src/test/cpp/enum.cpp
+++ b/ome-xml/src/test/cpp/enum.cpp
@@ -57,35 +57,29 @@ TEST(Enum, LaserTypeAssign)
 
 TEST(Enum, LaserStrings)
 {
-  const LaserType::string_map_type& strings = LaserType::strings();
-  for(LaserType::string_map_type::const_iterator i = strings.begin();
-      i != strings.end();
-      ++i)
+  for(const auto& s: LaserType::strings())
     {
-      LaserType l1(i->first);
-      LaserType l2(i->second);
+      LaserType l1(s.first);
+      LaserType l2(s.second);
       ASSERT_EQ(l1, l2);
-      ASSERT_EQ(l1, i->first);
-      ASSERT_EQ(l1, i->second);
-      ASSERT_EQ(l2, i->first);
-      ASSERT_EQ(l2, i->second);
+      ASSERT_EQ(l1, s.first);
+      ASSERT_EQ(l1, s.second);
+      ASSERT_EQ(l2, s.first);
+      ASSERT_EQ(l2, s.second);
     }
 }
 
 TEST(Enum, LaserValues)
 {
-  const LaserType::value_map_type& values = LaserType::values();
-  for(LaserType::value_map_type::const_iterator i = values.begin();
-      i != values.end();
-      ++i)
+  for(const auto& v: LaserType::values())
     {
-      LaserType l1(i->first);
-      LaserType l2(i->second);
+      LaserType l1(v.first);
+      LaserType l2(v.second);
       ASSERT_EQ(l1, l2);
-      ASSERT_EQ(l1, i->first);
-      ASSERT_EQ(l1, i->second);
-      ASSERT_EQ(l2, i->first);
-      ASSERT_EQ(l2, i->second);
+      ASSERT_EQ(l1, v.first);
+      ASSERT_EQ(l1, v.second);
+      ASSERT_EQ(l2, v.first);
+      ASSERT_EQ(l2, v.second);
     }
 }
 

--- a/ome-xml/src/test/cpp/enum.cpp
+++ b/ome-xml/src/test/cpp/enum.cpp
@@ -230,7 +230,7 @@ public:
  {}
 };
 
-class LaserTypeValue : public ::testing::TestWithParam<EnumValueParameters<LaserType> >
+class LaserTypeValue : public ::testing::TestWithParam<EnumValueParameters<LaserType>>
 {
 public:
   typedef LaserType enum_type;

--- a/ome-xml/src/test/cpp/enum.cpp
+++ b/ome-xml/src/test/cpp/enum.cpp
@@ -176,20 +176,6 @@ TEST_P(EnumString, Compare)
     }
 }
 
-EnumStringParameters string_params[] =
-  {
-    EnumStringParameters("SolidState",             true,  false, false),
-    EnumStringParameters("solidstate",             false, true,  false),
-    EnumStringParameters("soLidsTaTe",             false, true,  false),
-    EnumStringParameters("    \tsolidstate",       false, true,  false),
-    EnumStringParameters("SolidState      \n",     false, true,  false),
-    EnumStringParameters("\f\f  solidstate    \v", false, true,  false),
-    EnumStringParameters("InvalidName",            false, false, false),
-    EnumStringParameters("--invalid--",            false, false, true),
-    EnumStringParameters("invalid3",               false, false, true)
-  };
-
-
 // This enum test is intentionally setting an invalid value, so don't
 // warn about it.
 #ifdef __GNUC__
@@ -340,33 +326,6 @@ TEST_P(LaserTypeValue, StreamInputFail)
   ASSERT_EQ(LaserType::OTHER, e); // Unchanged.
   ASSERT_NE(params.valueneg, e);
 }
-
-typedef EnumValueParameters<LaserType> lts_param;
-lts_param lt_value_params[] =
-  {
-    lts_param(LaserType(LaserType::METALVAPOR),
-              LaserType::METALVAPOR, LaserType::EXCIMER,
-              "MetalVapor", "Excimer"),
-    lts_param(LaserType(LaserType::EXCIMER),
-              LaserType::EXCIMER, LaserType::GAS,
-              "Excimer", "Gas"),
-    lts_param(LaserType(LaserType::SOLIDSTATE),
-              LaserType::SOLIDSTATE, LaserType::FREEELECTRON,
-              "SolidState", "FreeElectron"),
-    lts_param(LaserType(LaserType::OTHER),
-              LaserType::OTHER, LaserType::FREEELECTRON,
-              "Other", "FreeElectron"),
-    lts_param(LaserType("SolidState"),
-              LaserType::SOLIDSTATE, LaserType::FREEELECTRON,
-              "SolidState", "FreeElectron"),
-    lts_param(LaserType("SolidState", true),
-              LaserType::SOLIDSTATE, LaserType::FREEELECTRON,
-              "SolidState", "FreeElectron"),
-    lts_param(LaserType("\tSOLIDStaTe ", false),
-              LaserType::SOLIDSTATE, LaserType::FREEELECTRON,
-              "SolidState", "FreeElectron"),
-  };
-
 
 template<typename E>
 void
@@ -574,6 +533,44 @@ TEST(Enum, PixelTypePreprocessNested)
 #undef NESTED_TEST
 
 #endif // !_MSC_VER
+
+std::vector<EnumStringParameters> string_params =
+  {
+    { "SolidState",             true,  false, false },
+    { "solidstate",             false, true,  false },
+    { "soLidsTaTe",             false, true,  false },
+    { "    \tsolidstate",       false, true,  false },
+    { "SolidState      \n",     false, true,  false },
+    { "\f\f  solidstate    \v", false, true,  false },
+    { "InvalidName",            false, false, false },
+    { "--invalid--",            false, false, true },
+    { "invalid3",               false, false, true }
+  };
+
+std::vector<EnumValueParameters<LaserType>> lt_value_params =
+  {
+    { LaserType(LaserType::METALVAPOR),
+      LaserType::METALVAPOR, LaserType::EXCIMER,
+      "MetalVapor", "Excimer" },
+    { LaserType(LaserType::EXCIMER),
+      LaserType::EXCIMER, LaserType::GAS,
+      "Excimer", "Gas" },
+    { LaserType(LaserType::SOLIDSTATE),
+      LaserType::SOLIDSTATE, LaserType::FREEELECTRON,
+      "SolidState", "FreeElectron" },
+    { LaserType(LaserType::OTHER),
+      LaserType::OTHER, LaserType::FREEELECTRON,
+      "Other", "FreeElectron" },
+    { LaserType("SolidState"),
+      LaserType::SOLIDSTATE, LaserType::FREEELECTRON,
+      "SolidState", "FreeElectron" },
+    { LaserType("SolidState", true),
+      LaserType::SOLIDSTATE, LaserType::FREEELECTRON,
+      "SolidState", "FreeElectron" },
+    { LaserType("\tSOLIDStaTe ", false),
+      LaserType::SOLIDSTATE, LaserType::FREEELECTRON,
+      "SolidState", "FreeElectron" }
+  };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
 // this is solely to work around a missing prototype in gtest.

--- a/ome-xml/src/test/cpp/model.cpp
+++ b/ome-xml/src/test/cpp/model.cpp
@@ -161,7 +161,7 @@ TEST_P(ModelTest, Update)
 {
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
   model->update(docroot);
 }
@@ -170,7 +170,7 @@ TEST_P(ModelTest, CreateXML)
 {
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
   model->update(docroot);
 
@@ -185,7 +185,7 @@ TEST_P(ModelTest, CreateXMLRoundTrip)
 {
   // Read into OME model objects.
   ome::xml::meta::OMEXMLMetadata meta;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta.getRoot()));
   ome::common::xml::dom::Element docroot(doc.getDocumentElement());
   model->update(docroot);
 
@@ -200,7 +200,7 @@ TEST_P(ModelTest, CreateXMLRoundTrip)
   // Read into OME model objects.
   ome::common::xml::dom::Document doc2(ome::xml::createDocument(omexml));
   ome::xml::meta::OMEXMLMetadata meta2;
-  ome::compat::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model2(ome::compat::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
+  std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> model2(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta2.getRoot()));
   ome::common::xml::dom::Element docroot2(doc2.getDocumentElement());
   model2->update(docroot2);
 

--- a/ome-xml/src/test/cpp/non-negative-float.cpp
+++ b/ome-xml/src/test/cpp/non-negative-float.cpp
@@ -133,94 +133,83 @@ struct OperationDecrement<NonNegativeFloat>
 
 INSTANTIATE_TYPED_TEST_CASE_P(NonNegativeFloat, NumericTest, NonNegativeFloat);
 
-namespace
-{
-
-  NumericTest<NonNegativeFloat>::test_str init_strings[] =
-    { // str     pos      strpass pospass
-      {"23",      23.0,   true,   true},
-      {"-42.12", -42.12,  false,  false},
-      {"1.0",    -53.0,   true,   false},
-      {"82.232",  82.232, true,   true},
-      {"0",        0,     true,   true},
-      {"1.0",     -0.1,   true,   false},
-      {"invalid",  1.0,   false,  true},
-    };
-
-  NumericTest<NonNegativeFloat>::test_op init_ops[] =
-    { // v1     v2      expected        operation         pass   except rhsexcept
-      {   23.0,   23.0,            1.0, EQUAL,            true,  false, false},
-      {   23.0,  432.0,            0.0, EQUAL,            false, false, false},
-      {   23.0,   35.0,            1.0, NOT_EQUAL,        true,  false, false},
-      {   54.0,   54.0,            0.0, NOT_EQUAL,        false, false, false},
-
-      { 5432.0, 8272.0,            1.0, LESS,             true,  false, false},
-      {  534.0,  534.0,            0.0, LESS,             false, false, false},
-      {  947.0,   34.0,            0.0, LESS,             false, false, false},
-      { 5432.0, 8272.0,            1.0, LESS_OR_EQUAL,    true,  false, false},
-      {  534.0,  534.0,            1.0, LESS_OR_EQUAL,    true,  false, false},
-      {  947.0,   34.0,            0.0, LESS_OR_EQUAL,    false, false, false},
-
-      {10873.0, 8420.0,            1.0, GREATER,          true,  false, false},
-      { 3622.0, 3622.0,            0.0, GREATER,          false, false, false},
-      {  872.0, 2701.0,            0.0, GREATER,          false, false, false},
-      {10873.0, 8420.0,            1.0, GREATER_OR_EQUAL, true,  false, false},
-      { 3622.0, 3622.0,            1.0, GREATER_OR_EQUAL, true,  false, false},
-      {  872.0, 2701.0,            0.0, GREATER_OR_EQUAL, false, false, false},
-
-      {  432.0,  743.0, 432.0 +  743.0, ADD,              true,  false, false},
-      {  432.0,  -74.0, 432.0 -   74.0, ADD,              true,  false, true},
-      {  432.0, -743.0, 432.0 -  743.0, ADD,              false, true,  true},
-      {  432.0,  743.0,            1.0, ADD,              false, false, false},
-      {  823.0,   93.0, 823.0 +   93.0, ADD_ASSIGN,       true,  false, false},
-      {  823.0,  -93.0, 823.0 -   93.0, ADD_ASSIGN,       true,  false, true},
-      {  823.0, -932.0, 823.0 -  932.0, ADD_ASSIGN,       false, true,  true},
-      {  823.0,   93.0,            1.0, ADD_ASSIGN,       false, false, false},
-
-      {  432.0,  285.0, 432.0 -  285.0, SUBTRACT,         true,  false, false},
-      {  432.0, -285.0, 432.0 +  285.0, SUBTRACT,         true,  false, true},
-      {  432.0,  763.0, 432.0 -  763.0, SUBTRACT,         false, true,  false},
-      {  432.0,  285.0,            1.0, SUBTRACT,         false, false, false},
-      {  432.0,  431.0,            1.0, SUBTRACT,         true,  false, false},
-      {  432.0,  432.0,            0.0, SUBTRACT,         true,  false, false},
-      {  823.0,   93.0, 823.0 -   93.0, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823.0, -932.0, 823.0 +  932.0, SUBTRACT_ASSIGN,  true,  false, true},
-      {  823.0, 1393.0, 823.0 - 1393.0, SUBTRACT_ASSIGN,  false, true,  false},
-      {  823.0,   93.0,            1.0, SUBTRACT_ASSIGN,  false, false, false},
-      {  823.0,  822.0,            1.0, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823.0,  823.0,            0.0, SUBTRACT_ASSIGN,  true,  false, false},
-
-      {   40.0,   12.0,  40.0 *   12.0, MULTIPLY,         true,  false, false},
-      {   23.0,   -8.0,  23.0 *   -8.0, MULTIPLY,         false, true,  true},
-      {   40.0,   12.0,            1.0, MULTIPLY,         false, false, false},
-      {   18.0,    4.0,  18.0 *    4.0, MULTIPLY_ASSIGN,  true,  false, false},
-      {    2.0, -232.0,   2.0 * -232.0, MULTIPLY_ASSIGN,  false, true,  true},
-      {   18.0,    4.0,            1.0, MULTIPLY_ASSIGN,  false, false, false},
-
-      {  900.0,    5.0, 900.0 /    5.0, DIVIDE,           true,  false, false},
-      {  900.0,   -5.0, 900.0 /   -5.0, DIVIDE,           false, true,  true},
-      {  900.0,  900.0, 900.0 /  900.0, DIVIDE,           true,  false, false},
-      {  900.0,  901.0, 900.1 /  901.0, DIVIDE,           true,  false, false},
-      {  900.0,  900.0,            2.0, DIVIDE,           false, false, false},
-      {  480.0,   20.0, 480.0 /   20.0, DIVIDE_ASSIGN,    true,  false, false},
-      {  480.0,  -20.0, 480.0 /  -20.0, DIVIDE_ASSIGN,    false, true,  true},
-      {  480.0,  480.0, 480.0 /  480.0, DIVIDE_ASSIGN,    true,  false, false},
-      {  480.0,  481.0, 480.0 /  481.0, DIVIDE_ASSIGN,    true,  false, false},
-      {  480.0,  480.0,            2.0, DIVIDE_ASSIGN,    false, false, false},
-
-    };
-
-}
-
 template<>
 const std::vector<NumericTest<NonNegativeFloat>::test_str>
-NumericTest<NonNegativeFloat>::strings(init_strings,
-                                       init_strings + boost::size(init_strings));
+NumericTest<NonNegativeFloat>::strings =
+  { // str     pos      strpass pospass
+    {"23",      23.0,   true,   true},
+    {"-42.12", -42.12,  false,  false},
+    {"1.0",    -53.0,   true,   false},
+    {"82.232",  82.232, true,   true},
+    {"0",        0,     true,   true},
+    {"1.0",     -0.1,   true,   false},
+    {"invalid",  1.0,   false,  true},
+  };
 
 template<>
 const std::vector<NumericTest<NonNegativeFloat>::test_op>
-NumericTest<NonNegativeFloat>::ops(init_ops,
-                                   init_ops + boost::size(init_ops));
+NumericTest<NonNegativeFloat>::ops =
+  { // v1     v2      expected        operation         pass   except rhsexcept
+    {   23.0,   23.0,            1.0, EQUAL,            true,  false, false},
+    {   23.0,  432.0,            0.0, EQUAL,            false, false, false},
+    {   23.0,   35.0,            1.0, NOT_EQUAL,        true,  false, false},
+    {   54.0,   54.0,            0.0, NOT_EQUAL,        false, false, false},
+
+    { 5432.0, 8272.0,            1.0, LESS,             true,  false, false},
+    {  534.0,  534.0,            0.0, LESS,             false, false, false},
+    {  947.0,   34.0,            0.0, LESS,             false, false, false},
+    { 5432.0, 8272.0,            1.0, LESS_OR_EQUAL,    true,  false, false},
+    {  534.0,  534.0,            1.0, LESS_OR_EQUAL,    true,  false, false},
+    {  947.0,   34.0,            0.0, LESS_OR_EQUAL,    false, false, false},
+
+    {10873.0, 8420.0,            1.0, GREATER,          true,  false, false},
+    { 3622.0, 3622.0,            0.0, GREATER,          false, false, false},
+    {  872.0, 2701.0,            0.0, GREATER,          false, false, false},
+    {10873.0, 8420.0,            1.0, GREATER_OR_EQUAL, true,  false, false},
+    { 3622.0, 3622.0,            1.0, GREATER_OR_EQUAL, true,  false, false},
+    {  872.0, 2701.0,            0.0, GREATER_OR_EQUAL, false, false, false},
+
+    {  432.0,  743.0, 432.0 +  743.0, ADD,              true,  false, false},
+    {  432.0,  -74.0, 432.0 -   74.0, ADD,              true,  false, true},
+    {  432.0, -743.0, 432.0 -  743.0, ADD,              false, true,  true},
+    {  432.0,  743.0,            1.0, ADD,              false, false, false},
+    {  823.0,   93.0, 823.0 +   93.0, ADD_ASSIGN,       true,  false, false},
+    {  823.0,  -93.0, 823.0 -   93.0, ADD_ASSIGN,       true,  false, true},
+    {  823.0, -932.0, 823.0 -  932.0, ADD_ASSIGN,       false, true,  true},
+    {  823.0,   93.0,            1.0, ADD_ASSIGN,       false, false, false},
+
+    {  432.0,  285.0, 432.0 -  285.0, SUBTRACT,         true,  false, false},
+    {  432.0, -285.0, 432.0 +  285.0, SUBTRACT,         true,  false, true},
+    {  432.0,  763.0, 432.0 -  763.0, SUBTRACT,         false, true,  false},
+    {  432.0,  285.0,            1.0, SUBTRACT,         false, false, false},
+    {  432.0,  431.0,            1.0, SUBTRACT,         true,  false, false},
+    {  432.0,  432.0,            0.0, SUBTRACT,         true,  false, false},
+    {  823.0,   93.0, 823.0 -   93.0, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823.0, -932.0, 823.0 +  932.0, SUBTRACT_ASSIGN,  true,  false, true},
+    {  823.0, 1393.0, 823.0 - 1393.0, SUBTRACT_ASSIGN,  false, true,  false},
+    {  823.0,   93.0,            1.0, SUBTRACT_ASSIGN,  false, false, false},
+    {  823.0,  822.0,            1.0, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823.0,  823.0,            0.0, SUBTRACT_ASSIGN,  true,  false, false},
+
+    {   40.0,   12.0,  40.0 *   12.0, MULTIPLY,         true,  false, false},
+    {   23.0,   -8.0,  23.0 *   -8.0, MULTIPLY,         false, true,  true},
+    {   40.0,   12.0,            1.0, MULTIPLY,         false, false, false},
+    {   18.0,    4.0,  18.0 *    4.0, MULTIPLY_ASSIGN,  true,  false, false},
+    {    2.0, -232.0,   2.0 * -232.0, MULTIPLY_ASSIGN,  false, true,  true},
+    {   18.0,    4.0,            1.0, MULTIPLY_ASSIGN,  false, false, false},
+
+    {  900.0,    5.0, 900.0 /    5.0, DIVIDE,           true,  false, false},
+    {  900.0,   -5.0, 900.0 /   -5.0, DIVIDE,           false, true,  true},
+    {  900.0,  900.0, 900.0 /  900.0, DIVIDE,           true,  false, false},
+    {  900.0,  901.0, 900.1 /  901.0, DIVIDE,           true,  false, false},
+    {  900.0,  900.0,            2.0, DIVIDE,           false, false, false},
+    {  480.0,   20.0, 480.0 /   20.0, DIVIDE_ASSIGN,    true,  false, false},
+    {  480.0,  -20.0, 480.0 /  -20.0, DIVIDE_ASSIGN,    false, true,  true},
+    {  480.0,  480.0, 480.0 /  480.0, DIVIDE_ASSIGN,    true,  false, false},
+    {  480.0,  481.0, 480.0 /  481.0, DIVIDE_ASSIGN,    true,  false, false},
+    {  480.0,  480.0,            2.0, DIVIDE_ASSIGN,    false, false, false},
+
+  };
 
 template<>
 const NonNegativeFloat::value_type NumericTest<NonNegativeFloat>::error(0.0005);

--- a/ome-xml/src/test/cpp/non-negative-integer.cpp
+++ b/ome-xml/src/test/cpp/non-negative-integer.cpp
@@ -46,109 +46,98 @@ using ome::xml::model::primitives::NonNegativeInteger;
 
 INSTANTIATE_TYPED_TEST_CASE_P(NonNegativeInteger, NumericTest, NonNegativeInteger);
 
-namespace
-{
-
-  NumericTest<NonNegativeInteger>::test_str init_strings[] =
-    { // str      pos  strpass pospass
-      {"23",       23, true,   true},
-      {"-1",       -1, false,  false},
-      {"-42",     -42, false,  false},
-      {"1",       -53, true,   false},
-      {"82",       82, true,   true},
-      {"0",         0, true,   true},
-      {"invalid",   1, false,  true},
-    };
-
-  NumericTest<NonNegativeInteger>::test_op init_ops[] =
-    { // v1   v2    expected    operation         pass   except rhsexcept
-      {   23,   23,          1, EQUAL,            true,  false, false},
-      {   23,  432,          0, EQUAL,            false, false, false},
-      {   23,   35,          1, NOT_EQUAL,        true,  false, false},
-      {   54,   54,          0, NOT_EQUAL,        false, false, false},
-
-      { 5432, 8272,          1, LESS,             true,  false, false},
-      {  534,  534,          0, LESS,             false, false, false},
-      {  947,   34,          0, LESS,             false, false, false},
-      { 5432, 8272,          1, LESS_OR_EQUAL,    true,  false, false},
-      {  534,  534,          1, LESS_OR_EQUAL,    true,  false, false},
-      {  947,   34,          0, LESS_OR_EQUAL,    false, false, false},
-
-      {10873, 8420,          1, GREATER,          true,  false, false},
-      { 3622, 3622,          0, GREATER,          false, false, false},
-      {  872, 2701,          0, GREATER,          false, false, false},
-      {10873, 8420,          1, GREATER_OR_EQUAL, true,  false, false},
-      { 3622, 3622,          1, GREATER_OR_EQUAL, true,  false, false},
-      {  872, 2701,          0, GREATER_OR_EQUAL, false, false, false},
-
-      {  432,  743, 432 +  743, ADD,              true,  false, false},
-      {  432,  -74, 432 -   74, ADD,              true,  false, true},
-      {  432, -743, 432 -  743, ADD,              false, true,  true},
-      {  432,  743,          1, ADD,              false, false, false},
-      {  823,   93, 823 +   93, ADD_ASSIGN,       true,  false, false},
-      {  823,  -93, 823 -   93, ADD_ASSIGN,       true,  false, true},
-      {  823, -932, 823 -  932, ADD_ASSIGN,       false, true,  true},
-      {  823,   93,          1, ADD_ASSIGN,       false, false, false},
-
-      {  432,  285, 432 -  285, SUBTRACT,         true,  false, false},
-      {  432, -285, 432 +  285, SUBTRACT,         true,  false, true},
-      {  432,  763, 432 -  763, SUBTRACT,         false, true,  false},
-      {  432,  285,          1, SUBTRACT,         false, false, false},
-      {  432,  431,          1, SUBTRACT,         true,  false, false},
-      {  432,  432,          0, SUBTRACT,         true,  false, false},
-      {  432,  433,         -1, SUBTRACT,         false, true,  false},
-      {  823,   93, 823 -   93, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823, -932, 823 +  932, SUBTRACT_ASSIGN,  true,  false, true},
-      {  823, 1393, 823 - 1393, SUBTRACT_ASSIGN,  false, true,  false},
-      {  823,   93,          1, SUBTRACT_ASSIGN,  false, false, false},
-      {  823,  822,          1, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823,  823,          0, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823,  824,         -1, SUBTRACT_ASSIGN,  false, true,  false},
-
-      {   40,   12,  40 *   12, MULTIPLY,         true,  false, false},
-      {   23,   -8,  23 *   -8, MULTIPLY,         false, true,  true},
-      {   40,   12,          1, MULTIPLY,         false, false, false},
-      {   18,    4,  18 *    4, MULTIPLY_ASSIGN,  true,  false, false},
-      {    2, -232,   2 * -232, MULTIPLY_ASSIGN,  false, true,  true},
-      {   18,    4,          1, MULTIPLY_ASSIGN,  false, false, false},
-
-      {  900,    5, 900 /    5, DIVIDE,           true,  false, false},
-      {  900,   -5, 900 /   -5, DIVIDE,           false, true,  true},
-      {  900,  900, 900 /  900, DIVIDE,           true,  false, false},
-      {  900,  901,          0, DIVIDE,           true,  false, false},
-      {  900,  900,          2, DIVIDE,           false, false, false},
-      {  480,   20, 480 /   20, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  -20, 480 /  -20, DIVIDE_ASSIGN,    false, true,  true},
-      {  480,  480, 480 /  480, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  481,          0, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  480,          2, DIVIDE_ASSIGN,    false, false, false},
-
-      {  901,  900,          1, MODULO,           true,  false, false},
-      {  901,  900,          2, MODULO,           false, false, false},
-      {   43,   43,          0, MODULO,           true,  false, false},
-      {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
-      {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
-      {   43,   43,          0, MODULO_ASSIGN,    true,  false, false},
-
-      {  33,     0,         34, INCREMENT,        true,  false, false},
-      {  33,     0,         33, INCREMENT,        false, false, false},
-      {   0,     0,          1, INCREMENT,        true,  false, false},
-      {  33,     0,         32, DECREMENT,        true,  false, false},
-      {  33,     0,         33, DECREMENT,        false, false, false},
-      {   0,     0,          0, DECREMENT,        false, true,  false}
-    };
-
-}
-
 template<>
 const std::vector<NumericTest<NonNegativeInteger>::test_str>
-NumericTest<NonNegativeInteger>::strings(init_strings,
-                                         init_strings + boost::size(init_strings));
+NumericTest<NonNegativeInteger>::strings =
+  { // str      pos  strpass pospass
+    {"23",       23, true,   true},
+    {"-1",       -1, false,  false},
+    {"-42",     -42, false,  false},
+    {"1",       -53, true,   false},
+    {"82",       82, true,   true},
+    {"0",         0, true,   true},
+    {"invalid",   1, false,  true},
+  };
 
 template<>
 const std::vector<NumericTest<NonNegativeInteger>::test_op>
-NumericTest<NonNegativeInteger>::ops(init_ops,
-                                     init_ops + boost::size(init_ops));
+NumericTest<NonNegativeInteger>::ops =
+  { // v1   v2    expected    operation         pass   except rhsexcept
+    {   23,   23,          1, EQUAL,            true,  false, false},
+    {   23,  432,          0, EQUAL,            false, false, false},
+    {   23,   35,          1, NOT_EQUAL,        true,  false, false},
+    {   54,   54,          0, NOT_EQUAL,        false, false, false},
+
+    { 5432, 8272,          1, LESS,             true,  false, false},
+    {  534,  534,          0, LESS,             false, false, false},
+    {  947,   34,          0, LESS,             false, false, false},
+    { 5432, 8272,          1, LESS_OR_EQUAL,    true,  false, false},
+    {  534,  534,          1, LESS_OR_EQUAL,    true,  false, false},
+    {  947,   34,          0, LESS_OR_EQUAL,    false, false, false},
+
+    {10873, 8420,          1, GREATER,          true,  false, false},
+    { 3622, 3622,          0, GREATER,          false, false, false},
+    {  872, 2701,          0, GREATER,          false, false, false},
+    {10873, 8420,          1, GREATER_OR_EQUAL, true,  false, false},
+    { 3622, 3622,          1, GREATER_OR_EQUAL, true,  false, false},
+    {  872, 2701,          0, GREATER_OR_EQUAL, false, false, false},
+
+    {  432,  743, 432 +  743, ADD,              true,  false, false},
+    {  432,  -74, 432 -   74, ADD,              true,  false, true},
+    {  432, -743, 432 -  743, ADD,              false, true,  true},
+    {  432,  743,          1, ADD,              false, false, false},
+    {  823,   93, 823 +   93, ADD_ASSIGN,       true,  false, false},
+    {  823,  -93, 823 -   93, ADD_ASSIGN,       true,  false, true},
+    {  823, -932, 823 -  932, ADD_ASSIGN,       false, true,  true},
+    {  823,   93,          1, ADD_ASSIGN,       false, false, false},
+
+    {  432,  285, 432 -  285, SUBTRACT,         true,  false, false},
+    {  432, -285, 432 +  285, SUBTRACT,         true,  false, true},
+    {  432,  763, 432 -  763, SUBTRACT,         false, true,  false},
+    {  432,  285,          1, SUBTRACT,         false, false, false},
+    {  432,  431,          1, SUBTRACT,         true,  false, false},
+    {  432,  432,          0, SUBTRACT,         true,  false, false},
+    {  432,  433,         -1, SUBTRACT,         false, true,  false},
+    {  823,   93, 823 -   93, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823, -932, 823 +  932, SUBTRACT_ASSIGN,  true,  false, true},
+    {  823, 1393, 823 - 1393, SUBTRACT_ASSIGN,  false, true,  false},
+    {  823,   93,          1, SUBTRACT_ASSIGN,  false, false, false},
+    {  823,  822,          1, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823,  823,          0, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823,  824,         -1, SUBTRACT_ASSIGN,  false, true,  false},
+
+    {   40,   12,  40 *   12, MULTIPLY,         true,  false, false},
+    {   23,   -8,  23 *   -8, MULTIPLY,         false, true,  true},
+    {   40,   12,          1, MULTIPLY,         false, false, false},
+    {   18,    4,  18 *    4, MULTIPLY_ASSIGN,  true,  false, false},
+    {    2, -232,   2 * -232, MULTIPLY_ASSIGN,  false, true,  true},
+    {   18,    4,          1, MULTIPLY_ASSIGN,  false, false, false},
+
+    {  900,    5, 900 /    5, DIVIDE,           true,  false, false},
+    {  900,   -5, 900 /   -5, DIVIDE,           false, true,  true},
+    {  900,  900, 900 /  900, DIVIDE,           true,  false, false},
+    {  900,  901,          0, DIVIDE,           true,  false, false},
+    {  900,  900,          2, DIVIDE,           false, false, false},
+    {  480,   20, 480 /   20, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  -20, 480 /  -20, DIVIDE_ASSIGN,    false, true,  true},
+    {  480,  480, 480 /  480, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  481,          0, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  480,          2, DIVIDE_ASSIGN,    false, false, false},
+
+    {  901,  900,          1, MODULO,           true,  false, false},
+    {  901,  900,          2, MODULO,           false, false, false},
+    {   43,   43,          0, MODULO,           true,  false, false},
+    {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
+    {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
+    {   43,   43,          0, MODULO_ASSIGN,    true,  false, false},
+
+    {  33,     0,         34, INCREMENT,        true,  false, false},
+    {  33,     0,         33, INCREMENT,        false, false, false},
+    {   0,     0,          1, INCREMENT,        true,  false, false},
+    {  33,     0,         32, DECREMENT,        true,  false, false},
+    {  33,     0,         33, DECREMENT,        false, false, false},
+    {   0,     0,          0, DECREMENT,        false, true,  false}
+  };
 
 template<>
 const NonNegativeInteger::value_type NumericTest<NonNegativeInteger>::error(0);

--- a/ome-xml/src/test/cpp/non-negative-long.cpp
+++ b/ome-xml/src/test/cpp/non-negative-long.cpp
@@ -46,110 +46,99 @@ using ome::xml::model::primitives::NonNegativeLong;
 
 INSTANTIATE_TYPED_TEST_CASE_P(NonNegativeLong, NumericTest, NonNegativeLong);
 
-namespace
-{
-
-  NumericTest<NonNegativeLong>::test_str init_strings[] =
-    { // str        pos         strpass pospass
-      {"743544628", 743544628L, true,   true},
-      {"23",                23, true,   true},
-      {"-1",                -1, false,  false},
-      {"-42",              -42, false,  false},
-      {"1",                -53, true,   false},
-      {"82",                82, true,   true},
-      {"0",                  0,  true,  true},
-      {"invalid",            1,  false, true},
-    };
-
-  NumericTest<NonNegativeLong>::test_op init_ops[] =
-    { // v1   v2    expected    operation         pass   except rhsexcept
-      {   23,   23,          1, EQUAL,            true,  false, false},
-      {   23,  432,          0, EQUAL,            false, false, false},
-      {   23,   35,          1, NOT_EQUAL,        true,  false, false},
-      {   54,   54,          0, NOT_EQUAL,        false, false, false},
-
-      { 5432, 8272,          1, LESS,             true,  false, false},
-      {  534,  534,          0, LESS,             false, false, false},
-      {  947,   34,          0, LESS,             false, false, false},
-      { 5432, 8272,          1, LESS_OR_EQUAL,    true,  false, false},
-      {  534,  534,          1, LESS_OR_EQUAL,    true,  false, false},
-      {  947,   34,          0, LESS_OR_EQUAL,    false, false, false},
-
-      {10873, 8420,          1, GREATER,          true,  false, false},
-      { 3622, 3622,          0, GREATER,          false, false, false},
-      {  872, 2701,          0, GREATER,          false, false, false},
-      {10873, 8420,          1, GREATER_OR_EQUAL, true,  false, false},
-      { 3622, 3622,          1, GREATER_OR_EQUAL, true,  false, false},
-      {  872, 2701,          0, GREATER_OR_EQUAL, false, false, false},
-
-      {  432,  743, 432 +  743, ADD,              true,  false, false},
-      {  432,  -74, 432 -   74, ADD,              true,  false, true},
-      {  432, -743, 432 -  743, ADD,              false, true,  true},
-      {  432,  743,          1, ADD,              false, false, false},
-      {  823,   93, 823 +   93, ADD_ASSIGN,       true,  false, false},
-      {  823,  -93, 823 -   93, ADD_ASSIGN,       true,  false, true},
-      {  823, -932, 823 -  932, ADD_ASSIGN,       false, true,  true},
-      {  823,   93,          1, ADD_ASSIGN,       false, false, false},
-
-      {  432,  285, 432 -  285, SUBTRACT,         true,  false, false},
-      {  432, -285, 432 +  285, SUBTRACT,         true,  false, true},
-      {  432,  763, 432 -  763, SUBTRACT,         false, true,  false},
-      {  432,  285,          1, SUBTRACT,         false, false, false},
-      {  432,  431,          1, SUBTRACT,         true,  false, false},
-      {  432,  432,          0, SUBTRACT,         true,  false, false},
-      {  432,  433,         -1, SUBTRACT,         false, true,  false},
-      {  823,   93, 823 -   93, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823, -932, 823 +  932, SUBTRACT_ASSIGN,  true,  false, true},
-      {  823, 1393, 823 - 1393, SUBTRACT_ASSIGN,  false, true,  false},
-      {  823,   93,          1, SUBTRACT_ASSIGN,  false, false, false},
-      {  823,  822,          1, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823,  823,          0, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823,  824,         -1, SUBTRACT_ASSIGN,  false, true,  false},
-
-      {   40,   12,  40 *   12, MULTIPLY,         true,  false, false},
-      {   23,   -8,  23 *   -8, MULTIPLY,         false, true,  true},
-      {   40,   12,          1, MULTIPLY,         false, false, false},
-      {   18,    4,  18 *    4, MULTIPLY_ASSIGN,  true,  false, false},
-      {    2, -232,   2 * -232, MULTIPLY_ASSIGN,  false, true,  true},
-      {   18,    4,          1, MULTIPLY_ASSIGN,  false, false, false},
-
-      {  900,    5, 900 /    5, DIVIDE,           true,  false, false},
-      {  900,   -5, 900 /   -5, DIVIDE,           false, true,  true},
-      {  900,  900, 900 /  900, DIVIDE,           true,  false, false},
-      {  900,  901,          0, DIVIDE,           true,  false, false},
-      {  900,  900,          2, DIVIDE,           false, false, false},
-      {  480,   20, 480 /   20, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  -20, 480 /  -20, DIVIDE_ASSIGN,    false, true,  true},
-      {  480,  480, 480 /  480, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  481,          0, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  480,          2, DIVIDE_ASSIGN,    false, false, false},
-
-      {  901,  900,          1, MODULO,           true,  false, false},
-      {  901,  900,          2, MODULO,           false, false, false},
-      {   43,   43,          0, MODULO,           true,  false, false},
-      {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
-      {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
-      {   43,   43,          0, MODULO_ASSIGN,    true,  false, false},
-
-      {  33,     0,         34, INCREMENT,        true,  false, false},
-      {  33,     0,         33, INCREMENT,        false, false, false},
-      {   0,     0,          1, INCREMENT,        true,  false, false},
-      {  33,     0,         32, DECREMENT,        true,  false, false},
-      {  33,     0,         33, DECREMENT,        false, false, false},
-      {   0,     0,          0, DECREMENT,        false, true,  false}
-    };
-
-}
-
 template<>
 const std::vector<NumericTest<NonNegativeLong>::test_str>
-NumericTest<NonNegativeLong>::strings(init_strings,
-                                      init_strings + boost::size(init_strings));
+NumericTest<NonNegativeLong>::strings =
+  { // str        pos         strpass pospass
+    {"743544628", 743544628L, true,   true},
+    {"23",                23, true,   true},
+    {"-1",                -1, false,  false},
+    {"-42",              -42, false,  false},
+    {"1",                -53, true,   false},
+    {"82",                82, true,   true},
+    {"0",                  0,  true,  true},
+    {"invalid",            1,  false, true},
+  };
 
 template<>
 const std::vector<NumericTest<NonNegativeLong>::test_op>
-NumericTest<NonNegativeLong>::ops(init_ops,
-                                  init_ops + boost::size(init_ops));
+NumericTest<NonNegativeLong>::ops =
+  { // v1   v2    expected    operation         pass   except rhsexcept
+    {   23,   23,          1, EQUAL,            true,  false, false},
+    {   23,  432,          0, EQUAL,            false, false, false},
+    {   23,   35,          1, NOT_EQUAL,        true,  false, false},
+    {   54,   54,          0, NOT_EQUAL,        false, false, false},
+
+    { 5432, 8272,          1, LESS,             true,  false, false},
+    {  534,  534,          0, LESS,             false, false, false},
+    {  947,   34,          0, LESS,             false, false, false},
+    { 5432, 8272,          1, LESS_OR_EQUAL,    true,  false, false},
+    {  534,  534,          1, LESS_OR_EQUAL,    true,  false, false},
+    {  947,   34,          0, LESS_OR_EQUAL,    false, false, false},
+
+    {10873, 8420,          1, GREATER,          true,  false, false},
+    { 3622, 3622,          0, GREATER,          false, false, false},
+    {  872, 2701,          0, GREATER,          false, false, false},
+    {10873, 8420,          1, GREATER_OR_EQUAL, true,  false, false},
+    { 3622, 3622,          1, GREATER_OR_EQUAL, true,  false, false},
+    {  872, 2701,          0, GREATER_OR_EQUAL, false, false, false},
+
+    {  432,  743, 432 +  743, ADD,              true,  false, false},
+    {  432,  -74, 432 -   74, ADD,              true,  false, true},
+    {  432, -743, 432 -  743, ADD,              false, true,  true},
+    {  432,  743,          1, ADD,              false, false, false},
+    {  823,   93, 823 +   93, ADD_ASSIGN,       true,  false, false},
+    {  823,  -93, 823 -   93, ADD_ASSIGN,       true,  false, true},
+    {  823, -932, 823 -  932, ADD_ASSIGN,       false, true,  true},
+    {  823,   93,          1, ADD_ASSIGN,       false, false, false},
+
+    {  432,  285, 432 -  285, SUBTRACT,         true,  false, false},
+    {  432, -285, 432 +  285, SUBTRACT,         true,  false, true},
+    {  432,  763, 432 -  763, SUBTRACT,         false, true,  false},
+    {  432,  285,          1, SUBTRACT,         false, false, false},
+    {  432,  431,          1, SUBTRACT,         true,  false, false},
+    {  432,  432,          0, SUBTRACT,         true,  false, false},
+    {  432,  433,         -1, SUBTRACT,         false, true,  false},
+    {  823,   93, 823 -   93, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823, -932, 823 +  932, SUBTRACT_ASSIGN,  true,  false, true},
+    {  823, 1393, 823 - 1393, SUBTRACT_ASSIGN,  false, true,  false},
+    {  823,   93,          1, SUBTRACT_ASSIGN,  false, false, false},
+    {  823,  822,          1, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823,  823,          0, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823,  824,         -1, SUBTRACT_ASSIGN,  false, true,  false},
+
+    {   40,   12,  40 *   12, MULTIPLY,         true,  false, false},
+    {   23,   -8,  23 *   -8, MULTIPLY,         false, true,  true},
+    {   40,   12,          1, MULTIPLY,         false, false, false},
+    {   18,    4,  18 *    4, MULTIPLY_ASSIGN,  true,  false, false},
+    {    2, -232,   2 * -232, MULTIPLY_ASSIGN,  false, true,  true},
+    {   18,    4,          1, MULTIPLY_ASSIGN,  false, false, false},
+
+    {  900,    5, 900 /    5, DIVIDE,           true,  false, false},
+    {  900,   -5, 900 /   -5, DIVIDE,           false, true,  true},
+    {  900,  900, 900 /  900, DIVIDE,           true,  false, false},
+    {  900,  901,          0, DIVIDE,           true,  false, false},
+    {  900,  900,          2, DIVIDE,           false, false, false},
+    {  480,   20, 480 /   20, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  -20, 480 /  -20, DIVIDE_ASSIGN,    false, true,  true},
+    {  480,  480, 480 /  480, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  481,          0, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  480,          2, DIVIDE_ASSIGN,    false, false, false},
+
+    {  901,  900,          1, MODULO,           true,  false, false},
+    {  901,  900,          2, MODULO,           false, false, false},
+    {   43,   43,          0, MODULO,           true,  false, false},
+    {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
+    {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
+    {   43,   43,          0, MODULO_ASSIGN,    true,  false, false},
+
+    {  33,     0,         34, INCREMENT,        true,  false, false},
+    {  33,     0,         33, INCREMENT,        false, false, false},
+    {   0,     0,          1, INCREMENT,        true,  false, false},
+    {  33,     0,         32, DECREMENT,        true,  false, false},
+    {  33,     0,         33, DECREMENT,        false, false, false},
+    {   0,     0,          0, DECREMENT,        false, true,  false}
+  };
 
 template<>
 const NonNegativeLong::value_type NumericTest<NonNegativeLong>::error(0);

--- a/ome-xml/src/test/cpp/percent-fraction.cpp
+++ b/ome-xml/src/test/cpp/percent-fraction.cpp
@@ -132,103 +132,92 @@ struct OperationDecrement<PercentFraction>
 
 INSTANTIATE_TYPED_TEST_CASE_P(PercentFraction, NumericTest, PercentFraction);
 
-namespace
-{
-
-  NumericTest<PercentFraction>::test_str init_strings[] =
-    { // str     pos        strpass pospass
-      {"-42.12", -42.12F,   false,  false},
-      {"1.0",    -53.0F,    true,   false},
-      {"82.232",  82.232F,  false,  false},
-      {"0.23",     0.23F,   true,   true},
-      {"0.0001",   0.0001F, true,   true},
-      {"0",        0.0F,    true,   true},
-      {"1",        1.0F,    true,   true},
-      {"1.001",    1.001F,  false,  false},
-      {"1.0",     -0.1F,    true,   false},
-      {"invalid",  1.0F,    false,  true},
-    };
-
-  NumericTest<PercentFraction>::test_op init_ops[] =
-    { // v1      v2        expected           operation         pass   except rhsexcept
-      {0.0F,     0.0F,               1.0F,    EQUAL,            true,  false, false},
-      {1.0F,     1.0F,               1.0F,    EQUAL,            true,  false, false},
-      {0.822F,   0.822F,             1.0F,    EQUAL,            true,  false, false},
-      {0.230F,   0.230F,             1.0F,    EQUAL,            true,  false, false},
-      {0.23F,    0.48F,              0.0F,    EQUAL,            false, false, false},
-      {0.23F,    0.35F,              1.0F,    NOT_EQUAL,        true,  false, false},
-      {0.54F,    0.54F,              0.0F,    NOT_EQUAL,        false, false, false},
-
-      {0.5432F,  0.8272F,            1.0F,    LESS,             true,  false, false},
-      {0.5340F,  0.5340F,            0.0F,    LESS,             false, false, false},
-      {0.9470F,  0.340F,             0.0F,    LESS,             false, false, false},
-      {0.54320F, 0.82720F,           1.0F,    LESS_OR_EQUAL,    true,  false, false},
-      {0.5340F,  0.5340F,            1.0F,    LESS_OR_EQUAL,    true,  false, false},
-      {0.9470F,  0.340F,             0.0F,    LESS_OR_EQUAL,    false, false, false},
-
-      {0.908F,   0.842F,             1.0F,    GREATER,          true,  false, false},
-      {0.3622F,  0.3622F,            0.0F,    GREATER,          false, false, false},
-      {0.0872F,  0.2701F,            0.0F,    GREATER,          false, false, false},
-      {0.908F,   0.842F,             1.0F,    GREATER_OR_EQUAL, true,  false, false},
-      {0.3622F,  0.3622F,            1.0F,    GREATER_OR_EQUAL, true,  false, false},
-      {0.0872F,  0.2701F,            0.0F,    GREATER_OR_EQUAL, false, false, false},
-
-      {0.432F,   0.0743F,  0.432F +  0.0743F, ADD,              true,  false, false},
-      {0.432F,  -0.074F,   0.432F -  0.074F,  ADD,              true,  false, true},
-      {0.432F,  -0.743F,   0.432F -  0.743F,  ADD,              false, true,  true},
-      {0.432F,   0.8F,     0.432F +  0.8F,    ADD,              false, true,  false},
-      {0.432F,   0.0743F,            1.0F,    ADD,              false, false, false},
-      {0.823F,   0.093F,   0.823F +  0.093F,  ADD_ASSIGN,       true,  false, false},
-      {0.823F,  -0.093F,   0.823F -  0.093F,  ADD_ASSIGN,       true,  false, true},
-      {0.823F,  -0.932F,   0.823F -  0.932F,  ADD_ASSIGN,       false, true,  true},
-      {0.823F,   0.93F,    0.823F +  0.93F,   ADD_ASSIGN,       false, true,  false},
-      {0.823F,   0.093F,             0.1F,    ADD_ASSIGN,       false, false, false},
-
-      {0.432F,   0.285F,   0.432F -  0.285F,  SUBTRACT,         true,  false, false},
-      {0.432F,  -0.285F,   0.432F +  0.285F,  SUBTRACT,         true,  false, true},
-      {0.432F,   0.763F,   0.432F -  0.763F,  SUBTRACT,         false, true,  false},
-      {0.432F,   0.285F,             0.1F,    SUBTRACT,         false, false, false},
-      {0.432F,   0.431F,             0.001F,  SUBTRACT,         true,  false, false},
-      {0.432F,   0.432F,             0.0F,    SUBTRACT,         true,  false, false},
-      {0.432F,   0.433F,            -0.001F,  SUBTRACT,         false, true,  false},
-      {0.823F,   0.093F,   0.823F -  0.093F,  SUBTRACT_ASSIGN,  true,  false, false},
-      {0.823F,  -0.0932F,  0.823F +  0.0932F, SUBTRACT_ASSIGN,  true,  false, true},
-      {0.823F,   0.9139F,  0.823F -  0.9139F, SUBTRACT_ASSIGN,  false, true,  false},
-      {0.823F,   0.093F,             0.1F,    SUBTRACT_ASSIGN,  false, false, false},
-      {0.823F,   0.822F,             0.001F,  SUBTRACT_ASSIGN,  true,  false, false},
-      {0.823F,   0.823F,             0.0F,    SUBTRACT_ASSIGN,  true,  false, false},
-
-      {0.40F,    0.12F,    0.40F *   0.12F,   MULTIPLY,         true,  false, false},
-      {0.23F,   -0.8F,     0.23F *  -0.8F,    MULTIPLY,         false, true,  true},
-      {0.40F,    0.12F,              0.1F,    MULTIPLY,         false, false, false},
-      {0.18F,    0.4F,     0.18F *   0.4F,    MULTIPLY_ASSIGN,  true,  false, false},
-      {0.2F,    -0.232F,   0.2F  *  -0.232F,  MULTIPLY_ASSIGN,  false, true,  true},
-      {0.18F,    0.4F,               0.1F,    MULTIPLY_ASSIGN,  false, false, false},
-
-      {0.900F,   2.0F,     0.900F /  2.0F,    DIVIDE,           true,  false, true},
-      {0.900F,  -2.0F,     0.900F / -2.0F,    DIVIDE,           false, true,  true},
-      {0.2F,     0.900F,   0.2F   /  0.900F,  DIVIDE,           true,  false, false},
-      {0.5F,     0.901F,   0.5F   /  0.901F,  DIVIDE,           true,  false, false},
-      {0.5F,     0.900F,             0.2F,    DIVIDE,           false, false, false},
-      {0.480F,   2.0F,     0.480F /  2.0F,    DIVIDE_ASSIGN,    true,  false, true},
-      {0.480F,  -2.0F,     0.480F / -2.0F,    DIVIDE_ASSIGN,    false, true,  true},
-      {0.480F,   0.480F,   0.480F /  0.480F,  DIVIDE_ASSIGN,    true,  false, false},
-      {0.480F,   0.481F,   0.480F /  0.481F,  DIVIDE_ASSIGN,    true,  false, false},
-      {0.480F,   0.480F,             0.2F,    DIVIDE_ASSIGN,    false, false, false},
-
-    };
-
-}
-
 template<>
 const std::vector<NumericTest<PercentFraction>::test_str>
-NumericTest<PercentFraction>::strings(init_strings,
-                                      init_strings + boost::size(init_strings));
+NumericTest<PercentFraction>::strings =
+  { // str     pos        strpass pospass
+    {"-42.12", -42.12F,   false,  false},
+    {"1.0",    -53.0F,    true,   false},
+    {"82.232",  82.232F,  false,  false},
+    {"0.23",     0.23F,   true,   true},
+    {"0.0001",   0.0001F, true,   true},
+    {"0",        0.0F,    true,   true},
+    {"1",        1.0F,    true,   true},
+    {"1.001",    1.001F,  false,  false},
+    {"1.0",     -0.1F,    true,   false},
+    {"invalid",  1.0F,    false,  true},
+  };
 
 template<>
 const std::vector<NumericTest<PercentFraction>::test_op>
-NumericTest<PercentFraction>::ops(init_ops,
-                                  init_ops + boost::size(init_ops));
+NumericTest<PercentFraction>::ops =
+  { // v1      v2        expected           operation         pass   except rhsexcept
+    {0.0F,     0.0F,               1.0F,    EQUAL,            true,  false, false},
+    {1.0F,     1.0F,               1.0F,    EQUAL,            true,  false, false},
+    {0.822F,   0.822F,             1.0F,    EQUAL,            true,  false, false},
+    {0.230F,   0.230F,             1.0F,    EQUAL,            true,  false, false},
+    {0.23F,    0.48F,              0.0F,    EQUAL,            false, false, false},
+    {0.23F,    0.35F,              1.0F,    NOT_EQUAL,        true,  false, false},
+    {0.54F,    0.54F,              0.0F,    NOT_EQUAL,        false, false, false},
+
+    {0.5432F,  0.8272F,            1.0F,    LESS,             true,  false, false},
+    {0.5340F,  0.5340F,            0.0F,    LESS,             false, false, false},
+    {0.9470F,  0.340F,             0.0F,    LESS,             false, false, false},
+    {0.54320F, 0.82720F,           1.0F,    LESS_OR_EQUAL,    true,  false, false},
+    {0.5340F,  0.5340F,            1.0F,    LESS_OR_EQUAL,    true,  false, false},
+    {0.9470F,  0.340F,             0.0F,    LESS_OR_EQUAL,    false, false, false},
+
+    {0.908F,   0.842F,             1.0F,    GREATER,          true,  false, false},
+    {0.3622F,  0.3622F,            0.0F,    GREATER,          false, false, false},
+    {0.0872F,  0.2701F,            0.0F,    GREATER,          false, false, false},
+    {0.908F,   0.842F,             1.0F,    GREATER_OR_EQUAL, true,  false, false},
+    {0.3622F,  0.3622F,            1.0F,    GREATER_OR_EQUAL, true,  false, false},
+    {0.0872F,  0.2701F,            0.0F,    GREATER_OR_EQUAL, false, false, false},
+
+    {0.432F,   0.0743F,  0.432F +  0.0743F, ADD,              true,  false, false},
+    {0.432F,  -0.074F,   0.432F -  0.074F,  ADD,              true,  false, true},
+    {0.432F,  -0.743F,   0.432F -  0.743F,  ADD,              false, true,  true},
+    {0.432F,   0.8F,     0.432F +  0.8F,    ADD,              false, true,  false},
+    {0.432F,   0.0743F,            1.0F,    ADD,              false, false, false},
+    {0.823F,   0.093F,   0.823F +  0.093F,  ADD_ASSIGN,       true,  false, false},
+    {0.823F,  -0.093F,   0.823F -  0.093F,  ADD_ASSIGN,       true,  false, true},
+    {0.823F,  -0.932F,   0.823F -  0.932F,  ADD_ASSIGN,       false, true,  true},
+    {0.823F,   0.93F,    0.823F +  0.93F,   ADD_ASSIGN,       false, true,  false},
+    {0.823F,   0.093F,             0.1F,    ADD_ASSIGN,       false, false, false},
+
+    {0.432F,   0.285F,   0.432F -  0.285F,  SUBTRACT,         true,  false, false},
+    {0.432F,  -0.285F,   0.432F +  0.285F,  SUBTRACT,         true,  false, true},
+    {0.432F,   0.763F,   0.432F -  0.763F,  SUBTRACT,         false, true,  false},
+    {0.432F,   0.285F,             0.1F,    SUBTRACT,         false, false, false},
+    {0.432F,   0.431F,             0.001F,  SUBTRACT,         true,  false, false},
+    {0.432F,   0.432F,             0.0F,    SUBTRACT,         true,  false, false},
+    {0.432F,   0.433F,            -0.001F,  SUBTRACT,         false, true,  false},
+    {0.823F,   0.093F,   0.823F -  0.093F,  SUBTRACT_ASSIGN,  true,  false, false},
+    {0.823F,  -0.0932F,  0.823F +  0.0932F, SUBTRACT_ASSIGN,  true,  false, true},
+    {0.823F,   0.9139F,  0.823F -  0.9139F, SUBTRACT_ASSIGN,  false, true,  false},
+    {0.823F,   0.093F,             0.1F,    SUBTRACT_ASSIGN,  false, false, false},
+    {0.823F,   0.822F,             0.001F,  SUBTRACT_ASSIGN,  true,  false, false},
+    {0.823F,   0.823F,             0.0F,    SUBTRACT_ASSIGN,  true,  false, false},
+
+    {0.40F,    0.12F,    0.40F *   0.12F,   MULTIPLY,         true,  false, false},
+    {0.23F,   -0.8F,     0.23F *  -0.8F,    MULTIPLY,         false, true,  true},
+    {0.40F,    0.12F,              0.1F,    MULTIPLY,         false, false, false},
+    {0.18F,    0.4F,     0.18F *   0.4F,    MULTIPLY_ASSIGN,  true,  false, false},
+    {0.2F,    -0.232F,   0.2F  *  -0.232F,  MULTIPLY_ASSIGN,  false, true,  true},
+    {0.18F,    0.4F,               0.1F,    MULTIPLY_ASSIGN,  false, false, false},
+
+    {0.900F,   2.0F,     0.900F /  2.0F,    DIVIDE,           true,  false, true},
+    {0.900F,  -2.0F,     0.900F / -2.0F,    DIVIDE,           false, true,  true},
+    {0.2F,     0.900F,   0.2F   /  0.900F,  DIVIDE,           true,  false, false},
+    {0.5F,     0.901F,   0.5F   /  0.901F,  DIVIDE,           true,  false, false},
+    {0.5F,     0.900F,             0.2F,    DIVIDE,           false, false, false},
+    {0.480F,   2.0F,     0.480F /  2.0F,    DIVIDE_ASSIGN,    true,  false, true},
+    {0.480F,  -2.0F,     0.480F / -2.0F,    DIVIDE_ASSIGN,    false, true,  true},
+    {0.480F,   0.480F,   0.480F /  0.480F,  DIVIDE_ASSIGN,    true,  false, false},
+    {0.480F,   0.481F,   0.480F /  0.481F,  DIVIDE_ASSIGN,    true,  false, false},
+    {0.480F,   0.480F,             0.2F,    DIVIDE_ASSIGN,    false, false, false},
+
+  };
 
 template<>
 const PercentFraction::value_type NumericTest<PercentFraction>::error(0.0005F);

--- a/ome-xml/src/test/cpp/positive-float.cpp
+++ b/ome-xml/src/test/cpp/positive-float.cpp
@@ -133,94 +133,83 @@ struct OperationDecrement<PositiveFloat>
 
 INSTANTIATE_TYPED_TEST_CASE_P(PositiveFloat, NumericTest, PositiveFloat);
 
-namespace
-{
-
-  NumericTest<PositiveFloat>::test_str init_strings[] =
-    { // str     pos      strpass pospass
-      {"23",      23.0,   true,   true},
-      {"-42.12", -42.12,  false,  false},
-      {"1.0",    -53.0,   true,   false},
-      {"82.232",  82.232, true,   true},
-      {"0",        0,     false,  false},
-      {"1.0",      0.0,   true,   false},
-      {"invalid",  1.0,   false,  true},
-    };
-
-  NumericTest<PositiveFloat>::test_op init_ops[] =
-    { // v1   v2        expected        operation         pass   except rhsexcept
-      {   23.0,   23.0,            1.0, EQUAL,            true,  false, false},
-      {   23.0,  432.0,            0.0, EQUAL,            false, false, false},
-      {   23.0,   35.0,            1.0, NOT_EQUAL,        true,  false, false},
-      {   54.0,   54.0,            0.0, NOT_EQUAL,        false, false, false},
-
-      { 5432.0, 8272.0,            1.0, LESS,             true,  false, false},
-      {  534.0,  534.0,            0.0, LESS,             false, false, false},
-      {  947.0,   34.0,            0.0, LESS,             false, false, false},
-      { 5432.0, 8272.0,            1.0, LESS_OR_EQUAL,    true,  false, false},
-      {  534.0,  534.0,            1.0, LESS_OR_EQUAL,    true,  false, false},
-      {  947.0,   34.0,            0.0, LESS_OR_EQUAL,    false, false, false},
-
-      {10873.0, 8420.0,            1.0, GREATER,          true,  false, false},
-      { 3622.0, 3622.0,            0.0, GREATER,          false, false, false},
-      {  872.0, 2701.0,            0.0, GREATER,          false, false, false},
-      {10873.0, 8420.0,            1.0, GREATER_OR_EQUAL, true,  false, false},
-      { 3622.0, 3622.0,            1.0, GREATER_OR_EQUAL, true,  false, false},
-      {  872.0, 2701.0,            0.0, GREATER_OR_EQUAL, false, false, false},
-
-      {  432.0,  743.0, 432.0 +  743.0, ADD,              true,  false, false},
-      {  432.0,  -74.0, 432.0 -   74.0, ADD,              true,  false, true},
-      {  432.0, -743.0, 432.0 -  743.0, ADD,              false, true,  true},
-      {  432.0,  743.0,            1.0, ADD,              false, false, false},
-      {  823.0,   93.0, 823.0 +   93.0, ADD_ASSIGN,       true,  false, false},
-      {  823.0,  -93.0, 823.0 -   93.0, ADD_ASSIGN,       true,  false, true},
-      {  823.0, -932.0, 823.0 -  932.0, ADD_ASSIGN,       false, true,  true},
-      {  823.0,   93.0,            1.0, ADD_ASSIGN,       false, false, false},
-
-      {  432.0,  285.0, 432.0 -  285.0, SUBTRACT,         true,  false, false},
-      {  432.0, -285.0, 432.0 +  285.0, SUBTRACT,         true,  false, true},
-      {  432.0,  763.0, 432.0 -  763.0, SUBTRACT,         false, true,  false},
-      {  432.0,  285.0,            1.0, SUBTRACT,         false, false, false},
-      {  432.0,  431.0,            1.0, SUBTRACT,         true,  false, false},
-      {  432.0,  432.0,            0.0, SUBTRACT,         false, true,  false},
-      {  823.0,   93.0, 823.0 -   93.0, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823.0, -932.0, 823.0 +  932.0, SUBTRACT_ASSIGN,  true,  false, true},
-      {  823.0, 1393.0, 823.0 - 1393.0, SUBTRACT_ASSIGN,  false, true,  false},
-      {  823.0,   93.0,            1.0, SUBTRACT_ASSIGN,  false, false, false},
-      {  823.0,  822.0,            1.0, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823.0,  823.0,            0.0, SUBTRACT_ASSIGN,  false, true,  false},
-
-      {   40.0,   12.0,  40.0 *   12.0, MULTIPLY,         true,  false, false},
-      {   23.0,   -8.0,  23.0 *   -8.0, MULTIPLY,         false, true,  true},
-      {   40.0,   12.0,            1.0, MULTIPLY,         false, false, false},
-      {   18.0,    4.0,  18.0 *    4.0, MULTIPLY_ASSIGN,  true,  false, false},
-      {    2.0, -232.0,   2.0 * -232.0, MULTIPLY_ASSIGN,  false, true,  true},
-      {   18.0,    4.0,            1.0, MULTIPLY_ASSIGN,  false, false, false},
-
-      {  900.0,    5.0, 900.0 /    5.0, DIVIDE,           true,  false, false},
-      {  900.0,   -5.0, 900.0 /   -5.0, DIVIDE,           false, true,  true},
-      {  900.0,  900.0, 900.0 /  900.0, DIVIDE,           true,  false, false},
-      {  900.0,  901.0, 900.1 /  901.0, DIVIDE,           true,  false, false},
-      {  900.0,  900.0,            2.0, DIVIDE,           false, false, false},
-      {  480.0,   20.0, 480.0 /   20.0, DIVIDE_ASSIGN,    true,  false, false},
-      {  480.0,  -20.0, 480.0 /  -20.0, DIVIDE_ASSIGN,    false, true,  true},
-      {  480.0,  480.0, 480.0 /  480.0, DIVIDE_ASSIGN,    true,  false, false},
-      {  480.0,  481.0, 480.0 /  481.0, DIVIDE_ASSIGN,    true,  false, false},
-      {  480.0,  480.0,            2.0, DIVIDE_ASSIGN,    false, false, false},
-
-    };
-
-}
-
 template<>
 const std::vector<NumericTest<PositiveFloat>::test_str>
-NumericTest<PositiveFloat>::strings(init_strings,
-                                    init_strings + boost::size(init_strings));
+NumericTest<PositiveFloat>::strings =
+  { // str     pos      strpass pospass
+    {"23",      23.0,   true,   true},
+    {"-42.12", -42.12,  false,  false},
+    {"1.0",    -53.0,   true,   false},
+    {"82.232",  82.232, true,   true},
+    {"0",        0,     false,  false},
+    {"1.0",      0.0,   true,   false},
+    {"invalid",  1.0,   false,  true},
+  };
 
 template<>
 const std::vector<NumericTest<PositiveFloat>::test_op>
-NumericTest<PositiveFloat>::ops(init_ops,
-                                init_ops + boost::size(init_ops));
+NumericTest<PositiveFloat>::ops =
+  { // v1   v2        expected        operation         pass   except rhsexcept
+    {   23.0,   23.0,            1.0, EQUAL,            true,  false, false},
+    {   23.0,  432.0,            0.0, EQUAL,            false, false, false},
+    {   23.0,   35.0,            1.0, NOT_EQUAL,        true,  false, false},
+    {   54.0,   54.0,            0.0, NOT_EQUAL,        false, false, false},
+
+    { 5432.0, 8272.0,            1.0, LESS,             true,  false, false},
+    {  534.0,  534.0,            0.0, LESS,             false, false, false},
+    {  947.0,   34.0,            0.0, LESS,             false, false, false},
+    { 5432.0, 8272.0,            1.0, LESS_OR_EQUAL,    true,  false, false},
+    {  534.0,  534.0,            1.0, LESS_OR_EQUAL,    true,  false, false},
+    {  947.0,   34.0,            0.0, LESS_OR_EQUAL,    false, false, false},
+
+    {10873.0, 8420.0,            1.0, GREATER,          true,  false, false},
+    { 3622.0, 3622.0,            0.0, GREATER,          false, false, false},
+    {  872.0, 2701.0,            0.0, GREATER,          false, false, false},
+    {10873.0, 8420.0,            1.0, GREATER_OR_EQUAL, true,  false, false},
+    { 3622.0, 3622.0,            1.0, GREATER_OR_EQUAL, true,  false, false},
+    {  872.0, 2701.0,            0.0, GREATER_OR_EQUAL, false, false, false},
+
+    {  432.0,  743.0, 432.0 +  743.0, ADD,              true,  false, false},
+    {  432.0,  -74.0, 432.0 -   74.0, ADD,              true,  false, true},
+    {  432.0, -743.0, 432.0 -  743.0, ADD,              false, true,  true},
+    {  432.0,  743.0,            1.0, ADD,              false, false, false},
+    {  823.0,   93.0, 823.0 +   93.0, ADD_ASSIGN,       true,  false, false},
+    {  823.0,  -93.0, 823.0 -   93.0, ADD_ASSIGN,       true,  false, true},
+    {  823.0, -932.0, 823.0 -  932.0, ADD_ASSIGN,       false, true,  true},
+    {  823.0,   93.0,            1.0, ADD_ASSIGN,       false, false, false},
+
+    {  432.0,  285.0, 432.0 -  285.0, SUBTRACT,         true,  false, false},
+    {  432.0, -285.0, 432.0 +  285.0, SUBTRACT,         true,  false, true},
+    {  432.0,  763.0, 432.0 -  763.0, SUBTRACT,         false, true,  false},
+    {  432.0,  285.0,            1.0, SUBTRACT,         false, false, false},
+    {  432.0,  431.0,            1.0, SUBTRACT,         true,  false, false},
+    {  432.0,  432.0,            0.0, SUBTRACT,         false, true,  false},
+    {  823.0,   93.0, 823.0 -   93.0, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823.0, -932.0, 823.0 +  932.0, SUBTRACT_ASSIGN,  true,  false, true},
+    {  823.0, 1393.0, 823.0 - 1393.0, SUBTRACT_ASSIGN,  false, true,  false},
+    {  823.0,   93.0,            1.0, SUBTRACT_ASSIGN,  false, false, false},
+    {  823.0,  822.0,            1.0, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823.0,  823.0,            0.0, SUBTRACT_ASSIGN,  false, true,  false},
+
+    {   40.0,   12.0,  40.0 *   12.0, MULTIPLY,         true,  false, false},
+    {   23.0,   -8.0,  23.0 *   -8.0, MULTIPLY,         false, true,  true},
+    {   40.0,   12.0,            1.0, MULTIPLY,         false, false, false},
+    {   18.0,    4.0,  18.0 *    4.0, MULTIPLY_ASSIGN,  true,  false, false},
+    {    2.0, -232.0,   2.0 * -232.0, MULTIPLY_ASSIGN,  false, true,  true},
+    {   18.0,    4.0,            1.0, MULTIPLY_ASSIGN,  false, false, false},
+
+    {  900.0,    5.0, 900.0 /    5.0, DIVIDE,           true,  false, false},
+    {  900.0,   -5.0, 900.0 /   -5.0, DIVIDE,           false, true,  true},
+    {  900.0,  900.0, 900.0 /  900.0, DIVIDE,           true,  false, false},
+    {  900.0,  901.0, 900.1 /  901.0, DIVIDE,           true,  false, false},
+    {  900.0,  900.0,            2.0, DIVIDE,           false, false, false},
+    {  480.0,   20.0, 480.0 /   20.0, DIVIDE_ASSIGN,    true,  false, false},
+    {  480.0,  -20.0, 480.0 /  -20.0, DIVIDE_ASSIGN,    false, true,  true},
+    {  480.0,  480.0, 480.0 /  480.0, DIVIDE_ASSIGN,    true,  false, false},
+    {  480.0,  481.0, 480.0 /  481.0, DIVIDE_ASSIGN,    true,  false, false},
+    {  480.0,  480.0,            2.0, DIVIDE_ASSIGN,    false, false, false},
+
+  };
 
 template<>
 const PositiveFloat::value_type NumericTest<PositiveFloat>::error(0.0005);

--- a/ome-xml/src/test/cpp/positive-integer.cpp
+++ b/ome-xml/src/test/cpp/positive-integer.cpp
@@ -46,107 +46,96 @@ using ome::xml::model::primitives::PositiveInteger;
 
 INSTANTIATE_TYPED_TEST_CASE_P(PositiveInteger, NumericTest, PositiveInteger);
 
-namespace
-{
-
-  NumericTest<PositiveInteger>::test_str init_strings[] =
-    { // str      pos  strpass pospass
-      {"23",       23, true,   true},
-      {"-42",     -42, false,  false},
-      {"1",       -53, true,   false},
-      {"82",       82, true,   true},
-      {"0",         0, false,  false},
-      {"1",         0, true,   false},
-      {"invalid",   1, false,  true},
-    };
-
-  NumericTest<PositiveInteger>::test_op init_ops[] =
-    { // v1   v2    expected    operation         pass   except rhsexcept
-      {   23,   23,          1, EQUAL,            true,  false, false},
-      {   23,  432,          0, EQUAL,            false, false, false},
-      {   23,   35,          1, NOT_EQUAL,        true,  false, false},
-      {   54,   54,          0, NOT_EQUAL,        false, false, false},
-
-      { 5432, 8272,          1, LESS,             true,  false, false},
-      {  534,  534,          0, LESS,             false, false, false},
-      {  947,   34,          0, LESS,             false, false, false},
-      { 5432, 8272,          1, LESS_OR_EQUAL,    true,  false, false},
-      {  534,  534,          1, LESS_OR_EQUAL,    true,  false, false},
-      {  947,   34,          0, LESS_OR_EQUAL,    false, false, false},
-
-      {10873, 8420,          1, GREATER,          true,  false, false},
-      { 3622, 3622,          0, GREATER,          false, false, false},
-      {  872, 2701,          0, GREATER,          false, false, false},
-      {10873, 8420,          1, GREATER_OR_EQUAL, true,  false, false},
-      { 3622, 3622,          1, GREATER_OR_EQUAL, true,  false, false},
-      {  872, 2701,          0, GREATER_OR_EQUAL, false, false, false},
-
-      {  432,  743, 432 +  743, ADD,              true,  false, false},
-      {  432,  -74, 432 -   74, ADD,              true,  false, true},
-      {  432, -743, 432 -  743, ADD,              false, true,  true},
-      {  432,  743,          1, ADD,              false, false, false},
-      {  823,   93, 823 +   93, ADD_ASSIGN,       true,  false, false},
-      {  823,  -93, 823 -   93, ADD_ASSIGN,       true,  false, true},
-      {  823, -932, 823 -  932, ADD_ASSIGN,       false, true,  true},
-      {  823,   93,          1, ADD_ASSIGN,       false, false, false},
-
-      {  432,  285, 432 -  285, SUBTRACT,         true,  false, false},
-      {  432, -285, 432 +  285, SUBTRACT,         true,  false, true},
-      {  432,  763, 432 -  763, SUBTRACT,         false, true,  false},
-      {  432,  285,          1, SUBTRACT,         false, false, false},
-      {  432,  431,          1, SUBTRACT,         true,  false, false},
-      {  432,  432,          0, SUBTRACT,         false, true,  false},
-      {  823,   93, 823 -   93, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823, -932, 823 +  932, SUBTRACT_ASSIGN,  true,  false, true},
-      {  823, 1393, 823 - 1393, SUBTRACT_ASSIGN,  false, true,  false},
-      {  823,   93,          1, SUBTRACT_ASSIGN,  false, false, false},
-      {  823,  822,          1, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823,  823,          0, SUBTRACT_ASSIGN,  false, true,  false},
-
-      {   40,   12,  40 *   12, MULTIPLY,         true,  false, false},
-      {   23,   -8,  23 *   -8, MULTIPLY,         false, true,  true},
-      {   40,   12,          1, MULTIPLY,         false, false, false},
-      {   18,    4,  18 *    4, MULTIPLY_ASSIGN,  true,  false, false},
-      {    2, -232,   2 * -232, MULTIPLY_ASSIGN,  false, true,  true},
-      {   18,    4,          1, MULTIPLY_ASSIGN,  false, false, false},
-
-      {  900,    5, 900 /    5, DIVIDE,           true,  false, false},
-      {  900,   -5, 900 /   -5, DIVIDE,           false, true,  true},
-      {  900,  900, 900 /  900, DIVIDE,           true,  false, false},
-      {  900,  901,          0, DIVIDE,           false, true,  false},
-      {  900,  900,          2, DIVIDE,           false, false, false},
-      {  480,   20, 480 /   20, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  -20, 480 /  -20, DIVIDE_ASSIGN,    false, true,  true},
-      {  480,  480, 480 /  480, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  481,          0, DIVIDE_ASSIGN,    false, true,  false},
-      {  480,  480,          2, DIVIDE_ASSIGN,    false, false, false},
-
-      {  901,  900,          1, MODULO,           true,  false, false},
-      {  901,  900,          2, MODULO,           false, false, false},
-      {   43,   43,          0, MODULO,           false, true,  false},
-      {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
-      {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
-      {   43,   43,          0, MODULO_ASSIGN,    false, true,  false},
-
-      {  33,     1,         34, INCREMENT,        true,  false, false},
-      {  33,     1,         33, INCREMENT,        false, false, false},
-      {   1,     1,          2, INCREMENT,        true,  false, false},
-      {  33,     1,         32, DECREMENT,        true,  false, false},
-      {  33,     1,         33, DECREMENT,        false, false, false},
-      {   1,     1,          0, DECREMENT,        false, true,  false}
-    };
-
-}
-
 template<>
 const std::vector<NumericTest<PositiveInteger>::test_str>
-NumericTest<PositiveInteger>::strings(init_strings,
-                                      init_strings + boost::size(init_strings));
+NumericTest<PositiveInteger>::strings =
+  { // str      pos  strpass pospass
+    {"23",       23, true,   true},
+    {"-42",     -42, false,  false},
+    {"1",       -53, true,   false},
+    {"82",       82, true,   true},
+    {"0",         0, false,  false},
+    {"1",         0, true,   false},
+    {"invalid",   1, false,  true},
+  };
 
 template<>
 const std::vector<NumericTest<PositiveInteger>::test_op>
-NumericTest<PositiveInteger>::ops(init_ops,
-                                  init_ops + boost::size(init_ops));
+NumericTest<PositiveInteger>::ops =
+  { // v1   v2    expected    operation         pass   except rhsexcept
+    {   23,   23,          1, EQUAL,            true,  false, false},
+    {   23,  432,          0, EQUAL,            false, false, false},
+    {   23,   35,          1, NOT_EQUAL,        true,  false, false},
+    {   54,   54,          0, NOT_EQUAL,        false, false, false},
+
+    { 5432, 8272,          1, LESS,             true,  false, false},
+    {  534,  534,          0, LESS,             false, false, false},
+    {  947,   34,          0, LESS,             false, false, false},
+    { 5432, 8272,          1, LESS_OR_EQUAL,    true,  false, false},
+    {  534,  534,          1, LESS_OR_EQUAL,    true,  false, false},
+    {  947,   34,          0, LESS_OR_EQUAL,    false, false, false},
+
+    {10873, 8420,          1, GREATER,          true,  false, false},
+    { 3622, 3622,          0, GREATER,          false, false, false},
+    {  872, 2701,          0, GREATER,          false, false, false},
+    {10873, 8420,          1, GREATER_OR_EQUAL, true,  false, false},
+    { 3622, 3622,          1, GREATER_OR_EQUAL, true,  false, false},
+    {  872, 2701,          0, GREATER_OR_EQUAL, false, false, false},
+
+    {  432,  743, 432 +  743, ADD,              true,  false, false},
+    {  432,  -74, 432 -   74, ADD,              true,  false, true},
+    {  432, -743, 432 -  743, ADD,              false, true,  true},
+    {  432,  743,          1, ADD,              false, false, false},
+    {  823,   93, 823 +   93, ADD_ASSIGN,       true,  false, false},
+    {  823,  -93, 823 -   93, ADD_ASSIGN,       true,  false, true},
+    {  823, -932, 823 -  932, ADD_ASSIGN,       false, true,  true},
+    {  823,   93,          1, ADD_ASSIGN,       false, false, false},
+
+    {  432,  285, 432 -  285, SUBTRACT,         true,  false, false},
+    {  432, -285, 432 +  285, SUBTRACT,         true,  false, true},
+    {  432,  763, 432 -  763, SUBTRACT,         false, true,  false},
+    {  432,  285,          1, SUBTRACT,         false, false, false},
+    {  432,  431,          1, SUBTRACT,         true,  false, false},
+    {  432,  432,          0, SUBTRACT,         false, true,  false},
+    {  823,   93, 823 -   93, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823, -932, 823 +  932, SUBTRACT_ASSIGN,  true,  false, true},
+    {  823, 1393, 823 - 1393, SUBTRACT_ASSIGN,  false, true,  false},
+    {  823,   93,          1, SUBTRACT_ASSIGN,  false, false, false},
+    {  823,  822,          1, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823,  823,          0, SUBTRACT_ASSIGN,  false, true,  false},
+
+    {   40,   12,  40 *   12, MULTIPLY,         true,  false, false},
+    {   23,   -8,  23 *   -8, MULTIPLY,         false, true,  true},
+    {   40,   12,          1, MULTIPLY,         false, false, false},
+    {   18,    4,  18 *    4, MULTIPLY_ASSIGN,  true,  false, false},
+    {    2, -232,   2 * -232, MULTIPLY_ASSIGN,  false, true,  true},
+    {   18,    4,          1, MULTIPLY_ASSIGN,  false, false, false},
+
+    {  900,    5, 900 /    5, DIVIDE,           true,  false, false},
+    {  900,   -5, 900 /   -5, DIVIDE,           false, true,  true},
+    {  900,  900, 900 /  900, DIVIDE,           true,  false, false},
+    {  900,  901,          0, DIVIDE,           false, true,  false},
+    {  900,  900,          2, DIVIDE,           false, false, false},
+    {  480,   20, 480 /   20, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  -20, 480 /  -20, DIVIDE_ASSIGN,    false, true,  true},
+    {  480,  480, 480 /  480, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  481,          0, DIVIDE_ASSIGN,    false, true,  false},
+    {  480,  480,          2, DIVIDE_ASSIGN,    false, false, false},
+
+    {  901,  900,          1, MODULO,           true,  false, false},
+    {  901,  900,          2, MODULO,           false, false, false},
+    {   43,   43,          0, MODULO,           false, true,  false},
+    {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
+    {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
+    {   43,   43,          0, MODULO_ASSIGN,    false, true,  false},
+
+    {  33,     1,         34, INCREMENT,        true,  false, false},
+    {  33,     1,         33, INCREMENT,        false, false, false},
+    {   1,     1,          2, INCREMENT,        true,  false, false},
+    {  33,     1,         32, DECREMENT,        true,  false, false},
+    {  33,     1,         33, DECREMENT,        false, false, false},
+    {   1,     1,          0, DECREMENT,        false, true,  false}
+  };
 
 template<>
 const PositiveInteger::value_type NumericTest<PositiveInteger>::error(0);

--- a/ome-xml/src/test/cpp/positive-long.cpp
+++ b/ome-xml/src/test/cpp/positive-long.cpp
@@ -46,108 +46,97 @@ using ome::xml::model::primitives::PositiveLong;
 
 INSTANTIATE_TYPED_TEST_CASE_P(PositiveLong, NumericTest, PositiveLong);
 
-namespace
-{
-
-  NumericTest<PositiveLong>::test_str init_strings[] =
-    { // str        pos         strpass pospass
-      {"743544628", 743544628L, true,   true},
-      {"23",                23, true,   true},
-      {"-42",              -42, false,  false},
-      {"1",                -53, true,   false},
-      {"82",                82, true,   true},
-      {"0",                  0, false,  false},
-      {"1",                  0, true,   false},
-      {"invalid",            1, false,  true},
-    };
-
-  NumericTest<PositiveLong>::test_op init_ops[] =
-    { // v1   v2    expected    operation         pass   except rhsexcept
-      {   23,   23,          1, EQUAL,            true,  false, false},
-      {   23,  432,          0, EQUAL,            false, false, false},
-      {   23,   35,          1, NOT_EQUAL,        true,  false, false},
-      {   54,   54,          0, NOT_EQUAL,        false, false, false},
-
-      { 5432, 8272,          1, LESS,             true,  false, false},
-      {  534,  534,          0, LESS,             false, false, false},
-      {  947,   34,          0, LESS,             false, false, false},
-      { 5432, 8272,          1, LESS_OR_EQUAL,    true,  false, false},
-      {  534,  534,          1, LESS_OR_EQUAL,    true,  false, false},
-      {  947,   34,          0, LESS_OR_EQUAL,    false, false, false},
-
-      {10873, 8420,          1, GREATER,          true,  false, false},
-      { 3622, 3622,          0, GREATER,          false, false, false},
-      {  872, 2701,          0, GREATER,          false, false, false},
-      {10873, 8420,          1, GREATER_OR_EQUAL, true,  false, false},
-      { 3622, 3622,          1, GREATER_OR_EQUAL, true,  false, false},
-      {  872, 2701,          0, GREATER_OR_EQUAL, false, false, false},
-
-      {  432,  743, 432 +  743, ADD,              true,  false, false},
-      {  432,  -74, 432 -   74, ADD,              true,  false, true},
-      {  432, -743, 432 -  743, ADD,              false, true,  true},
-      {  432,  743,          1, ADD,              false, false, false},
-      {  823,   93, 823 +   93, ADD_ASSIGN,       true,  false, false},
-      {  823,  -93, 823 -   93, ADD_ASSIGN,       true,  false, true},
-      {  823, -932, 823 -  932, ADD_ASSIGN,       false, true,  true},
-      {  823,   93,          1, ADD_ASSIGN,       false, false, false},
-
-      {  432,  285, 432 -  285, SUBTRACT,         true,  false, false},
-      {  432, -285, 432 +  285, SUBTRACT,         true,  false, true},
-      {  432,  763, 432 -  763, SUBTRACT,         false, true,  false},
-      {  432,  285,          1, SUBTRACT,         false, false, false},
-      {  432,  431,          1, SUBTRACT,         true,  false, false},
-      {  432,  432,          0, SUBTRACT,         false, true,  false},
-      {  823,   93, 823 -   93, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823, -932, 823 +  932, SUBTRACT_ASSIGN,  true,  false, true},
-      {  823, 1393, 823 - 1393, SUBTRACT_ASSIGN,  false, true,  false},
-      {  823,   93,          1, SUBTRACT_ASSIGN,  false, false, false},
-      {  823,  822,          1, SUBTRACT_ASSIGN,  true,  false, false},
-      {  823,  823,          0, SUBTRACT_ASSIGN,  false, true,  false},
-
-      {   40,   12,  40 *   12, MULTIPLY,         true,  false, false},
-      {   23,   -8,  23 *   -8, MULTIPLY,         false, true,  true},
-      {   40,   12,          1, MULTIPLY,         false, false, false},
-      {   18,    4,  18 *    4, MULTIPLY_ASSIGN,  true,  false, false},
-      {    2, -232,   2 * -232, MULTIPLY_ASSIGN,  false, true,  true},
-      {   18,    4,          1, MULTIPLY_ASSIGN,  false, false, false},
-
-      {  900,    5, 900 /    5, DIVIDE,           true,  false, false},
-      {  900,   -5, 900 /   -5, DIVIDE,           false, true,  true},
-      {  900,  900, 900 /  900, DIVIDE,           true,  false, false},
-      {  900,  901,          0, DIVIDE,           false, true,  false},
-      {  900,  900,          2, DIVIDE,           false, false, false},
-      {  480,   20, 480 /   20, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  -20, 480 /  -20, DIVIDE_ASSIGN,    false, true,  true},
-      {  480,  480, 480 /  480, DIVIDE_ASSIGN,    true,  false, false},
-      {  480,  481,          0, DIVIDE_ASSIGN,    false, true,  false},
-      {  480,  480,          2, DIVIDE_ASSIGN,    false, false, false},
-
-      {  901,  900,          1, MODULO,           true,  false, false},
-      {  901,  900,          2, MODULO,           false, false, false},
-      {   43,   43,          0, MODULO,           false, true,  false},
-      {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
-      {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
-      {   43,   43,          0, MODULO_ASSIGN,    false, true,  false},
-
-      {  33,     1,         34, INCREMENT,        true,  false, false},
-      {  33,     1,         33, INCREMENT,        false, false, false},
-      {   1,     1,          2, INCREMENT,        true,  false, false},
-      {  33,     1,         32, DECREMENT,        true,  false, false},
-      {  33,     1,         33, DECREMENT,        false, false, false},
-      {   1,     1,          0, DECREMENT,        false, true,  false}
-    };
-
-}
-
 template<>
 const std::vector<NumericTest<PositiveLong>::test_str>
-NumericTest<PositiveLong>::strings(init_strings,
-                                   init_strings + boost::size(init_strings));
+NumericTest<PositiveLong>::strings =
+  { // str        pos         strpass pospass
+    {"743544628", 743544628L, true,   true},
+    {"23",                23, true,   true},
+    {"-42",              -42, false,  false},
+    {"1",                -53, true,   false},
+    {"82",                82, true,   true},
+    {"0",                  0, false,  false},
+    {"1",                  0, true,   false},
+    {"invalid",            1, false,  true},
+  };
 
 template<>
 const std::vector<NumericTest<PositiveLong>::test_op>
-NumericTest<PositiveLong>::ops(init_ops,
-                               init_ops + (sizeof(init_ops) / sizeof(init_ops[0])));
+NumericTest<PositiveLong>::ops =
+  { // v1   v2    expected    operation         pass   except rhsexcept
+    {   23,   23,          1, EQUAL,            true,  false, false},
+    {   23,  432,          0, EQUAL,            false, false, false},
+    {   23,   35,          1, NOT_EQUAL,        true,  false, false},
+    {   54,   54,          0, NOT_EQUAL,        false, false, false},
+
+    { 5432, 8272,          1, LESS,             true,  false, false},
+    {  534,  534,          0, LESS,             false, false, false},
+    {  947,   34,          0, LESS,             false, false, false},
+    { 5432, 8272,          1, LESS_OR_EQUAL,    true,  false, false},
+    {  534,  534,          1, LESS_OR_EQUAL,    true,  false, false},
+    {  947,   34,          0, LESS_OR_EQUAL,    false, false, false},
+
+    {10873, 8420,          1, GREATER,          true,  false, false},
+    { 3622, 3622,          0, GREATER,          false, false, false},
+    {  872, 2701,          0, GREATER,          false, false, false},
+    {10873, 8420,          1, GREATER_OR_EQUAL, true,  false, false},
+    { 3622, 3622,          1, GREATER_OR_EQUAL, true,  false, false},
+    {  872, 2701,          0, GREATER_OR_EQUAL, false, false, false},
+
+    {  432,  743, 432 +  743, ADD,              true,  false, false},
+    {  432,  -74, 432 -   74, ADD,              true,  false, true},
+    {  432, -743, 432 -  743, ADD,              false, true,  true},
+    {  432,  743,          1, ADD,              false, false, false},
+    {  823,   93, 823 +   93, ADD_ASSIGN,       true,  false, false},
+    {  823,  -93, 823 -   93, ADD_ASSIGN,       true,  false, true},
+    {  823, -932, 823 -  932, ADD_ASSIGN,       false, true,  true},
+    {  823,   93,          1, ADD_ASSIGN,       false, false, false},
+
+    {  432,  285, 432 -  285, SUBTRACT,         true,  false, false},
+    {  432, -285, 432 +  285, SUBTRACT,         true,  false, true},
+    {  432,  763, 432 -  763, SUBTRACT,         false, true,  false},
+    {  432,  285,          1, SUBTRACT,         false, false, false},
+    {  432,  431,          1, SUBTRACT,         true,  false, false},
+    {  432,  432,          0, SUBTRACT,         false, true,  false},
+    {  823,   93, 823 -   93, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823, -932, 823 +  932, SUBTRACT_ASSIGN,  true,  false, true},
+    {  823, 1393, 823 - 1393, SUBTRACT_ASSIGN,  false, true,  false},
+    {  823,   93,          1, SUBTRACT_ASSIGN,  false, false, false},
+    {  823,  822,          1, SUBTRACT_ASSIGN,  true,  false, false},
+    {  823,  823,          0, SUBTRACT_ASSIGN,  false, true,  false},
+
+    {   40,   12,  40 *   12, MULTIPLY,         true,  false, false},
+    {   23,   -8,  23 *   -8, MULTIPLY,         false, true,  true},
+    {   40,   12,          1, MULTIPLY,         false, false, false},
+    {   18,    4,  18 *    4, MULTIPLY_ASSIGN,  true,  false, false},
+    {    2, -232,   2 * -232, MULTIPLY_ASSIGN,  false, true,  true},
+    {   18,    4,          1, MULTIPLY_ASSIGN,  false, false, false},
+
+    {  900,    5, 900 /    5, DIVIDE,           true,  false, false},
+    {  900,   -5, 900 /   -5, DIVIDE,           false, true,  true},
+    {  900,  900, 900 /  900, DIVIDE,           true,  false, false},
+    {  900,  901,          0, DIVIDE,           false, true,  false},
+    {  900,  900,          2, DIVIDE,           false, false, false},
+    {  480,   20, 480 /   20, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  -20, 480 /  -20, DIVIDE_ASSIGN,    false, true,  true},
+    {  480,  480, 480 /  480, DIVIDE_ASSIGN,    true,  false, false},
+    {  480,  481,          0, DIVIDE_ASSIGN,    false, true,  false},
+    {  480,  480,          2, DIVIDE_ASSIGN,    false, false, false},
+
+    {  901,  900,          1, MODULO,           true,  false, false},
+    {  901,  900,          2, MODULO,           false, false, false},
+    {   43,   43,          0, MODULO,           false, true,  false},
+    {  901,  900,          1, MODULO_ASSIGN,    true,  false, false},
+    {  901,  900,          2, MODULO_ASSIGN,    false, false, false},
+    {   43,   43,          0, MODULO_ASSIGN,    false, true,  false},
+
+    {  33,     1,         34, INCREMENT,        true,  false, false},
+    {  33,     1,         33, INCREMENT,        false, false, false},
+    {   1,     1,          2, INCREMENT,        true,  false, false},
+    {  33,     1,         32, DECREMENT,        true,  false, false},
+    {  33,     1,         33, DECREMENT,        false, false, false},
+    {   1,     1,          0, DECREMENT,        false, true,  false}
+  };
 
 template<>
 const PositiveLong::value_type NumericTest<PositiveLong>::error(0);

--- a/ome-xml/src/test/cpp/quantity.h
+++ b/ome-xml/src/test/cpp/quantity.h
@@ -83,7 +83,7 @@ struct test_op
 };
 
 // From unit name, to unit name, test data
-typedef std::map<std::pair<std::string, std::string>, std::vector<test_op> > test_map;
+typedef std::map<std::pair<std::string, std::string>, std::vector<test_op>> test_map;
 
 extern test_map test_data;
 

--- a/ome-xml/src/test/cpp/timestamp.cpp
+++ b/ome-xml/src/test/cpp/timestamp.cpp
@@ -76,27 +76,6 @@ operator<< (std::basic_ostream<charT,traits>& os,
   return os << params.input;
 }
 
-TimestampTestParameters params[] =
-  {
-    //                      input                           throws seconds     ms   output
-    TimestampTestParameters("2003-08-26T19:46:38",          false, 1061927198,   0, "2003-08-26T19:46:38Z"),
-    TimestampTestParameters("2003-08-26T19:46:38.762",      false, 1061927198, 762, "2003-08-26T19:46:38.762000Z"),
-    TimestampTestParameters("2003-08-26T19:46:38.762Z",     false, 1061927198, 762, "2003-08-26T19:46:38.762000Z"),
-    TimestampTestParameters("2003-08-26T19:46:38.762-0300", false, 1061937998, 762, "2003-08-26T22:46:38.762000Z"),
-    TimestampTestParameters("2003-08-26T19:46:38.762+0400", false, 1061912798, 762, "2003-08-26T15:46:38.762000Z"),
-    TimestampTestParameters("2003-08-26T19:46:38.762-1130", false, 1061968598, 762, "2003-08-27T07:16:38.762000Z"),
-    TimestampTestParameters("2003-08-26T19:46:38.762+",     true,  0,          762, ""), // Time difference is invalid
-    TimestampTestParameters("2003-08-26T19:46:38.762-",     true,  0,          762, ""), // Time difference is invalid
-    TimestampTestParameters("invalid",                      true,  0,            0, ""), // Invalid
-    TimestampTestParameters("2011-10-20T09:30:10-05:00",    true,  0,            0, ""), // Time difference is invalid
-    TimestampTestParameters("2011-10-20T15:07:14",          false, 1319123234,   0, "2011-10-20T15:07:14Z"),
-    TimestampTestParameters("2011-10-20T15:07:14.312",      false, 1319123234, 312, "2011-10-20T15:07:14.312000Z"),
-    TimestampTestParameters("2011-10-20T15:07:14Z",         false, 1319123234,   0, "2011-10-20T15:07:14Z"),
-    TimestampTestParameters("2011-10-20T15:07:14.632Z",     false, 1319123234, 632, "2011-10-20T15:07:14.632000Z"),
-    TimestampTestParameters("1200-12-04T13:12:12",          true,  0,            0, ""), // Too far in the past
-    TimestampTestParameters("20111020T093010.654",          true,  0,            0, "")  // Invalid
-  };
-
 class TimestampTest : public ::testing::TestWithParam<TimestampTestParameters>
 {
 };
@@ -168,6 +147,27 @@ TEST_P(TimestampTest, TimeFromEpoch)
       ASSERT_EQ(milliseconds, params.milliseconds);
     }
 }
+
+std::vector<TimestampTestParameters> params =
+  {
+    // input                          throws seconds     ms   output
+    { "2003-08-26T19:46:38",          false, 1061927198,   0, "2003-08-26T19:46:38Z" },
+    { "2003-08-26T19:46:38.762",      false, 1061927198, 762, "2003-08-26T19:46:38.762000Z" },
+    { "2003-08-26T19:46:38.762Z",     false, 1061927198, 762, "2003-08-26T19:46:38.762000Z" },
+    { "2003-08-26T19:46:38.762-0300", false, 1061937998, 762, "2003-08-26T22:46:38.762000Z" },
+    { "2003-08-26T19:46:38.762+0400", false, 1061912798, 762, "2003-08-26T15:46:38.762000Z" },
+    { "2003-08-26T19:46:38.762-1130", false, 1061968598, 762, "2003-08-27T07:16:38.762000Z" },
+    { "2003-08-26T19:46:38.762+",     true,  0,          762, "" }, // Time difference is invalid
+    { "2003-08-26T19:46:38.762-",     true,  0,          762, "" }, // Time difference is invalid
+    { "invalid",                      true,  0,            0, "" }, // Invalid
+    { "2011-10-20T09:30:10-05:00",    true,  0,            0, "" }, // Time difference is invalid
+    { "2011-10-20T15:07:14",          false, 1319123234,   0, "2011-10-20T15:07:14Z" },
+    { "2011-10-20T15:07:14.312",      false, 1319123234, 312, "2011-10-20T15:07:14.312000Z" },
+    { "2011-10-20T15:07:14Z",         false, 1319123234,   0, "2011-10-20T15:07:14Z" },
+    { "2011-10-20T15:07:14.632Z",     false, 1319123234, 632, "2011-10-20T15:07:14.632000Z" },
+    { "1200-12-04T13:12:12",          true,  0,            0, "" }, // Too far in the past
+    { "20111020T093010.654",          true,  0,            0, "" }// Invalid
+  };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
 // this is solely to work around a missing prototype in gtest.

--- a/xsd-fu/python/ome/modeltools/property.py
+++ b/xsd-fu/python/ome/modeltools/property.py
@@ -567,7 +567,7 @@ class OMEModelProperty(OMEModelEntity):
                 qtype = self.langTypeNS
                 if self.minOccurs == 0:
                     if self.maxOccurs == 1:
-                        itype = "const ome::compat::shared_ptr<%s>&" % qtype
+                        itype = "const std::shared_ptr<%s>&" % qtype
                     else:
                         itype = "const std::vector<%s>&" % qtype
                 elif self.minOccurs == 0 and self.maxOccurs == 1:
@@ -576,11 +576,11 @@ class OMEModelProperty(OMEModelEntity):
                     itype = "const std::vector<%s>&" % qtype
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = "ome::compat::shared_ptr<%s>&" % ns_sep
+                    itype = "std::shared_ptr<%s>&" % ns_sep
                 else:
                     itype = "const %s&" % self.langTypeNS
             elif self.isReference or self.isBackReference:
-                itype = "ome::compat::weak_ptr<%s>&" % ns_sep
+                itype = "std::weak_ptr<%s>&" % ns_sep
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstract or
                     self.isAttribute or not self.isComplex() or
@@ -588,11 +588,11 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = "ome::compat::shared_ptr<%s>&" % ns_sep
+                    itype = "std::shared_ptr<%s>&" % ns_sep
                 else:
                     itype = "const %s&" % self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstract:
-                itype = "std::vector<ome::compat::shared_ptr<%s> >&" % ns_sep
+                itype = "std::vector<std::shared_ptr<%s> >&" % ns_sep
 
         return itype
     argType = property(_get_argType, doc="""The property's argument type.""")
@@ -620,8 +620,8 @@ class OMEModelProperty(OMEModelEntity):
                 qtype = self.langTypeNS
                 if self.minOccurs == 0:
                     if self.maxOccurs == 1:
-                        itype = {' const': "const ome::compat::shared_ptr<%s>&" % qtype,
-                                 '': "ome::compat::shared_ptr<%s>&" % qtype}
+                        itype = {' const': "const std::shared_ptr<%s>&" % qtype,
+                                 '': "std::shared_ptr<%s>&" % qtype}
                     else:
                         itype = {' const': "const std::vector<%s>&" % qtype,
                                  '': "std::vector<%s>&" % qtype}
@@ -633,16 +633,16 @@ class OMEModelProperty(OMEModelEntity):
                              '': "std::vector<%s>&" % qtype}
             elif self.isEnumeration:
                 if self.minOccurs == 0:
-                    itype = {' const': "const ome::compat::shared_ptr<%s>"
+                    itype = {' const': "const std::shared_ptr<%s>"
                              % ns_sep,
-                             '':       "ome::compat::shared_ptr<%s>"
+                             '':       "std::shared_ptr<%s>"
                              % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif self.isReference or self.isBackReference:
-                itype = {' const': "const ome::compat::weak_ptr<%s>" % ns_sep,
-                         '':       "ome::compat::weak_ptr<%s>" % ns_sep}
+                itype = {' const': "const std::weak_ptr<%s>" % ns_sep,
+                         '':       "std::weak_ptr<%s>" % ns_sep}
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstract or
                     self.isAttribute or not self.isComplex() or
@@ -651,19 +651,19 @@ class OMEModelProperty(OMEModelEntity):
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
                     itype = {' const':
-                             "const ome::compat::shared_ptr<%s>"
+                             "const std::shared_ptr<%s>"
                              % ns_sep,
                              '':
-                             "ome::compat::shared_ptr<%s>"
+                             "std::shared_ptr<%s>"
                              % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS}
             elif self.maxOccurs > 1 and not self.parent.isAbstract:
                 itype = {' const':
-                         "const std::vector<ome::compat::shared_ptr<%s> >"
+                         "const std::vector<std::shared_ptr<%s> >"
                          % ns_sep,
                          '':
-                         "std::vector<ome::compat::shared_ptr<%s> >"
+                         "std::vector<std::shared_ptr<%s> >"
                          % ns_sep}
 
         return itype
@@ -691,7 +691,7 @@ class OMEModelProperty(OMEModelEntity):
                     not self.isChoice):
                 itype = self.argType()
             elif self.maxOccurs > 1 and not self.parent.isAbstract:
-                itype = "ome::compat::shared_ptr<%s>&" % ns_sep
+                itype = "std::shared_ptr<%s>&" % ns_sep
 
         return itype
     elementArgType = property(
@@ -728,9 +728,9 @@ class OMEModelProperty(OMEModelEntity):
                 itype = self.argType()
             elif (self.maxOccurs > 1 and
                   not self.parent.isAbstract):
-                itype = {' const': "const ome::compat::shared_ptr<%s>&"
+                itype = {' const': "const std::shared_ptr<%s>&"
                          % ns_sep,
-                         '':       "ome::compat::shared_ptr<%s>&"
+                         '':       "std::shared_ptr<%s>&"
                          % ns_sep}
 
         return itype
@@ -763,18 +763,18 @@ class OMEModelProperty(OMEModelEntity):
             elif self.isEnumeration:
                 if self.minOccurs == 0:
                     itype = {' const':
-                             "ome::compat::shared_ptr<const %s>" %
+                             "std::shared_ptr<const %s>" %
                              ns_sep,
                              '':
-                             "ome::compat::shared_ptr<%s>" %
+                             "std::shared_ptr<%s>" %
                              ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
                              '':       "%s&" % self.langTypeNS}
             elif self.isReference or self.isBackReference:
-                itype = {' const': "ome::compat::shared_ptr<const %s>"
+                itype = {' const': "std::shared_ptr<const %s>"
                          % ns_sep,
-                         '':       "ome::compat::shared_ptr<%s>"
+                         '':       "std::shared_ptr<%s>"
                          % ns_sep}
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstract or
@@ -783,9 +783,9 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = {' const': "ome::compat::shared_ptr<const %s>"
+                    itype = {' const': "std::shared_ptr<const %s>"
                              % ns_sep,
-                             '': "ome::compat::shared_ptr<%s>"
+                             '': "std::shared_ptr<%s>"
                              % ns_sep}
                 else:
                     itype = {' const': "const %s&" % self.langTypeNS,
@@ -793,10 +793,10 @@ class OMEModelProperty(OMEModelEntity):
             elif (self.maxOccurs > 1 and
                     not self.parent.isAbstract):
                 itype = {' const':
-                         "const std::vector<ome::compat::shared_ptr<%s> >"
+                         "const std::vector<std::shared_ptr<%s> >"
                          % ns_sep,
                          '':
-                         "std::vector<ome::compat::shared_ptr<%s> >"
+                         "std::vector<std::shared_ptr<%s> >"
                          % ns_sep}
 
         return itype
@@ -865,7 +865,7 @@ class OMEModelProperty(OMEModelEntity):
                 qtype = self.langTypeNS
                 if self.minOccurs == 0:
                     if self.maxOccurs == 1:
-                        itype = "ome::compat::shared_ptr<%s>" % qtype
+                        itype = "std::shared_ptr<%s>" % qtype
                     else:
                         itype = "std::vector<%s>" % qtype
                 elif self.minOccurs == 0 and self.maxOccurs == 1:
@@ -874,14 +874,14 @@ class OMEModelProperty(OMEModelEntity):
                     itype = "std::vector<%s>" % qtype
             elif self.isReference and self.maxOccurs > 1:
                 itype = ("OMEModelObject::indexed_container"
-                         "<%s, ome::compat::weak_ptr>::type") % ns_sep
+                         "<%s, std::weak_ptr>::type") % ns_sep
             elif self.isReference:
-                itype = "ome::compat::weak_ptr<%s>" % ns_sep
+                itype = "std::weak_ptr<%s>" % ns_sep
             elif self.isBackReference and self.maxOccurs > 1:
                 itype = ("OMEModelObject::indexed_container"
-                         "<%s, ome::compat::weak_ptr>::type") % ns_sep
+                         "<%s, std::weak_ptr>::type") % ns_sep
             elif self.isBackReference:
-                itype = "ome::compat::weak_ptr<%s>" % ns_sep
+                itype = "std::weak_ptr<%s>" % ns_sep
             elif self.maxOccurs == 1 and (
                     not self.parent.isAbstract or
                     self.isAttribute or not self.isComplex() or
@@ -889,11 +889,11 @@ class OMEModelProperty(OMEModelEntity):
                 if self.minOccurs == 0 or (
                         not self.model.opts.lang.hasPrimitiveType(
                             self.langType) and not self.isEnumeration):
-                    itype = "ome::compat::shared_ptr<%s>" % ns_sep
+                    itype = "std::shared_ptr<%s>" % ns_sep
                 else:
                     itype = self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstract:
-                itype = "std::vector<ome::compat::shared_ptr<%s> >" % ns_sep
+                itype = "std::vector<std::shared_ptr<%s> >" % ns_sep
 
         return itype
     instanceVariableType = property(
@@ -929,7 +929,7 @@ class OMEModelProperty(OMEModelEntity):
                 if self.isEnumeration:
                     if self.minOccurs == 0:
                         idefault = (
-                            "ome::compat::shared_ptr<%s>(new %s(%s::%s))"
+                            "std::shared_ptr<%s>(new %s(%s::%s))"
                             % (ns_sep, self.langTypeNS, self.langTypeNS,
                                self.defaultValue.upper()))
                     else:

--- a/xsd-fu/python/ome/modeltools/property.py
+++ b/xsd-fu/python/ome/modeltools/property.py
@@ -592,7 +592,7 @@ class OMEModelProperty(OMEModelEntity):
                 else:
                     itype = "const %s&" % self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstract:
-                itype = "std::vector<std::shared_ptr<%s> >&" % ns_sep
+                itype = "std::vector<std::shared_ptr<%s>>&" % ns_sep
 
         return itype
     argType = property(_get_argType, doc="""The property's argument type.""")
@@ -660,10 +660,10 @@ class OMEModelProperty(OMEModelEntity):
                     itype = {' const': "const %s&" % self.langTypeNS}
             elif self.maxOccurs > 1 and not self.parent.isAbstract:
                 itype = {' const':
-                         "const std::vector<std::shared_ptr<%s> >"
+                         "const std::vector<std::shared_ptr<%s>>"
                          % ns_sep,
                          '':
-                         "std::vector<std::shared_ptr<%s> >"
+                         "std::vector<std::shared_ptr<%s>>"
                          % ns_sep}
 
         return itype
@@ -793,10 +793,10 @@ class OMEModelProperty(OMEModelEntity):
             elif (self.maxOccurs > 1 and
                     not self.parent.isAbstract):
                 itype = {' const':
-                         "const std::vector<std::shared_ptr<%s> >"
+                         "const std::vector<std::shared_ptr<%s>>"
                          % ns_sep,
                          '':
-                         "std::vector<std::shared_ptr<%s> >"
+                         "std::vector<std::shared_ptr<%s>>"
                          % ns_sep}
 
         return itype
@@ -893,7 +893,7 @@ class OMEModelProperty(OMEModelEntity):
                 else:
                     itype = self.langTypeNS
             elif self.maxOccurs > 1 and not self.parent.isAbstract:
-                itype = "std::vector<std::shared_ptr<%s> >" % ns_sep
+                itype = "std::vector<std::shared_ptr<%s>>" % ns_sep
 
         return itype
     instanceVariableType = property(

--- a/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -21,11 +21,9 @@
       AggregateMetadata::index_type
       AggregateMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])}) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             /// TODO: No handling of -1 as for Java.  Callee must throw.
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_name_string(indexes[:-1])});
@@ -48,11 +46,9 @@
       ${prop.metadataStoreRetType}
       AggregateMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)}) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
@@ -71,11 +67,9 @@
       ${prop.metadataStoreRetType}
       AggregateMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_name_string(indexes)});
           }
@@ -94,11 +88,9 @@
       ${prop.metadataStoreRetType}
       AggregateMetadata::get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}() const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}();
           }
@@ -122,11 +114,9 @@
       void
       AggregateMetadata::set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
       {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (auto& i : delegates)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
@@ -145,11 +135,9 @@
       void
       AggregateMetadata::set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
       {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (auto& i : delegates)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)});
           }
@@ -168,11 +156,9 @@
       void
       AggregateMetadata::set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
       {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (auto& i : delegates)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName});
           }
@@ -367,11 +353,9 @@ namespace ome
       void
       AggregateMetadata::createRoot()
       {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (auto& i : delegates)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(i);
             if (store)
               store->createRoot();
           }
@@ -467,11 +451,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getBooleanAnnotationAnnotationCount(index_type booleanAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getBooleanAnnotationAnnotationCount(booleanAnnotationIndex);
           }
@@ -489,11 +471,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getCommentAnnotationAnnotationCount(index_type commentAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getCommentAnnotationAnnotationCount(commentAnnotationIndex);
           }
@@ -511,11 +491,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getDoubleAnnotationAnnotationCount(index_type doubleAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getDoubleAnnotationAnnotationCount(doubleAnnotationIndex);
           }
@@ -533,11 +511,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getFileAnnotationAnnotationCount(index_type fileAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getFileAnnotationAnnotationCount(fileAnnotationIndex);
           }
@@ -555,11 +531,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getListAnnotationAnnotationCount(index_type listAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getListAnnotationAnnotationCount(listAnnotationIndex);
           }
@@ -577,11 +551,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getLongAnnotationAnnotationCount(index_type longAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getLongAnnotationAnnotationCount(longAnnotationIndex);
           }
@@ -599,11 +571,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getMapAnnotationAnnotationCount(index_type mapAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getMapAnnotationAnnotationCount(mapAnnotationIndex);
           }
@@ -621,11 +591,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getTagAnnotationAnnotationCount(index_type tagAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getTagAnnotationAnnotationCount(tagAnnotationIndex);
           }
@@ -643,11 +611,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getTermAnnotationAnnotationCount(index_type termAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getTermAnnotationAnnotationCount(termAnnotationIndex);
           }
@@ -665,11 +631,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getTimestampAnnotationAnnotationCount(index_type timestampAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getTimestampAnnotationAnnotationCount(timestampAnnotationIndex);
           }
@@ -687,11 +651,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::getXMLAnnotationAnnotationCount(index_type xmlAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getXMLAnnotationAnnotationCount(xmlAnnotationIndex);
           }
@@ -716,11 +678,9 @@ namespace ome
       const std::string&
       AggregateMetadata::get${abstractClass}Type(${indexes_string(v)}) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->get${abstractClass}Type(${indexes_name_string(v)});
           }
@@ -738,11 +698,9 @@ namespace ome
       AggregateMetadata::index_type
       AggregateMetadata::get${abstractClass}Count(${indexes_string(v[:-1])}) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->get${abstractClass}Count(${indexes_name_string(v[:-1])});
           }
@@ -773,11 +731,9 @@ namespace ome
       void
       AggregateMetadata::set${o.name}Value(${o.langBaseType} value, ${indexes_string(indexes[o.name].items()[0][1])})
       {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (auto& i : delegates)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(i);
             if (store)
               store->set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
           }
@@ -794,11 +750,9 @@ namespace ome
       ${o.langBaseType}
       AggregateMetadata::get${o.name}Value(${indexes_string(indexes[o.name].items()[0][1])}) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->get${o.name}Value(${indexes_name_string(indexes[o.name].items()[0][1])});
           }
@@ -839,11 +793,9 @@ ${counter(k, o, v)}\
       const std::string&
       AggregateMetadata::getUUID() const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getUUID();
           }
@@ -861,11 +813,9 @@ ${counter(k, o, v)}\
       const ome::xml::model::primitives::OrderedMultimap&
       AggregateMetadata::getMapAnnotationValue(index_type mapAnnotationIndex) const
       {
-        for (delegate_list_type::const_iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (const auto& i : delegates)
           {
-            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(i);
             if (retrieve)
               return retrieve->getMapAnnotationValue(mapAnnotationIndex);
           }
@@ -1023,11 +973,9 @@ ${getter(k, o, prop, v)}\
       void
       AggregateMetadata::setUUID(const std::string& uuid)
       {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (auto& i : delegates)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(i);
             if (store)
               store->setUUID(uuid);
           }
@@ -1047,11 +995,9 @@ ${getter(k, o, prop, v)}\
       AggregateMetadata::setMapAnnotationValue(const ome::xml::model::primitives::OrderedMultimap& value,
                                                index_type                                          mapAnnotationIndex)
       {
-        for (delegate_list_type::iterator i = delegates.begin();
-             i != delegates.end();
-             ++i)
+        for (auto& i : delegates)
           {
-            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(i);
             if (store)
               store->setMapAnnotationValue(value, mapAnnotationIndex);
           }

--- a/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -305,7 +305,7 @@ namespace ome
       {
       public:
         /// A list of MetadataStore and MetadataRetrieve instances.
-        typedef std::vector<std::shared_ptr<BaseMetadata> > delegate_list_type;
+        typedef std::vector<std::shared_ptr<BaseMetadata>> delegate_list_type;
 
       private:
         /** The active metadata store delegates. */

--- a/xsd-fu/templates-cpp/AggregateMetadata.template
+++ b/xsd-fu/templates-cpp/AggregateMetadata.template
@@ -25,7 +25,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             /// TODO: No handling of -1 as for Java.  Callee must throw.
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_name_string(indexes[:-1])});
@@ -52,7 +52,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
@@ -75,7 +75,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_name_string(indexes)});
           }
@@ -98,7 +98,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}();
           }
@@ -126,7 +126,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}(${prop.argumentName}, ${indexes_name_string(indexes)}, ${index_name_string(prop.name)});
           }
@@ -149,7 +149,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName}, ${indexes_name_string(indexes)});
           }
@@ -172,7 +172,7 @@
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.argumentName});
           }
@@ -305,7 +305,7 @@ namespace ome
       {
       public:
         /// A list of MetadataStore and MetadataRetrieve instances.
-        typedef std::vector<ome::compat::shared_ptr<BaseMetadata> > delegate_list_type;
+        typedef std::vector<std::shared_ptr<BaseMetadata> > delegate_list_type;
 
       private:
         /** The active metadata store delegates. */
@@ -351,7 +351,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->createModel();
           }
@@ -371,7 +371,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->createRoot();
           }
@@ -385,11 +385,11 @@ namespace ome
          * exception if called.
          * @throws MetadataException always.
          */
-        ome::compat::shared_ptr<MetadataModel>
+        std::shared_ptr<MetadataModel>
         getModel();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataModel>
+      std::shared_ptr<MetadataModel>
       AggregateMetadata::getModel()
       {
         throw MetadataException("AggregateMetadata", "getModel",
@@ -405,11 +405,11 @@ namespace ome
          * @throws MetadataException always.
          */
         void
-        setModel(ome::compat::shared_ptr<MetadataModel> model);
+        setModel(std::shared_ptr<MetadataModel> model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      AggregateMetadata::setModel(ome::compat::shared_ptr<MetadataModel> /* model */)
+      AggregateMetadata::setModel(std::shared_ptr<MetadataModel> /* model */)
       {
         throw MetadataException("AggregateMetadata", "setModel",
                                 "unsupported");
@@ -423,11 +423,11 @@ namespace ome
          * exception if called.
          * @throws MetadataException always.
          */
-        ome::compat::shared_ptr<MetadataRoot>
+        std::shared_ptr<MetadataRoot>
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>
+      std::shared_ptr<MetadataRoot>
       AggregateMetadata::getRoot()
       {
         throw MetadataException("AggregateMetadata", "getRoot",
@@ -443,11 +443,11 @@ namespace ome
          * @throws MetadataException always.
          */
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot> root);
+        setRoot(std::shared_ptr<MetadataRoot> root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      AggregateMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> /* root */)
+      AggregateMetadata::setRoot(std::shared_ptr<MetadataRoot> /* root */)
       {
         throw MetadataException("AggregateMetadata", "setRoot",
                                 "unsupported");
@@ -471,7 +471,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getBooleanAnnotationAnnotationCount(booleanAnnotationIndex);
           }
@@ -493,7 +493,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getCommentAnnotationAnnotationCount(commentAnnotationIndex);
           }
@@ -515,7 +515,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getDoubleAnnotationAnnotationCount(doubleAnnotationIndex);
           }
@@ -537,7 +537,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getFileAnnotationAnnotationCount(fileAnnotationIndex);
           }
@@ -559,7 +559,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getListAnnotationAnnotationCount(listAnnotationIndex);
           }
@@ -581,7 +581,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getLongAnnotationAnnotationCount(longAnnotationIndex);
           }
@@ -603,7 +603,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getMapAnnotationAnnotationCount(mapAnnotationIndex);
           }
@@ -625,7 +625,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTagAnnotationAnnotationCount(tagAnnotationIndex);
           }
@@ -647,7 +647,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTermAnnotationAnnotationCount(termAnnotationIndex);
           }
@@ -669,7 +669,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getTimestampAnnotationAnnotationCount(timestampAnnotationIndex);
           }
@@ -691,7 +691,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getXMLAnnotationAnnotationCount(xmlAnnotationIndex);
           }
@@ -720,7 +720,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get${abstractClass}Type(${indexes_name_string(v)});
           }
@@ -742,7 +742,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get${abstractClass}Count(${indexes_name_string(v[:-1])});
           }
@@ -777,7 +777,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->set${o.name}Value(value, ${indexes_name_string(indexes[o.name].items()[0][1])});
           }
@@ -798,7 +798,7 @@ namespace ome
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->get${o.name}Value(${indexes_name_string(indexes[o.name].items()[0][1])});
           }
@@ -843,7 +843,7 @@ ${counter(k, o, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getUUID();
           }
@@ -865,7 +865,7 @@ ${counter(k, o, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getMapAnnotationValue(mapAnnotationIndex);
           }
@@ -889,7 +889,7 @@ ${counter(k, o, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getGenericExcitationSourceMap(instrumentIndex, lightSourceIndex);
           }
@@ -911,7 +911,7 @@ ${counter(k, o, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataRetrieve> retrieve = ome::compat::dynamic_pointer_cast<MetadataRetrieve>(*i);
+            std::shared_ptr<MetadataRetrieve> retrieve = std::dynamic_pointer_cast<MetadataRetrieve>(*i);
             if (retrieve)
               return retrieve->getImagingEnvironmentMap(imageIndex);
           }
@@ -1027,7 +1027,7 @@ ${getter(k, o, prop, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setUUID(uuid);
           }
@@ -1051,7 +1051,7 @@ ${getter(k, o, prop, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setMapAnnotationValue(value, mapAnnotationIndex);
           }
@@ -1077,7 +1077,7 @@ ${getter(k, o, prop, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setGenericExcitationSourceMap(value, instrumentIndex, lightSourceIndex);
           }
@@ -1101,7 +1101,7 @@ ${getter(k, o, prop, v)}\
              i != delegates.end();
              ++i)
           {
-            ome::compat::shared_ptr<MetadataStore> store = ome::compat::dynamic_pointer_cast<MetadataStore>(*i);
+            std::shared_ptr<MetadataStore> store = std::dynamic_pointer_cast<MetadataStore>(*i);
             if (store)
               store->setImagingEnvironmentMap(value, imageIndex);
           }

--- a/xsd-fu/templates-cpp/DummyMetadata.template
+++ b/xsd-fu/templates-cpp/DummyMetadata.template
@@ -281,11 +281,11 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataModel>
+        std::shared_ptr<MetadataModel>
         getModel();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataModel>
+      std::shared_ptr<MetadataModel>
       DummyMetadata::getModel()
       {
         throw MetadataException("DummyMetadata", "getModel",
@@ -296,22 +296,22 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        setModel(ome::compat::shared_ptr<MetadataModel> model);
+        setModel(std::shared_ptr<MetadataModel> model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      DummyMetadata::setModel(ome::compat::shared_ptr<MetadataModel> /* model */)
+      DummyMetadata::setModel(std::shared_ptr<MetadataModel> /* model */)
       {
       }
 {% end source %}\
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>
+        std::shared_ptr<MetadataRoot>
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>
+      std::shared_ptr<MetadataRoot>
       DummyMetadata::getRoot()
       {
         throw MetadataException("DummyMetadata", "getRoot",
@@ -322,11 +322,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot> root);
+        setRoot(std::shared_ptr<MetadataRoot> root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      DummyMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> /* root */)
+      DummyMetadata::setRoot(std::shared_ptr<MetadataRoot> /* root */)
       {
       }
 {% end source %}\

--- a/xsd-fu/templates-cpp/FilterMetadata.template
+++ b/xsd-fu/templates-cpp/FilterMetadata.template
@@ -190,7 +190,7 @@ namespace ome
       {
       private:
         /// The wrapped metadata store.
-        ome::compat::shared_ptr<MetadataStore> store;
+        std::shared_ptr<MetadataStore> store;
         /// Is filtering enabled?
         bool filter;
 
@@ -202,11 +202,11 @@ namespace ome
          * @param filter @c true to enable filtering, @c false to
          * disable.
          */
-        FilterMetadata(ome::compat::shared_ptr<MetadataStore>& store,
+        FilterMetadata(std::shared_ptr<MetadataStore>& store,
                        bool filter);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      FilterMetadata::FilterMetadata(ome::compat::shared_ptr<MetadataStore>& store,
+      FilterMetadata::FilterMetadata(std::shared_ptr<MetadataStore>& store,
                                      bool filter):
         store(store),
         filter(filter)
@@ -253,11 +253,11 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataModel>
+        std::shared_ptr<MetadataModel>
         getModel();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataModel>
+      std::shared_ptr<MetadataModel>
       FilterMetadata::getModel()
       {
         return store->getModel();
@@ -267,11 +267,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        setModel(ome::compat::shared_ptr<MetadataModel> model);
+        setModel(std::shared_ptr<MetadataModel> model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      FilterMetadata::setModel(ome::compat::shared_ptr<MetadataModel> model)
+      FilterMetadata::setModel(std::shared_ptr<MetadataModel> model)
       {
         store->setModel(model);
       }
@@ -279,11 +279,11 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>
+        std::shared_ptr<MetadataRoot>
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>
+      std::shared_ptr<MetadataRoot>
       FilterMetadata::getRoot()
       {
         return store->getRoot();
@@ -293,11 +293,11 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot> root);
+        setRoot(std::shared_ptr<MetadataRoot> root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      FilterMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> root)
+      FilterMetadata::setRoot(std::shared_ptr<MetadataRoot> root)
       {
         store->setRoot(root);
       }

--- a/xsd-fu/templates-cpp/MetadataRetrieve.template
+++ b/xsd-fu/templates-cpp/MetadataRetrieve.template
@@ -117,9 +117,8 @@
 #ifndef ${fu.GUARD}
 #define ${fu.GUARD}
 
+#include <memory>
 #include <string>
-
-#include <ome/compat/memory.h>
 
 #include <ome/xml/meta/BaseMetadata.h>
 #include <ome/xml/model/AffineTransform.h>

--- a/xsd-fu/templates-cpp/MetadataStore.template
+++ b/xsd-fu/templates-cpp/MetadataStore.template
@@ -109,9 +109,8 @@
 #ifndef ${fu.GUARD}
 #define ${fu.GUARD}
 
+#include <memory>
 #include <string>
-
-#include <ome/compat/memory.h>
 
 #include <ome/xml/meta/BaseMetadata.h>
 #include <ome/xml/meta/MetadataModel.h>
@@ -230,7 +229,7 @@ namespace ome
          *
          * @todo should this be a reference or shared_ptr?
          */
-        virtual ome::compat::shared_ptr<MetadataModel>
+        virtual std::shared_ptr<MetadataModel>
         getModel() = 0;
 
         /**
@@ -244,7 +243,7 @@ namespace ome
          * @todo should this be a reference or shared_ptr?
          */
         virtual void
-        setModel(ome::compat::shared_ptr<MetadataModel> model) = 0;
+        setModel(std::shared_ptr<MetadataModel> model) = 0;
 
         /**
          * Get the root node of the metadata.  Note that the root node
@@ -255,7 +254,7 @@ namespace ome
          *
          * @todo should this be a reference or shared_ptr?
          */
-        virtual ome::compat::shared_ptr<MetadataRoot>
+        virtual std::shared_ptr<MetadataRoot>
         getRoot() = 0;
 
         /**
@@ -269,7 +268,7 @@ namespace ome
          * @todo should this be a reference or shared_ptr?
          */
         virtual void
-        setRoot(ome::compat::shared_ptr<MetadataRoot> root) = 0;
+        setRoot(std::shared_ptr<MetadataRoot> root) = 0;
 
 {% if debug %}\
         // -- Entity storage (manual definitions) --

--- a/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -199,8 +199,8 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         // ${prop.name} is abstract and is a reference
         std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
-        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
+        std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         root->addReference(o_base, ref);
         // ${parent} is abstract
@@ -249,7 +249,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         root->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
         std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
@@ -271,8 +271,8 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         // ${prop.name} is reference and occurs more than once
         std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
-        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
+        std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         root->addReference(modelObject, ref);
 {% end %}\
@@ -309,7 +309,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
-        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         root->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
         std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
@@ -967,28 +967,28 @@ namespace ome
       {
         if (root->sizeOfImageList() == imageIndex)
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(std::make_shared< ::${lang.omexml_model_package}::Image>());
+            std::shared_ptr<::${lang.omexml_model_package}::Image> newImage(std::make_shared<::${lang.omexml_model_package}::Image>());
             root->addImage(newImage);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        std::shared_ptr<::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared< ::${lang.omexml_model_package}::Pixels>());
+            std::shared_ptr<::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared<::${lang.omexml_model_package}::Pixels>());
             o1->setPixels(newPixels);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
+        std::shared_ptr<::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
         if (o2->sizeOfTiffDataList() == tiffDataIndex)
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::TiffData> newTiffData(std::make_shared< ::${lang.omexml_model_package}::TiffData>());
+            std::shared_ptr<::${lang.omexml_model_package}::TiffData> newTiffData(std::make_shared<::${lang.omexml_model_package}::TiffData>());
             o2->addTiffData(newTiffData);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
+        std::shared_ptr<::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
         if (!o3->getUUID()) // null
           {
-            std::shared_ptr< ::${lang.omexml_model_package}::UUID> newUUID(std::make_shared< ::${lang.omexml_model_package}::UUID>());
+            std::shared_ptr<::${lang.omexml_model_package}::UUID> newUUID(std::make_shared<::${lang.omexml_model_package}::UUID>());
             o3->setUUID(newUUID);
           }
-        std::shared_ptr< ::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
+        std::shared_ptr<::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
         o4->setValue(value);
       }
 {% end source %}\

--- a/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -80,7 +80,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         // ${parent} is abstract, is reference and occurs more than once
         // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
@@ -89,7 +89,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
@@ -98,7 +98,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract and not a reference
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o = ome::compat::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -122,7 +122,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
+        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -131,7 +131,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        ome::compat::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}().lock());
+        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
@@ -197,10 +197,10 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${prop.name} is abstract and is a reference
-        ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
+        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
+        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         root->addReference(o_base, ref);
         // ${parent} is abstract
@@ -211,48 +211,48 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when v['level'] == 2 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${obj.langTypeNS}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${obj.langTypeNS}>());
             o${i}->add${v['concreteName']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
             o${i}->add${v['concreteName']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
 {% if not v['isAbstractSub'] %}\
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['type']}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
             o${i}->set${v['name']}(value);
 {% end %}\
 {% if v['isAbstractSub'] %}\
-            ome::compat::shared_ptr< ${v['concreteType']}> value(ome::compat::make_shared< ${v['concreteType']}>());
+            std::shared_ptr< ${v['concreteType']}> value(std::make_shared< ${v['concreteType']}>());
             o${i}->set${v['name']}(value);
 {% end %}\
           }
 {% end %}\
 {% end %}\
-        ome::compat::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         root->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(ome::compat::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -261,7 +261,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(ome::compat::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\
@@ -269,10 +269,10 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs more than once
-        ome::compat::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(ome::compat::make_shared< ${prop.instanceTypeNS}>());
+        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
+        std::shared_ptr< ::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast< ::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         root->addReference(modelObject, ref);
 {% end %}\
@@ -282,37 +282,37 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when v['max_occurs'] > 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['concreteType']}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['concreteType']}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
 {% when v['max_occurs'] == 1 %}\
 {% if i == 0 %}\
-        ome::compat::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
+        std::shared_ptr<OMEXMLMetadataRoot>& o0(this->root);
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
-            ome::compat::shared_ptr< ${v['type']}> value(ome::compat::make_shared< ${v['concreteType']}>());
+            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['concreteType']}>());
             o${i}->set${v['name']}(value);
           }
 {% end %}\
 {% end %}\
 {% if not v['isAbstractSub'] %}\
-        ome::compat::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% end %}\
 {% if v['isAbstractSub'] %}\
-        ome::compat::shared_ptr< ${v['concreteType']}> o${i + 1} = ome::compat::static_pointer_cast< ${v['concreteType']}>(o${i}->${v['accessor']});
+        std::shared_ptr< ${v['concreteType']}> o${i + 1} = std::static_pointer_cast< ${v['concreteType']}>(o${i}->${v['accessor']});
 {% end %}\
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(ome::compat::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
+        std::shared_ptr< ::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast< ::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         root->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        ome::compat::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(ome::compat::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -321,7 +321,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(ome::compat::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\
@@ -408,7 +408,7 @@ ${customContent[obj.name][prop.name]}
           ret = "safe_fetch(%s->%s, \"%s [%s]\")" % (ret, calls[call]['accessor'], method, calls[call]['accessor'])
           if 'isAbstractSub' in calls[call]:
             if calls[call]['isAbstractSub']:
-              ret = "(ome::compat::dynamic_pointer_cast< ome::xml::model::"+calls[call]['concreteName']+">("+ret+"))"
+              ret = "(std::dynamic_pointer_cast< ome::xml::model::"+calls[call]['concreteName']+">("+ret+"))"
     return ret
 
   def getCounterMethod(multipath, parent, name):
@@ -511,8 +511,8 @@ namespace
 
   // Throw an exception if a pointer is invalid.
   template<typename T>
-  ome::compat::shared_ptr<T>
-  safe_fetch(ome::compat::shared_ptr<T> ptr,
+  std::shared_ptr<T>
+  safe_fetch(std::shared_ptr<T> ptr,
              const char * const method)
   {
     if (!ptr)
@@ -523,11 +523,11 @@ namespace
 
   // Throw an exception if a pointer is invalid.
   template<typename T>
-  ome::compat::shared_ptr<T>
-  safe_fetch(ome::compat::weak_ptr<T>   ptr,
+  std::shared_ptr<T>
+  safe_fetch(std::weak_ptr<T>   ptr,
              const char * const method)
   {
-    ome::compat::shared_ptr<T> shared(ptr.lock());
+    std::shared_ptr<T> shared(ptr.lock());
     if (!shared)
       throw ome::xml::meta::MetadataException("OMEXMLMetadata", method,
                                               "Internal metadata store inconsistency: null weak reference");
@@ -564,7 +564,7 @@ namespace ome
       {
       private:
         /// OME-XML model and root node.
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> root; // OME
+        std::shared_ptr<OMEXMLMetadataRoot> root; // OME
 
       public:
 {% end header %}\
@@ -600,21 +600,21 @@ namespace ome
       void
       OMEXMLMetadata::createModel()
       {
-        ome::compat::shared_ptr<MetadataModel> newmodel(ome::compat::make_shared<OMEXMLMetadataRoot>());
+        std::shared_ptr<MetadataModel> newmodel(std::make_shared<OMEXMLMetadataRoot>());
         setModel(newmodel);
       }
 {% end source %}\
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataModel>
+        std::shared_ptr<MetadataModel>
         getModel();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataModel>
+      std::shared_ptr<MetadataModel>
       OMEXMLMetadata::getModel()
       {
-        return ome::compat::dynamic_pointer_cast<MetadataModel>(this->root);
+        return std::dynamic_pointer_cast<MetadataModel>(this->root);
       }
 {% end source %}\
 
@@ -627,14 +627,14 @@ namespace ome
          * @copydoc ::${lang.metadata_package}::MetadataStore::setModel()
          */
         void
-        setModel(ome::compat::shared_ptr<MetadataModel> model);
+        setModel(std::shared_ptr<MetadataModel> model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      OMEXMLMetadata::setModel(ome::compat::shared_ptr<MetadataModel> model)
+      OMEXMLMetadata::setModel(std::shared_ptr<MetadataModel> model)
       {
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> newmodel =
-          ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(model);
+        std::shared_ptr<OMEXMLMetadataRoot> newmodel =
+          std::dynamic_pointer_cast<OMEXMLMetadataRoot>(model);
 
         if (!newmodel)
           throw MetadataException("OMEXMLMetadata", "setModel",
@@ -659,14 +659,14 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in base class.
-        ome::compat::shared_ptr<MetadataRoot>
+        std::shared_ptr<MetadataRoot>
         getRoot();
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr<MetadataRoot>
+      std::shared_ptr<MetadataRoot>
       OMEXMLMetadata::getRoot()
       {
-        return ome::compat::dynamic_pointer_cast<MetadataRoot>(this->root);
+        return std::dynamic_pointer_cast<MetadataRoot>(this->root);
       }
 {% end source %}\
 
@@ -679,14 +679,14 @@ namespace ome
          * @copydoc ::${lang.metadata_package}::MetadataStore::setRoot()
          */
         void
-        setRoot(ome::compat::shared_ptr<MetadataRoot> root);
+        setRoot(std::shared_ptr<MetadataRoot> root);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      OMEXMLMetadata::setRoot(ome::compat::shared_ptr<MetadataRoot> root)
+      OMEXMLMetadata::setRoot(std::shared_ptr<MetadataRoot> root)
       {
-        ome::compat::shared_ptr<OMEXMLMetadataRoot> newroot =
-          ome::compat::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
+        std::shared_ptr<OMEXMLMetadataRoot> newroot =
+          std::dynamic_pointer_cast<OMEXMLMetadataRoot>(root);
 
         if (!newroot)
           throw MetadataException("OMEXMLMetadata", "setRoot",
@@ -967,28 +967,28 @@ namespace ome
       {
         if (root->sizeOfImageList() == imageIndex)
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(ome::compat::make_shared< ::${lang.omexml_model_package}::Image>());
+            std::shared_ptr< ::${lang.omexml_model_package}::Image> newImage(std::make_shared< ::${lang.omexml_model_package}::Image>());
             root->addImage(newImage);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
+        std::shared_ptr< ::${lang.omexml_model_package}::Image> o1 = root->getImage(imageIndex);
         if (!o1->getPixels()) // null
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(ome::compat::make_shared< ::${lang.omexml_model_package}::Pixels>());
+            std::shared_ptr< ::${lang.omexml_model_package}::Pixels> newPixels(std::make_shared< ::${lang.omexml_model_package}::Pixels>());
             o1->setPixels(newPixels);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
+        std::shared_ptr< ::${lang.omexml_model_package}::Pixels> o2 = o1->getPixels();
         if (o2->sizeOfTiffDataList() == tiffDataIndex)
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::TiffData> newTiffData(ome::compat::make_shared< ::${lang.omexml_model_package}::TiffData>());
+            std::shared_ptr< ::${lang.omexml_model_package}::TiffData> newTiffData(std::make_shared< ::${lang.omexml_model_package}::TiffData>());
             o2->addTiffData(newTiffData);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
+        std::shared_ptr< ::${lang.omexml_model_package}::TiffData> o3 = o2->getTiffData(tiffDataIndex);
         if (!o3->getUUID()) // null
           {
-            ome::compat::shared_ptr< ::${lang.omexml_model_package}::UUID> newUUID(ome::compat::make_shared< ::${lang.omexml_model_package}::UUID>());
+            std::shared_ptr< ::${lang.omexml_model_package}::UUID> newUUID(std::make_shared< ::${lang.omexml_model_package}::UUID>());
             o3->setUUID(newUUID);
           }
-        ome::compat::shared_ptr< ::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
+        std::shared_ptr< ::${lang.omexml_model_package}::UUID> o4 = o3->getUUID();
         o4->setValue(value);
       }
 {% end source %}\
@@ -1038,7 +1038,7 @@ ${counter(k, o, v)}\
       const std::string&
       OMEXMLMetadata::getUUID() const
       {
-        ome::compat::shared_ptr<const std::string> uuid = root->getUUID();
+        std::shared_ptr<const std::string> uuid = root->getUUID();
         if (uuid)
           return *root->getUUID();
         else
@@ -1073,7 +1073,7 @@ ${counter(k, o, v)}\
       OMEXMLMetadata::getGenericExcitationSourceMap(index_type instrumentIndex,
                                                     index_type lightSourceIndex) const
       {
-        return *safe_fetch(safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(root, "getGenericExcitationSourceMap [root]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->getMap(), "getGenericExcitationSourceMap [getMap()]");
+        return *safe_fetch(safe_fetch(std::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(root, "getGenericExcitationSourceMap [root]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->getMap(), "getGenericExcitationSourceMap [getMap()]");
       }
 {% end source %}\
 
@@ -1193,7 +1193,7 @@ ${getter(k, o, prop, v)}\
       void
       OMEXMLMetadata::setUUID(const std::string& uuid)
       {
-        ome::compat::shared_ptr<std::string> newString(ome::compat::make_shared<std::string>(uuid));
+        std::shared_ptr<std::string> newString(std::make_shared<std::string>(uuid));
         root->setUUID(newString);
       }
 {% end source %}\
@@ -1228,8 +1228,8 @@ ${getter(k, o, prop, v)}\
                                                     index_type                                          instrumentIndex,
                                                     index_type                                          lightSourceIndex)
       {
-        ome::compat::shared_ptr<ome::xml::model::primitives::OrderedMultimap> map(ome::compat::make_shared<ome::xml::model::primitives::OrderedMultimap>(value));
-        safe_fetch(ome::compat::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(root, "getGenericExcitationSourceMap [root]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->setMap(map);
+        std::shared_ptr<ome::xml::model::primitives::OrderedMultimap> map(std::make_shared<ome::xml::model::primitives::OrderedMultimap>(value));
+        safe_fetch(std::dynamic_pointer_cast<ome::xml::model::GenericExcitationSource>(safe_fetch(safe_fetch(safe_fetch(root, "getGenericExcitationSourceMap [root]")->getInstrument(instrumentIndex), "getGenericExcitationSourceMap [getInstrument(instrumentIndex)]")->getLightSource(lightSourceIndex), "getGenericExcitationSourceMap [getLightSource(lightSourceIndex)]")), "getGenericExcitationSourceMap [is GenericExcitationSource]")->setMap(map);
       }
 {% end source %}\
 
@@ -1244,7 +1244,7 @@ ${getter(k, o, prop, v)}\
       OMEXMLMetadata::setImagingEnvironmentMap(const ome::xml::model::primitives::OrderedMultimap& value,
                                                index_type                                          imageIndex)
       {
-        ome::compat::shared_ptr<ome::xml::model::primitives::OrderedMultimap> map(ome::compat::make_shared<ome::xml::model::primitives::OrderedMultimap>(value));
+        std::shared_ptr<ome::xml::model::primitives::OrderedMultimap> map(std::make_shared<ome::xml::model::primitives::OrderedMultimap>(value));
         safe_fetch(safe_fetch(safe_fetch(root, "getImagingEnvironmentMap [root]")->getImage(imageIndex), "getImagingEnvironmentMap [getImage(imageIndex)]")->getImagingEnvironment(), "getImagingEnvironmentMap [getImagingEnvironment()]")->setMap(map);
       }
 {% end source %}\

--- a/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -80,7 +80,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         // ${parent} is abstract, is reference and occurs more than once
         // ${obj.name} o = (${obj.name}) root.${".".join(accessor(obj.name, parent, prop)[:-1])};
         // return o.getLinked${prop.methodName}(${index_name_string(prop.name)}).getID();
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        std::shared_ptr<${obj.langTypeNS}> o = std::dynamic_pointer_cast<${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (ret)
           return ret->getID();
@@ -89,7 +89,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${parent} is abstract
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        std::shared_ptr<${obj.langTypeNS}> o = std::dynamic_pointer_cast<${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
         ${prop.assignableType[' const']} ret(o->getLinked${prop.methodName}().lock());
         if (ret)
           return ret->getID();
@@ -98,7 +98,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when is_abstract(parent) %}\
         // ${parent} is abstract and not a reference
-        std::shared_ptr< ${obj.langTypeNS}> o = std::dynamic_pointer_cast< ${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
+        std::shared_ptr<${obj.langTypeNS}> o = std::dynamic_pointer_cast<${obj.langTypeNS}>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], getPropMethod(is_multi_path[o.name], parent, obj.name, prop))});
 {% if prop.minOccurs == 0 %}\
         ${prop.retType[' const']} ret = o->get${prop.methodName}();
         if (ret)
@@ -122,7 +122,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
+        std::shared_ptr<${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}(${index_name_string(prop.name)}).lock());
         if (annotation)
           return annotation->getID();
         /// @todo: Need an exception for store inconsistency.
@@ -131,7 +131,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs only once
-        std::shared_ptr< ${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}().lock());
+        std::shared_ptr<${prop.langTypeNS}> annotation(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), getPropMethod(is_multi_path[o.name], parent, obj.name, prop))}->getLinked${prop.methodName}().lock());
         if (annotation)
           return annotation->getID();
         throw MetadataException("OMEXMLMetadata", "get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
@@ -197,7 +197,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${prop.name} is abstract and is a reference
-        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
+        std::shared_ptr<${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared<${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
         std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
@@ -215,7 +215,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${obj.langTypeNS}>());
+            std::shared_ptr<${v['type']}> value(std::make_shared<${obj.langTypeNS}>());
             o${i}->add${v['concreteName']}(value);
           }
 {% end %}\
@@ -225,7 +225,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
+            std::shared_ptr<${v['type']}> value(std::make_shared<${v['type']}>());
             o${i}->add${v['concreteName']}(value);
           }
 {% end %}\
@@ -236,23 +236,23 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         if (!o${i}->${v['accessor']}) // null
           {
 {% if not v['isAbstractSub'] %}\
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['type']}>());
+            std::shared_ptr<${v['type']}> value(std::make_shared<${v['type']}>());
             o${i}->set${v['name']}(value);
 {% end %}\
 {% if v['isAbstractSub'] %}\
-            std::shared_ptr< ${v['concreteType']}> value(std::make_shared< ${v['concreteType']}>());
+            std::shared_ptr<${v['concreteType']}> value(std::make_shared<${v['concreteType']}>());
             o${i}->set${v['name']}(value);
 {% end %}\
           }
 {% end %}\
 {% end %}\
-        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        std::shared_ptr<${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% if v['level'] == 2 %}\
 {% if "ID" == prop.name %}\
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         root->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        std::shared_ptr<${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast<${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -261,7 +261,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(std::make_shared<${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\
@@ -269,7 +269,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr< ${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared< ${prop.instanceTypeNS}>());
+        std::shared_ptr<${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared<${prop.instanceTypeNS}>());
         ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
         std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
@@ -286,7 +286,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
         if (o${i}->sizeOf${v['name']}List() == ${index_name_string(v['name'])})
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['concreteType']}>());
+            std::shared_ptr<${v['type']}> value(std::make_shared<${v['concreteType']}>());
             o${i}->add${v['name']}(value);
           }
 {% end %}\
@@ -296,23 +296,23 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
         if (!o${i}->${v['accessor']}) // null
           {
-            std::shared_ptr< ${v['type']}> value(std::make_shared< ${v['concreteType']}>());
+            std::shared_ptr<${v['type']}> value(std::make_shared<${v['concreteType']}>());
             o${i}->set${v['name']}(value);
           }
 {% end %}\
 {% end %}\
 {% if not v['isAbstractSub'] %}\
-        std::shared_ptr< ${v['type']}> o${i + 1} = o${i}->${v['accessor']};
+        std::shared_ptr<${v['type']}> o${i + 1} = o${i}->${v['accessor']};
 {% end %}\
 {% if v['isAbstractSub'] %}\
-        std::shared_ptr< ${v['concreteType']}> o${i + 1} = std::static_pointer_cast< ${v['concreteType']}>(o${i}->${v['accessor']});
+        std::shared_ptr<${v['concreteType']}> o${i + 1} = std::static_pointer_cast<${v['concreteType']}>(o${i}->${v['accessor']});
 {% end %}\
 {% if v['level'] == 1 %}\
 {% if "ID" == prop.name %}\
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o${i + 1}_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(o${i + 1}));
         root->addModelObject(${prop.argumentName}, o${i + 1}_base);
 {% end %}\
-        std::shared_ptr< ${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast< ${obj.langTypeNS}>(o${i + 1}));
+        std::shared_ptr<${obj.langTypeNS}> o${i + 1}_mostderived(std::static_pointer_cast<${obj.langTypeNS}>(o${i + 1}));
         if (!o${i + 1}_mostderived)
           throw MetadataException("OMEXMLMetadata", "set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}",
                                   "Internal metadata store inconsistency: null object");
@@ -321,7 +321,7 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
         o${i + 1}_mostderived->set${prop.methodName}(${prop.argumentName});
 {% end %}\
 {% if prop.isShared %}\
-        ${prop.instanceVariableType} newval(std::make_shared< ${prop.langTypeNS}>(${prop.argumentName}));
+        ${prop.instanceVariableType} newval(std::make_shared<${prop.langTypeNS}>(${prop.argumentName}));
         o${i + 1}_mostderived->set${prop.methodName}(newval);
 {% end %}\
 {% end %}\

--- a/xsd-fu/templates-cpp/OMEXMLModelEnum.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelEnum.template
@@ -83,14 +83,6 @@
 using boost::trim;
 using boost::format;
 
-namespace
-{
-
-  typedef std::pair<std::string,${klass.langTypeNS}::enum_value> smap;
-  typedef std::pair<${klass.langTypeNS}::enum_value,std::string> vmap;
-
-}
-
 {% end %}\
 namespace ome
 {
@@ -322,30 +314,27 @@ namespace ome
         const ${klass.langType}::string_map_type&
         ${klass.langType}::strings()
         {
-          const smap init_string_values[] =
+          static const string_map_type string_map
             {
 {% for value in klass.possibleValues %}\
 {% if klass.enumProperties is not None and value in klass.enumProperties and klass.enumProperties[value].get('enum', None) is not None %}\
 {% if value == klass.possibleValues[-1] %}\
-              smap("${value}", ${klass.langTypeNS}::${klass.enumProperties[value].enum}),
+              { "${value}", ${klass.langTypeNS}::${klass.enumProperties[value].enum} }
 {% end %}\
 {% if value != klass.possibleValues[-1] %}\
-              smap("${value}", ${klass.langTypeNS}::${klass.enumProperties[value].enum}),
+              { "${value}", ${klass.langTypeNS}::${klass.enumProperties[value].enum} },
 {% end %}\
 {% end %}\
 {% if klass.enumProperties is None or not value in klass.enumProperties or klass.enumProperties[value].get('enum', None) is None %}\
 {% if value == klass.possibleValues[-1] %}\
-              smap("${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+              { "${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()} }
 {% end %}\
 {% if value != klass.possibleValues[-1] %}\
-              smap("${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+              { "${value}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()} },
 {% end %}\
 {% end %}\
 {% end for %}\
             };
-
-          static const string_map_type string_map(init_string_values,
-                                                  init_string_values + (sizeof(init_string_values) / sizeof(init_string_values[0])));
 
           return string_map;
         }
@@ -353,30 +342,27 @@ namespace ome
         const ${klass.langType}::value_map_type&
         ${klass.langType}::values()
         {
-          vmap init_value_values[] =
+          static const value_map_type value_map
             {
 {% for value in klass.possibleValues %}\
 {% if klass.enumProperties is not None and value in klass.enumProperties and klass.enumProperties[value].get('enum', None) is not None %}\
 {% if value == klass.possibleValues[-1] %}\
-              vmap(${klass.langTypeNS}::${klass.enumProperties[value].enum}, "${value}")
+              { ${klass.langTypeNS}::${klass.enumProperties[value].enum}, "${value}" }
 {% end %}\
 {% if value != klass.possibleValues[-1] %}\
-              vmap(${klass.langTypeNS}::${klass.enumProperties[value].enum}, "${value}"),
+              { ${klass.langTypeNS}::${klass.enumProperties[value].enum}, "${value}" },
 {% end %}\
 {% end %}\
 {% if klass.enumProperties is None or not value in klass.enumProperties or klass.enumProperties[value].get('enum', None) is None %}\
 {% if value == klass.possibleValues[-1] %}\
-              vmap(${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}")
+              { ${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}" }
 {% end %}\
 {% if value != klass.possibleValues[-1] %}\
-              vmap(${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}"),
+              { ${klass.langTypeNS}::${enum_value_name(value, False).upper()}, "${value}" },
 {% end %}\
 {% end %}\
 {% end for %}\
             };
-
-          static const value_map_type value_map(init_value_values,
-                                                init_value_values + (sizeof(init_value_values) / sizeof(init_value_values[0])));
 
           return value_map;
         }
@@ -384,25 +370,25 @@ namespace ome
         const ${klass.langType}::string_map_type&
         ${klass.langType}::lowercase_strings()
         {
-          smap init_lcase_string_values[] =
+          static const string_map_type lcase_string_map
             {
 {% if klass.isUnitsEnumeration %}\
 {% for value in klass.possibleValues %}\
 {% if klass.enumProperties is not None and value in klass.enumProperties %}\
 {% if klass.enumProperties[value].get('name', None) is not None %}\
-              smap("${klass.enumProperties[value].name.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum}),
+              { "${klass.enumProperties[value].name.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum} },
 {% end %}\
 {% if klass.enumProperties[value].get('plural', None) is not None %}\
-              smap("${klass.enumProperties[value].plural.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum}),
+              { "${klass.enumProperties[value].plural.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum} },
 {% end %}\
 {% if klass.enumProperties[value].get('altname', None) is not None %}\
-              smap("${klass.enumProperties[value].altname.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum}),
+              { "${klass.enumProperties[value].altname.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum} },
 {% end %}\
 {% if klass.enumProperties[value].get('altplural', None) is not None %}\
-              smap("${klass.enumProperties[value].altplural.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum}),
+              { "${klass.enumProperties[value].altplural.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum} },
 {% end %}\
 {% if klass.enumProperties is None or not value in klass.enumProperties or klass.enumProperties[value].get('enum', None) is None %}\
-              smap("${enum_value_name(value, False).lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+              { "${enum_value_name(value, False).lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()} },
 {% end %}\
 {% end %}\
 {% end for %}\
@@ -410,25 +396,22 @@ namespace ome
 {% for value in klass.possibleValues %}\
 {% if klass.enumProperties is not None and value in klass.enumProperties and klass.enumProperties[value].get('enum', None) is not None %}\
 {% if value == klass.possibleValues[-1] %}\
-              smap("${value.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum})
+              { "${value.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum} }
 {% end %}\
 {% if value != klass.possibleValues[-1] %}\
-              smap("${value.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum}),
+              { "${value.lower()}", ${klass.langTypeNS}::${klass.enumProperties[value].enum} },
 {% end %}\
 {% end %}\
 {% if klass.enumProperties is None or not value in klass.enumProperties or klass.enumProperties[value].get('enum', None) is None %}\
 {% if value == klass.possibleValues[-1] %}\
-              smap("${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()})
+              { "${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()} }
 {% end %}\
 {% if value != klass.possibleValues[-1] %}\
-              smap("${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()}),
+              { "${value.lower()}", ${klass.langTypeNS}::${enum_value_name(value, False).upper()} },
 {% end %}\
 {% end %}\
 {% end for %}\
             };
-
-          static const string_map_type lcase_string_map(init_lcase_string_values,
-                                                        init_lcase_string_values + (sizeof(init_lcase_string_values) / sizeof(init_lcase_string_values[0])));
 
           return lcase_string_map;
         }

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -256,7 +256,7 @@ namespace ome
       private:
         class Impl;
         /// Private implementation details.
-        ome::compat::shared_ptr<Impl> impl;
+        std::shared_ptr<Impl> impl;
 
       public:
         /// Default constructor.
@@ -272,7 +272,7 @@ namespace ome
 {% if klass.parentName is not None %}\
         ${klass.parentName}(),
 {% end has parent %}\
-        impl(ome::compat::make_shared<Impl>())
+        impl(std::make_shared<Impl>())
       {
         logger.add_attribute("ClassName", logging::attributes::constant<std::string>("${klass.name}"));
 {% if klass.name == "AffineTransform" %}\
@@ -304,7 +304,7 @@ namespace ome
 {% if klass.parentName is not None %}\
         ${klass.parentName}(copy),
 {% end has parent %}\
-        impl(ome::compat::make_shared<Impl>(*copy.impl))
+        impl(std::make_shared<Impl>(*copy.impl))
       {
       }
 {% end source %}\
@@ -336,16 +336,16 @@ namespace ome
          *
          * @returns a new model object.
          */
-        static ome::compat::shared_ptr< ${klass.name}>
+        static std::shared_ptr< ${klass.name}>
         create(const common::xml::dom::Element& element,
                ${lang.omexml_model_package}::OMEModel& model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr< ${klass.name}>
+      std::shared_ptr< ${klass.name}>
       ${klass.name}::create(const common::xml::dom::Element& element,
                               ${lang.omexml_model_package}::OMEModel& model)
       {
-        ome::compat::shared_ptr< ${klass.name}> newinstance(ome::compat::make_shared< ${klass.name}>());
+        std::shared_ptr< ${klass.name}> newinstance(std::make_shared< ${klass.name}>());
         newinstance->update(element, model);
         return newinstance;
       }
@@ -354,17 +354,17 @@ namespace ome
 {% if klass.name == "OME" %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         /// @copydoc ome::xml::model::OMEModel::addModelObject
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         addModelObject (const std::string&                                           id,
-                        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+                        std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+      std::shared_ptr< ::ome::xml::model::OMEModelObject>
       OME::addModelObject(const std::string&                                           id,
-                          ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+                          std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
       {
         // Don't store references.
-        if (ome::compat::dynamic_pointer_cast<Reference>(object))
+        if (std::dynamic_pointer_cast<Reference>(object))
           return object;
 
         object_map_type::iterator i = this->impl->modelObjects.find(id);
@@ -379,14 +379,14 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in parent.
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         removeModelObject (const std::string& id);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+      std::shared_ptr< ::ome::xml::model::OMEModelObject>
       OME::removeModelObject(const std::string& id)
       {
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+        std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
 
         object_map_type::iterator i = this->impl->modelObjects.find(id);
         if (i != this->impl->modelObjects.end())
@@ -401,14 +401,14 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in parent.
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr< ::ome::xml::model::OMEModelObject>
         getModelObject (const std::string& id) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>
+      std::shared_ptr< ::ome::xml::model::OMEModelObject>
       OME::getModelObject(const std::string& id) const
       {
-        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+        std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
 
         object_map_type::const_iterator i = this->impl->modelObjects.find(id);
         if (i != this->impl->modelObjects.end())
@@ -434,13 +434,13 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         /// @copydoc ome::xml::model::OMEModel::addReference
         bool
-        addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                      ome::compat::shared_ptr<Reference>&                          b);
+        addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                      std::shared_ptr<Reference>&                          b);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      OME::addReference (ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
-                         ome::compat::shared_ptr<Reference>&                          b)
+      OME::addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+                         std::shared_ptr<Reference>&                          b)
       {
         reference_map_type::iterator i = this->impl->references.find(a);
 
@@ -483,7 +483,7 @@ namespace ome
              i != this->impl->references.end();
              ++i)
           {
-            const ome::compat::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
+            const std::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
 
             if (!a)
               {
@@ -520,7 +520,7 @@ namespace ome
                       {
                         const std::string& referenceID = (*ref)->getID();
 
-                        ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
+                        std::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                         if (!b)
                           {
                             BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
@@ -531,7 +531,7 @@ namespace ome
                           }
                         else
                           {
-                            ome::compat::shared_ptr< ::ome::xml::model::OMEModelObject> aw(ome::compat::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
+                            std::shared_ptr< ::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
                             aw->link(*ref, b);
                           }
                       }
@@ -681,10 +681,10 @@ ${customUpdatePropertyContent[prop.name]}
              elem != ${prop.name}_nodeList.end();
              ++elem)
           {
-            ome::compat::shared_ptr<${prop.name}> rcptr(ome::compat::make_shared< ${prop.name}>());
+            std::shared_ptr<${prop.name}> rcptr(std::make_shared< ${prop.name}>());
             rcptr->setID(elem->getAttribute("ID"));
-            ome::compat::shared_ptr<Reference> rptr(ome::compat::static_pointer_cast<Reference>(rcptr));
-            ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> optr(ome::compat::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+            std::shared_ptr<Reference> rptr(std::static_pointer_cast<Reference>(rcptr));
+            std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> optr(std::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
             model.addReference(optr, rptr);
           }
 {% end %}\
@@ -710,7 +710,7 @@ ${customUpdatePropertyContent[prop.name]}
              set${prop.methodName}(element.getAttribute("${prop.name}"));
 {% end if %}\
              // Adding this model object to the model handler
-             ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(ome::compat::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+             std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(std::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
              model.addModelObject(getID(), thisptr);
            }
 {% end when prop.isAttribute and prop.name == "ID" %}\
@@ -727,7 +727,7 @@ ${customUpdatePropertyContent[prop.name]}
             // Attribute property which is an enumeration ${prop.name}
 {% if prop.minOccurs == 0 %}\
             std::string text(element.getAttribute("${prop.name}"));
-            ${prop.instanceVariableType} nattr(ome::compat::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} nattr(std::make_shared< ${prop.langTypeNS}>(text));
             set${prop.methodName}(nattr);
 {% end prop.minOccurs == 0 %}\
 {% if prop.minOccurs > 0 %}\
@@ -778,13 +778,13 @@ ${customUpdatePropertyContent[prop.name]}
             // Element property ${prop.name} which is complex (has sub-elements)
 {% if prop.minOccurs == 0 or (not lang.hasPrimitiveType(prop.langType) and not prop.isEnumeration) %}\
             common::xml::dom::Element elem(${prop.name}_nodeList.at(0));
-            // While ome::compat::make_shared<> works, here,
+            // While std::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
 {% if prop.langTypeNS != 'ome::xml::model::primitives::OrderedMultimap' %}\
             ${prop.instanceVariableType} p(${prop.langTypeNS}::create(elem, model));
 {% end %}\
 {% if prop.langTypeNS == 'ome::xml::model::primitives::OrderedMultimap' %}\
-            ${prop.instanceVariableType} p(ome::compat::make_shared< ${prop.langTypeNS}>());
+            ${prop.instanceVariableType} p(std::make_shared< ${prop.langTypeNS}>());
 
             std::vector<common::xml::dom::Element> children(getChildrenByTagName(elem, "M"));
             for (std::vector<common::xml::dom::Element>::iterator child = children.begin();
@@ -835,7 +835,7 @@ ${customUpdatePropertyContent[prop.name]}
             // sub-elements)
             std::string text(${prop.name}_nodeList.at(0).getTextContent());
 {% if prop.minOccurs == 0 %}\
-            ${prop.instanceVariableType} ns(ome::compat::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} ns(std::make_shared< ${prop.langTypeNS}>(text));
             set${prop.methodName}(ns);
 {% end %}\
 {% if prop.minOccurs > 0 %}\
@@ -863,7 +863,7 @@ ${customUpdatePropertyContent[prop.name]}
       for (std::vector<common::xml::dom::Element>::iterator elem = ${subClass}_nodeList.begin();
            elem != ${subClass}_nodeList.end();++elem)
         {
-          ome::compat::shared_ptr<${prop.methodName}> object(${subClass}::create(*elem, model));
+          std::shared_ptr<${prop.methodName}> object(${subClass}::create(*elem, model));
           add${prop.methodName}(object);
         }
 {% end %}\
@@ -885,10 +885,10 @@ ${customUpdatePropertyContent[prop.name]}
                  inner_elem != ${inner_prop.name}_nodeList.end();
                  ++inner_elem)
                    {
-                     // While ome::compat::make_shared<> works, here,
+                     // While std::make_shared<> works, here,
                      // boost::make_shared<> does not, so use new
                      // directly.
-                     ome::compat::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(*elem, model));
+                     std::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(*elem, model));
                      object->update(*inner_elem, model);
                      add${prop.methodName}(object);
                    }
@@ -905,9 +905,9 @@ ${customUpdatePropertyContent[prop.name]}
              elem != ${prop.name}_nodeList.end();
              ++elem)
           {
-            // While ome::compat::make_shared<> works, here,
+            // While std::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
-            ome::compat::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(*elem, model));
+            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(*elem, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -921,7 +921,7 @@ ${customUpdatePropertyContent[prop.name]}
              ++elem)
           {
             std::string text(element.getTextContent());
-            ome::compat::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
+            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -942,13 +942,13 @@ ${customUpdatePropertyContent[prop.name]}
 
         /// @copydoc ${lang.omexml_model_package}::OMEModelObject::link
         bool
-        link (ome::compat::shared_ptr<Reference>& reference,
-              ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object);
+        link (std::shared_ptr<Reference>& reference,
+              std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::link (ome::compat::shared_ptr<Reference>& reference,
-                           ome::compat::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object)
+      ${klass.name}::link (std::shared_ptr<Reference>& reference,
+                           std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object)
       {
         if (${klass.parentName}::link(reference, object))
           {
@@ -956,18 +956,18 @@ ${customUpdatePropertyContent[prop.name]}
           }
 {% for prop in klass.properties.values() %}\
 {% if prop.isReference %}\
-        if (ome::compat::dynamic_pointer_cast<${prop.name}>(reference))
+        if (std::dynamic_pointer_cast<${prop.name}>(reference))
           {
             /// @todo This bit is silly; why do we have two dynamic_casts here.
-            ome::compat::shared_ptr<${prop.langTypeNS}> o_casted = ome::compat::dynamic_pointer_cast<${prop.langTypeNS}>(object);
+            std::shared_ptr<${prop.langTypeNS}> o_casted = std::dynamic_pointer_cast<${prop.langTypeNS}>(object);
             if (o_casted)
               {
 {% if not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-                o_casted->link${klass.type}(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+                o_casted->link${klass.type}(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-                o_casted->link${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+                o_casted->link${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
 {% end %}\
 {% end %}\
 {% if prop.maxOccurs > 1 %}\
@@ -978,7 +978,7 @@ ${customUpdatePropertyContent[prop.name]}
                   }
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
-                typedef OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::nth_index<1>::type container_set_type;
+                typedef OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::nth_index<1>::type container_set_type;
                 container_set_type::iterator it(this->impl->${prop.instanceVariableName}.get<1>().find(o_casted));
                 if (it != this->impl->${prop.instanceVariableName}.get<1>().end())
                   {
@@ -1084,11 +1084,11 @@ ${customUpdatePropertyContent[prop.name]}
          * @returns a weak pointer to the ${prop.methodName}.
          * @throws std::out_of_range if the index is invalid.
          */
-        const ome::compat::weak_ptr<${prop.langTypeNS}>&
+        const std::weak_ptr<${prop.langTypeNS}>&
         getLinked${prop.methodName} (${prop.instanceVariableType}::size_type index) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      const ome::compat::weak_ptr<${prop.langTypeNS}>&
+      const std::weak_ptr<${prop.langTypeNS}>&
       ${klass.name}::getLinked${prop.methodName} (${prop.instanceVariableType}::size_type index) const
       {
         return this->impl->${prop.instanceVariableName}.at(index);
@@ -1106,21 +1106,21 @@ ${customUpdatePropertyContent[prop.name]}
          * @returns a weak pointer to the ${prop.methodName}.
          * @throws std::out_of_range if the index is invalid.
          */
-        const ome::compat::weak_ptr<${prop.langTypeNS}>&
+        const std::weak_ptr<${prop.langTypeNS}>&
         setLinked${prop.methodName} (${prop.instanceVariableType}::size_type index,
-                                     const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+                                     const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      const ome::compat::weak_ptr<${prop.langTypeNS}>&
+      const std::weak_ptr<${prop.langTypeNS}>&
       ${klass.name}::setLinked${prop.methodName}(${prop.instanceVariableType}::size_type index,
-                                                 const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+                                                 const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isReference and not prop.isBackReference %}\
         return this->impl->${prop.instanceVariableName}.at(index) = ${prop.argumentName};
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
         ${prop.instanceVariableType}::iterator it(this->impl->${prop.instanceVariableName}.iterator_to(this->impl->${prop.instanceVariableName}.at(index)));
-        const ome::compat::weak_ptr<${prop.langTypeNS}> wp(${prop.argumentName});
+        const std::weak_ptr<${prop.langTypeNS}> wp(${prop.argumentName});
         this->impl->${prop.instanceVariableName}.replace(it, wp);
         return *it;
 {% end %}\
@@ -1139,18 +1139,18 @@ ${customUpdatePropertyContent[prop.name]}
          * Is this an artifact of the Java API?
          */
         bool
-        link${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        link${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::link${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::link${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->link${klass.type}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->link${klass.type}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->link${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->link${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% end %}\
 {% if not prop.isReference and not prop.isBackReference %}\
@@ -1161,11 +1161,11 @@ ${customUpdatePropertyContent[prop.name]}
           }
 {% end %}\
 {% if prop.isReference or prop.isBackReference %}\
-        typedef OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::nth_index<1>::type container_set_type;
+        typedef OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::nth_index<1>::type container_set_type;
         container_set_type::iterator it(this->impl->${prop.instanceVariableName}.get<1>().find(${prop.argumentName}));
         if (it == this->impl->${prop.instanceVariableName}.get<1>().end())
           {
-            std::pair<OMEModelObject::indexed_container<${prop.langTypeNS}, ome::compat::weak_ptr>::type::iterator, bool> res(this->impl->${prop.instanceVariableName}.push_back(ome::compat::weak_ptr<${prop.langTypeNS}>(${prop.argumentName})));
+            std::pair<OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::iterator, bool> res(this->impl->${prop.instanceVariableName}.push_back(std::weak_ptr<${prop.langTypeNS}>(${prop.argumentName})));
             return res.second;
           }
 {% end %}\
@@ -1190,18 +1190,18 @@ ${customUpdatePropertyContent[prop.name]}
          * aren't preventing duplicates on insertion.
          */
         bool
-        unlink${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        unlink${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      ${klass.name}::unlink${prop.methodName} (const ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::unlink${prop.methodName} (const std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->unlink${klass.type}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->unlink${klass.type}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% if fu.backReference_overridden(prop.name, klass.name) %}\
-        ${prop.argumentName}->unlink${klass.name}${prop.methodName}(ome::compat::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
+        ${prop.argumentName}->unlink${klass.name}${prop.methodName}(std::dynamic_pointer_cast<${klass.name}>(shared_from_this()));
 {% end %}\
 {% end %}\
         bool found = false;
@@ -1248,11 +1248,11 @@ ${customUpdatePropertyContent[prop.name]}
          * @param ${prop.argumentName} the ${prop.methodName} to link.
          */
         void
-        link${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        link${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      ${klass.name}::link${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::link${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
         this->impl->${prop.instanceVariableName} = ${prop.argumentName};
       }
@@ -1269,15 +1269,15 @@ ${customUpdatePropertyContent[prop.name]}
          * internally.
          */
         void
-        unlink${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
+        unlink${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName});
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       void
-      ${klass.name}::unlink${prop.methodName} (ome::compat::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
+      ${klass.name}::unlink${prop.methodName} (std::shared_ptr<${prop.langTypeNS}>& ${prop.argumentName})
       {
-        if (ome::compat::shared_ptr<${prop.langTypeNS}>(this->impl->${prop.instanceVariableName}) == ${prop.argumentName})
+        if (std::shared_ptr<${prop.langTypeNS}>(this->impl->${prop.instanceVariableName}) == ${prop.argumentName})
           {
-            this->impl->${prop.instanceVariableName} = ome::compat::shared_ptr<${prop.langTypeNS}>();
+            this->impl->${prop.instanceVariableName} = std::shared_ptr<${prop.langTypeNS}>();
           }
       }
 {% end source %}\
@@ -1401,7 +1401,7 @@ ${customUpdatePropertyContent[prop.name]}
                                             ${prop.elementArgType} ${prop.argumentName})
       {
 {% if klass.type != 'OME' %}\
-        ome::compat::weak_ptr<${klass.type}> self(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+        std::weak_ptr<${klass.type}> self(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
         ${prop.argumentName}->set${klass.type}(self);
 {% end %}\
 {% if not prop.isReference and not prop.isBackReference %}\
@@ -1431,7 +1431,7 @@ ${customUpdatePropertyContent[prop.name]}
       ${klass.name}::add${prop.methodName} (${prop.elementArgType} ${prop.argumentName})
       {
 {% if klass.type != 'OME' %}\
-        ome::compat::weak_ptr<${klass.type}> self(ome::compat::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
+        std::weak_ptr<${klass.type}> self(std::dynamic_pointer_cast<${klass.type}>(shared_from_this()));
         ${prop.argumentName}->set${klass.type}(self);
 {% end %}\
         this->impl->${prop.instanceVariableName}.push_back(${prop.argumentName});
@@ -1582,8 +1582,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
               // shared_ptr, but keep compatible with the rest of
               // the API to allow consistency for future
               // refactoring.
-              ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
-              ome::compat::shared_ptr<${prop.langTypeNS}> is(i->lock());
+              std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
+              std::shared_ptr<${prop.langTypeNS}> is(i->lock());
               if (is)
                 {
                   o->setID(is->getID());
@@ -1605,8 +1605,8 @@ ${customAsXMLElementPropertyContent[prop.name]}
           // Note that this doesn't strictly need to be a
           // shared_ptr, but keep compatible with the rest of the
           // API to allow consistency for future refactoring.
-          ome::compat::shared_ptr<${prop.name}> o(ome::compat::make_shared< ${prop.name}>());
-          ome::compat::shared_ptr<${prop.langTypeNS}> sv(this->impl->${prop.instanceVariableName}.lock());
+          std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
+          std::shared_ptr<${prop.langTypeNS}> sv(this->impl->${prop.instanceVariableName}.lock());
           if (sv)
             {
               o->setID(sv->getID());

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -479,15 +479,13 @@ namespace ome
       {
         size_type unhandledReferences = 0;
 
-        for (reference_map_type::iterator i = this->impl->references.begin();
-             i != this->impl->references.end();
-             ++i)
+        for (auto& i : this->impl->references)
           {
-            const std::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i->first);
+            const std::shared_ptr<const ::ome::xml::model::OMEModelObject>& a(i.first);
 
             if (!a)
               {
-                const reference_list_type& references(i->second);
+                const reference_list_type& references(i.second);
 
                 if (references.empty())
                   {
@@ -504,13 +502,11 @@ namespace ome
               }
             else
               {
-                reference_list_type& references(i->second);
+                reference_list_type& references(i.second);
 
-                for (reference_list_type::iterator ref = references.begin();
-                     ref != references.end();
-                     ++ref)
+                for (auto& ref : references)
                   {
-                    if (!(*ref))
+                    if (!ref)
                       {
                         BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
                           << typeid(*a).name() << "@" << a
@@ -518,7 +514,7 @@ namespace ome
                       }
                     else
                       {
-                        const std::string& referenceID = (*ref)->getID();
+                        const std::string& referenceID = ref->getID();
 
                         std::shared_ptr<::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                         if (!b)
@@ -532,7 +528,7 @@ namespace ome
                         else
                           {
                             std::shared_ptr<::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast<::ome::xml::model::OMEModelObject>(a));
-                            aw->link(*ref, b);
+                            aw->link(ref, b);
                           }
                       }
                   }
@@ -677,12 +673,10 @@ ${customUpdatePropertyContent[prop.name]}
 {% when prop.isReference %}\
         // Element reference ${prop.name}
         std::vector<common::xml::dom::Element> ${prop.name}_nodeList(getChildrenByTagName(element, "${prop.name}"));
-        for (std::vector<common::xml::dom::Element>::iterator elem = ${prop.name}_nodeList.begin();
-             elem != ${prop.name}_nodeList.end();
-             ++elem)
+        for (auto& elem : ${prop.name}_nodeList)
           {
             std::shared_ptr<${prop.name}> rcptr(std::make_shared<${prop.name}>());
-            rcptr->setID(elem->getAttribute("ID"));
+            rcptr->setID(elem.getAttribute("ID"));
             std::shared_ptr<Reference> rptr(std::static_pointer_cast<Reference>(rcptr));
             std::shared_ptr<${lang.omexml_model_package}::OMEModelObject> optr(std::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
             model.addReference(optr, rptr);
@@ -787,14 +781,12 @@ ${customUpdatePropertyContent[prop.name]}
             ${prop.instanceVariableType} p(std::make_shared<${prop.langTypeNS}>());
 
             std::vector<common::xml::dom::Element> children(getChildrenByTagName(elem, "M"));
-            for (std::vector<common::xml::dom::Element>::iterator child = children.begin();
-                 child != children.end();
-                 ++child)
+            for (auto& child : children)
               {
-                if (child->hasAttribute("K"))
+                if (child.hasAttribute("K"))
                   p->get<0>().insert(p->end(),
-                                     ome::xml::model::primitives::OrderedMultimap::value_type(child->getAttribute("K"),
-                                                                                              child->getTextContent()));
+                                     ome::xml::model::primitives::OrderedMultimap::value_type(child.getAttribute("K"),
+                                                                                              child.getTextContent()));
                 else
                   {
                     BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
@@ -860,10 +852,9 @@ ${customUpdatePropertyContent[prop.name]}
       // each "subclass".
 {% for subClass in prop.concreteClasses %}\
       std::vector<common::xml::dom::Element> ${subClass}_nodeList(getChildrenByTagName(element, "${subClass}"));
-      for (std::vector<common::xml::dom::Element>::iterator elem = ${subClass}_nodeList.begin();
-           elem != ${subClass}_nodeList.end();++elem)
+      for (auto& elem : ${subClass}_nodeList)
         {
-          std::shared_ptr<${prop.methodName}> object(${subClass}::create(*elem, model));
+          std::shared_ptr<${prop.methodName}> object(${subClass}::create(elem, model));
           add${prop.methodName}(object);
         }
 {% end %}\
@@ -874,24 +865,20 @@ ${customUpdatePropertyContent[prop.name]}
         // object type is also abstract so we need to have a handler for
         // each "subclass".
         std::vector<common::xml::dom::Element> ${prop.name}_nodeList(getChildrenByTagName(element, "${prop.name}"));
-        for (std::vector<common::xml::dom::Element>::iterator elem = ${prop.name}_nodeList.begin();
-             elem != ${prop.name}_nodeList.end();
-             ++elem)
+        for (const auto& elem : ${prop.name}_nodeList)
           {
 {% for inner_prop in model.getObjectByName(prop.name).properties.values() %}\
 {% if not inner_prop.isAttribute and inner_prop.isComplex() and not inner_prop.isReference and inner_prop.isChoice %}\
-            std::vector<common::xml::dom::Element> ${inner_prop.name}_nodeList(getChildrenByTagName(*elem, "${inner_prop.name}"));
-                 for (std::vector<common::xml::dom::Element>::iterator inner_elem = ${inner_prop.name}_nodeList.begin();
-                 inner_elem != ${inner_prop.name}_nodeList.end();
-                 ++inner_elem)
-                   {
-                     // While std::make_shared<> works, here,
-                     // boost::make_shared<> does not, so use new
-                     // directly.
-                     std::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(*elem, model));
-                     object->update(*inner_elem, model);
-                     add${prop.methodName}(object);
-                   }
+            std::vector<common::xml::dom::Element> ${inner_prop.name}_nodeList(getChildrenByTagName(elem, "${inner_prop.name}"));
+            for (auto& inner_elem : ${inner_prop.name}_nodeList)
+              {
+                // While std::make_shared<> works, here,
+                // boost::make_shared<> does not, so use new
+                // directly.
+                std::shared_ptr<${prop.methodName}> object(${inner_prop.langTypeNS}::create(elem, model));
+                object->update(inner_elem, model);
+                add${prop.methodName}(object);
+              }
 {% end %}\
 {% end %}\
           }
@@ -901,13 +888,11 @@ ${customUpdatePropertyContent[prop.name]}
         // Element property ${prop.name} which is complex (has
         // sub-elements) and occurs more than once
         std::vector<common::xml::dom::Element> ${prop.name}_nodeList(getChildrenByTagName(element, "${prop.name}"));
-        for (std::vector<common::xml::dom::Element>::iterator elem = ${prop.name}_nodeList.begin();
-             elem != ${prop.name}_nodeList.end();
-             ++elem)
+        for (auto& elem : ${prop.name}_nodeList)
           {
             // While std::make_shared<> works, here,
             // boost::make_shared<> does not, so use new directly.
-            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(*elem, model));
+            std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(elem, model));
             add${prop.methodName}(object);
           }
 {% end %}\
@@ -916,11 +901,9 @@ ${customUpdatePropertyContent[prop.name]}
         // Element property ${prop.name} which is not complex (has no
         // sub-elements) which occurs more than once
         std::vector<common::xml::dom::Element> ${prop.name}_nodeList(getChildrenByTagName("${prop.name}"));
-        for (std::vector<common::xml::dom::Element>::iterator elem = ${prop.name}_nodeList.begin();
-             elem != ${prop.name}_nodeList.end();
-             ++elem)
+        for (auto& elem : ${prop.name}_nodeList)
           {
-            std::string text(element.getTextContent());
+            std::string text(element.getTextContent()); /// @todo should this be elem?
             std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
             add${prop.methodName}(object);
           }
@@ -1574,16 +1557,14 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% when prop.isReference and prop.maxOccurs > 1 %}\
         {
           // Reference property ${prop.name} which occurs more than once
-          for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
-               i != this->impl->${prop.instanceVariableName}.end();
-               ++i)
+          for (auto& i : this->impl->${prop.instanceVariableName})
             {
               // Note that this doesn't strictly need to be a
               // shared_ptr, but keep compatible with the rest of
               // the API to allow consistency for future
               // refactoring.
               std::shared_ptr<${prop.name}> o(std::make_shared<${prop.name}>());
-              std::shared_ptr<${prop.langTypeNS}> is(i->lock());
+              std::shared_ptr<${prop.langTypeNS}> is(i.lock());
               if (is)
                 {
                   o->setID(is->getID());
@@ -1701,13 +1682,11 @@ ${customAsXMLElementPropertyContent[prop.name]}
         if (this->impl->${prop.instanceVariableName})
           {
             common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
-            for (order_index_type::const_iterator i = this->impl->${prop.instanceVariableName}->get<0>().begin();
-                 i != this->impl->${prop.instanceVariableName}->get<0>().end();
-                 ++i)
+            for (const auto& i : this->impl->${prop.instanceVariableName}->get<0>())
               {
                 common::xml::dom::Element pair = document.createElementNS(getXMLNamespace(), "M");
-                pair.setAttribute("K", i->first);
-                pair.setTextContent(i->second);
+                pair.setAttribute("K", i.first);
+                pair.setTextContent(i.second);
                 child.appendChild(pair);
               }
             element.appendChild(child);
@@ -1715,13 +1694,11 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% end %}\
 {% if prop.minOccurs != 0 %}\
           common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
-          for (order_index_type::const_iterator i = this->impl->${prop.instanceVariableName}.get<0>().begin();
-               i != this->impl->${prop.instanceVariableName}.get<0>().end();
-               ++i)
+          for (const auto& i : this->impl->${prop.instanceVariableName}.get<0>())
             {
               common::xml::dom::Element pair = document.createElementNS(getXMLNamespace(), "M");
-              pair.setAttribute("K", i->first);
-              pair.setTextContent(i->second);
+              pair.setAttribute("K", i.first);
+              pair.setTextContent(i.second);
               child.appendChild(pair);
             }
           element.appendChild(child);
@@ -1767,19 +1744,17 @@ ${customAsXMLElementPropertyContent[prop.name]}
         {
           // Element property ${prop.name} which is complex (has
           // sub-elements) and occurs more than once
-          for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
-               i != this->impl->${prop.instanceVariableName}.end();
-               ++i)
+          for (const auto& i : this->impl->${prop.instanceVariableName})
             {
-              if (*i)
+              if (i)
                 {
 {% if prop.isAbstractSubstitution %}\
-                  common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), (*i)->get${prop.name}Type()));
+                  common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), i->get${prop.name}Type()));
 {% end if %}\
 {% if not prop.isAbstractSubstitution %}\
                   common::xml::dom::Element child(document.createElementNS(getXMLNamespace(), "${prop.name}"));
 {% end if %}\
-                  (*i)->asXMLElement(document, child);
+                  i->asXMLElement(document, child);
                   element.appendChild(child);
                 }
             }
@@ -1789,9 +1764,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
         {
           // Element property ${prop.name} which is not complex (has no
           // sub-elements) which occurs more than once
-          for (${prop.instanceVariableType}::const_iterator i = this->impl->${prop.instanceVariableName}.begin();
-               i != this->impl->${prop.instanceVariableName}.end();
-               ++i)
+          for (const auto& i : this->impl->${prop.instanceVariableName})
             {
               common::xml::dom::Element this->impl->${prop.instanceVariableName}_element =
                                                                  document.createElementNS(getXMLNamespace(), "${prop.name}");
@@ -1801,7 +1774,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
               os << *i;
 {% end %}\
 {% if prop.langTypeNS == 'bool' %}\
-              os << std::boolalpha << *i;
+              os << std::boolalpha << i;
 {% end %}\
               this->impl->${prop.instanceVariableName}_element.setTextContent(os.str());
               common::xml::dom::Element child(this->impl->${prop.instanceVariableName}_element);

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -354,14 +354,14 @@ namespace ome
 {% if klass.name == "OME" %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         /// @copydoc ome::xml::model::OMEModel::addModelObject
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
         addModelObject (const std::string&                                           id,
-                        std::shared_ptr< ::ome::xml::model::OMEModelObject>& object);
+                        std::shared_ptr<::ome::xml::model::OMEModelObject>& object);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr< ::ome::xml::model::OMEModelObject>
+      std::shared_ptr<::ome::xml::model::OMEModelObject>
       OME::addModelObject(const std::string&                                           id,
-                          std::shared_ptr< ::ome::xml::model::OMEModelObject>& object)
+                          std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
       {
         // Don't store references.
         if (std::dynamic_pointer_cast<Reference>(object))
@@ -379,14 +379,14 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in parent.
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
         removeModelObject (const std::string& id);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr< ::ome::xml::model::OMEModelObject>
+      std::shared_ptr<::ome::xml::model::OMEModelObject>
       OME::removeModelObject(const std::string& id)
       {
-        std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+        std::shared_ptr<::ome::xml::model::OMEModelObject> ret;
 
         object_map_type::iterator i = this->impl->modelObjects.find(id);
         if (i != this->impl->modelObjects.end())
@@ -401,14 +401,14 @@ namespace ome
 
 {% if fu.SOURCE_TYPE == "header" %}\
         // Documented in parent.
-        std::shared_ptr< ::ome::xml::model::OMEModelObject>
+        std::shared_ptr<::ome::xml::model::OMEModelObject>
         getModelObject (const std::string& id) const;
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr< ::ome::xml::model::OMEModelObject>
+      std::shared_ptr<::ome::xml::model::OMEModelObject>
       OME::getModelObject(const std::string& id) const
       {
-        std::shared_ptr< ::ome::xml::model::OMEModelObject> ret;
+        std::shared_ptr<::ome::xml::model::OMEModelObject> ret;
 
         object_map_type::const_iterator i = this->impl->modelObjects.find(id);
         if (i != this->impl->modelObjects.end())
@@ -434,12 +434,12 @@ namespace ome
 {% if fu.SOURCE_TYPE == "header" %}\
         /// @copydoc ome::xml::model::OMEModel::addReference
         bool
-        addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+        addReference (std::shared_ptr<::ome::xml::model::OMEModelObject>& a,
                       std::shared_ptr<Reference>&                          b);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
-      OME::addReference (std::shared_ptr< ::ome::xml::model::OMEModelObject>& a,
+      OME::addReference (std::shared_ptr<::ome::xml::model::OMEModelObject>& a,
                          std::shared_ptr<Reference>&                          b)
       {
         reference_map_type::iterator i = this->impl->references.find(a);
@@ -520,7 +520,7 @@ namespace ome
                       {
                         const std::string& referenceID = (*ref)->getID();
 
-                        std::shared_ptr< ::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
+                        std::shared_ptr<::ome::xml::model::OMEModelObject> b = getModelObject(referenceID);
                         if (!b)
                           {
                             BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
@@ -531,7 +531,7 @@ namespace ome
                           }
                         else
                           {
-                            std::shared_ptr< ::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast< ::ome::xml::model::OMEModelObject>(a));
+                            std::shared_ptr<::ome::xml::model::OMEModelObject> aw(std::const_pointer_cast<::ome::xml::model::OMEModelObject>(a));
                             aw->link(*ref, b);
                           }
                       }

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -1677,7 +1677,6 @@ ${customAsXMLElementPropertyContent[prop.name]}
           }
 {% end %}\
 {% if prop.langTypeNS == 'ome::xml::model::primitives::OrderedMultimap' %}\
-            typedef ome::xml::model::primitives::OrderedMultimap::index<ome::xml::model::primitives::order_index>::type order_index_type;
 {% if prop.minOccurs == 0 %}\
         if (this->impl->${prop.instanceVariableName})
           {

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -336,16 +336,16 @@ namespace ome
          *
          * @returns a new model object.
          */
-        static std::shared_ptr< ${klass.name}>
+        static std::shared_ptr<${klass.name}>
         create(const common::xml::dom::Element& element,
                ${lang.omexml_model_package}::OMEModel& model);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
-      std::shared_ptr< ${klass.name}>
+      std::shared_ptr<${klass.name}>
       ${klass.name}::create(const common::xml::dom::Element& element,
                               ${lang.omexml_model_package}::OMEModel& model)
       {
-        std::shared_ptr< ${klass.name}> newinstance(std::make_shared< ${klass.name}>());
+        std::shared_ptr<${klass.name}> newinstance(std::make_shared<${klass.name}>());
         newinstance->update(element, model);
         return newinstance;
       }
@@ -681,10 +681,10 @@ ${customUpdatePropertyContent[prop.name]}
              elem != ${prop.name}_nodeList.end();
              ++elem)
           {
-            std::shared_ptr<${prop.name}> rcptr(std::make_shared< ${prop.name}>());
+            std::shared_ptr<${prop.name}> rcptr(std::make_shared<${prop.name}>());
             rcptr->setID(elem->getAttribute("ID"));
             std::shared_ptr<Reference> rptr(std::static_pointer_cast<Reference>(rcptr));
-            std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> optr(std::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+            std::shared_ptr<${lang.omexml_model_package}::OMEModelObject> optr(std::static_pointer_cast<${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
             model.addReference(optr, rptr);
           }
 {% end %}\
@@ -710,7 +710,7 @@ ${customUpdatePropertyContent[prop.name]}
              set${prop.methodName}(element.getAttribute("${prop.name}"));
 {% end if %}\
              // Adding this model object to the model handler
-             std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject> thisptr(std::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
+             std::shared_ptr<${lang.omexml_model_package}::OMEModelObject> thisptr(std::dynamic_pointer_cast<  ${lang.omexml_model_package}::OMEModelObject>(shared_from_this()));
              model.addModelObject(getID(), thisptr);
            }
 {% end when prop.isAttribute and prop.name == "ID" %}\
@@ -727,7 +727,7 @@ ${customUpdatePropertyContent[prop.name]}
             // Attribute property which is an enumeration ${prop.name}
 {% if prop.minOccurs == 0 %}\
             std::string text(element.getAttribute("${prop.name}"));
-            ${prop.instanceVariableType} nattr(std::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} nattr(std::make_shared<${prop.langTypeNS}>(text));
             set${prop.methodName}(nattr);
 {% end prop.minOccurs == 0 %}\
 {% if prop.minOccurs > 0 %}\
@@ -784,7 +784,7 @@ ${customUpdatePropertyContent[prop.name]}
             ${prop.instanceVariableType} p(${prop.langTypeNS}::create(elem, model));
 {% end %}\
 {% if prop.langTypeNS == 'ome::xml::model::primitives::OrderedMultimap' %}\
-            ${prop.instanceVariableType} p(std::make_shared< ${prop.langTypeNS}>());
+            ${prop.instanceVariableType} p(std::make_shared<${prop.langTypeNS}>());
 
             std::vector<common::xml::dom::Element> children(getChildrenByTagName(elem, "M"));
             for (std::vector<common::xml::dom::Element>::iterator child = children.begin();
@@ -835,7 +835,7 @@ ${customUpdatePropertyContent[prop.name]}
             // sub-elements)
             std::string text(${prop.name}_nodeList.at(0).getTextContent());
 {% if prop.minOccurs == 0 %}\
-            ${prop.instanceVariableType} ns(std::make_shared< ${prop.langTypeNS}>(text));
+            ${prop.instanceVariableType} ns(std::make_shared<${prop.langTypeNS}>(text));
             set${prop.methodName}(ns);
 {% end %}\
 {% if prop.minOccurs > 0 %}\
@@ -943,12 +943,12 @@ ${customUpdatePropertyContent[prop.name]}
         /// @copydoc ${lang.omexml_model_package}::OMEModelObject::link
         bool
         link (std::shared_ptr<Reference>& reference,
-              std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object);
+              std::shared_ptr<${lang.omexml_model_package}::OMEModelObject>& object);
 {% end header %}\
 {% if fu.SOURCE_TYPE == "source" %}\
       bool
       ${klass.name}::link (std::shared_ptr<Reference>& reference,
-                           std::shared_ptr< ${lang.omexml_model_package}::OMEModelObject>& object)
+                           std::shared_ptr<${lang.omexml_model_package}::OMEModelObject>& object)
       {
         if (${klass.parentName}::link(reference, object))
           {
@@ -1582,7 +1582,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
               // shared_ptr, but keep compatible with the rest of
               // the API to allow consistency for future
               // refactoring.
-              std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
+              std::shared_ptr<${prop.name}> o(std::make_shared<${prop.name}>());
               std::shared_ptr<${prop.langTypeNS}> is(i->lock());
               if (is)
                 {
@@ -1605,7 +1605,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
           // Note that this doesn't strictly need to be a
           // shared_ptr, but keep compatible with the rest of the
           // API to allow consistency for future refactoring.
-          std::shared_ptr<${prop.name}> o(std::make_shared< ${prop.name}>());
+          std::shared_ptr<${prop.name}> o(std::make_shared<${prop.name}>());
           std::shared_ptr<${prop.langTypeNS}> sv(this->impl->${prop.instanceVariableName}.lock());
           if (sv)
             {

--- a/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
@@ -11,11 +11,9 @@
         common::xml::dom::Element value_element = document.createElementNS(getXMLNamespace(), "Value");
         common::xml::dom::NodeList Value_subNodes = Value_document.getDocumentElement().getChildNodes();
 
-        for (common::xml::dom::NodeList::iterator elem = Value_subNodes.begin();
-             elem != Value_subNodes.end();
-             ++elem)
+        for (auto& elem : Value_subNodes)
           {
-            common::xml::dom::Node Value_subNode(document->importNode(elem->get(), true), false);
+            common::xml::dom::Node Value_subNode(document->importNode(elem.get(), true), false);
             value_element.appendChild(Value_subNode);
           }
         element.appendChild(value_element);

--- a/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_update_Value.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_update_Value.template
@@ -12,16 +12,12 @@
 
             std::string text;
 
-            for (common::xml::dom::NodeList::iterator i = nodes.begin();
-                 i != nodes.end();
-                 ++i)
+            for (auto& e : nodes)
               {
                 try
                   {
-                    common::xml::dom::Element e(*i);
-
                     std::string textvalue;
-                    ome::common::xml::dom::writeNode(*i, textvalue);
+                    ome::common::xml::dom::writeNode(e, textvalue);
 
                     // Trim leading and trailing whitespace
                     std::string::size_type start(textvalue.find_first_of('<'));
@@ -48,7 +44,7 @@
                         if (element->lookupNamespaceURI(0) != 0)
                           {
                             common::xml::String currentNS(element->lookupNamespaceURI(0));
-                            if ((*i)->isDefaultNamespace(currentNS))
+                            if (e->isDefaultNamespace(currentNS))
                               {
                                 std::string stripNS(static_cast<std::string>(currentNS));
                                 std::string::size_type stripStart(textvalue.find(stripNS));


### PR DESCRIPTION
Next part of [Minimal C++11 features](https://trello.com/c/h4pHPV2h/42-minimal-c-11-features) after https://github.com/ome/ome-common-cpp/pull/31.  This PR switches to using a few simple C++11 features.

- Use `<array>`, `<cstdint>`, `<memory>` and `<tuple>` in place of `<ome/compat/array.h>`, `<ome/compat/cstdint.h>`, `<ome/compat/memory.h>` and `<ome/compat/tuple.h>`, respectively (with namespace change from `ome::compat` to `std` for the corresponding types)
- Use `>>` in place of `> >` in templates (spaces previously required)
- Use `<::` in place of `< ::` (spaces previously required)
- Use initialiser lists when constructing objects, mainly containers.  This uses `foo{elem1, elem2, elemn}` in place of `foo` to directly fill containers with elements.  Mainly used with parameterised test data which had to use static arrays as the data source.
- Use range-based for loop and `auto` type rather than manually define complex iterator types and manually iterate; this greatly simplifies `for` loops
- Use `enum class` to scope enum values; previously they leaked into the enclosing scope
- Use C++11 type traits in place of Boost type traits

--------

Testing: Check all builds are green.