### PR TITLE
Fix permanent redirects

### DIFF
--- a/docs/sphinx/developers/EnumTool.rst
+++ b/docs/sphinx/developers/EnumTool.rst
@@ -141,5 +141,5 @@ which Enum Tool makes heavy use of internally.
 
 .. SeeAlso::
 
-    - `http://genshi.edgewall.org/ <http://genshi.edgewall.org/>`_
+    - `https://genshi.edgewall.org/ <https://genshi.edgewall.org/>`_
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -15,7 +15,8 @@ OME-TIFF is a multi-plane tiff file that contains OME metadata in the header,
 in the form of OME-XML. This allows the pixels to be read with any
 TIFF-compatible program, and the metadata to be extracted with any OME-aware
 application. Our `paper describing the design and implementation of the OME-XML file 
-<http://genomebiology.com/2005/6/5/R47>`_ appeared in Genome Biology.
+<http://genomebiology.biomedcentral.com/articles/10.1186/gb-2005-6-5-r47>`_
+appeared in Genome Biology.
 
 The OME consortium currently provides three major tools capable of working
 with OME-XML and OME-TIFF:

--- a/docs/sphinx/ome-tiff/index.rst
+++ b/docs/sphinx/ome-tiff/index.rst
@@ -32,20 +32,20 @@ OME-TIFF is supported by:
 * `Accelrys Inc. <http://accelrys.com/>`_
 * `GE Healthcare Life Sciences (formerly Applied Precision) <http://www.gelifesciences.com/webapp/wcs/stores/servlet/catalog/en/GELifeSciences-UK/brands/deltavision/>`_
 * `Bitplane AG <http://www.bitplane.com/>`_
-* `Carl Zeiss Microscopy GmbH <http://www.zeiss.com/microscopy/int/home.html>`_
+* `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
 * `Definiens <http://www.definiens.com>`_
 * `DRVision Technologies LLC <http://www.svisionllc.com/>`_
 * `iMagic <http://www.imagic.ch/index.php?id=15&L=2/>`_
-* `Intelligent Imaging Innovations, Inc. <http://www.intelligent-imaging.com>`_
+* `Intelligent Imaging Innovations, Inc. <https://www.intelligent-imaging.com>`_
 * `Leica Inc. <http://www.leica-microsystems.com/>`_
 * `Mayachitra Inc. <http://www.mayachitra.com/>`_
-* `Micro-Manager <http://valelab.ucsf.edu/~MM/MMwiki/>`_
-* `Molecular Devices Inc. <http://www.moleculardevices.com>`_
+* `Micro-Manager <https://micro-manager.org/wiki/>`_
+* `Molecular Devices Inc. <https://www.moleculardevices.com>`_
 * `PerkinElmer <http://www.perkinelmer.com/>`_
 * `Scientifica <http://www.scientifica.uk.com>`_
-* `Scientific Volume Imaging B.V. <http://www.svi.nl/>`_
-* `Strand Life Sciences <http://www.strandls.com>`_
-* `TILL Photonics GmbH, now FEI Munich <http://www.fei.com/>`_
+* `Scientific Volume Imaging B.V. <https://svi.nl/HomePage>`_
+* `Strand Life Sciences <http://strandls.com>`_
+* `TILL Photonics GmbH, now FEI Munich <https://www.fei.com/home/>`_
 
 Public image repositories allowing image downloads as OME-TIFF
 --------------------------------------------------------------
@@ -53,7 +53,7 @@ Public image repositories allowing image downloads as OME-TIFF
 * `ASCB CELL Image Library <http://www.cellimagelibrary.org/>`_
 * `Harvard Medical School LINCS Project <http://lincs.hms.harvard.edu/>`_
 * `JCB DataViewer <http://jcb-dataviewer.rupress.org/>`_
-* `Stowers Institute Original Data Repository <http://odr.stowers.org/>`_
+* `Stowers Institute Original Data Repository <http://www.stowers.org/research/publications/odr>`_
 
 |
 

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -3,7 +3,7 @@ OME-TIFF specification
 
 The following provides technical details on the OME-TIFF
 format. It assumes familiarity with both the
-`TIFF <http://partners.adobe.com/public/developer/tiff/index.html>`_ and
+`TIFF <https://en.wikipedia.org/wiki/TIFF>`_ and
 :schema_plone:`OME-XML <>` formats, although there is some review of both.
 
 An OME-TIFF dataset consists of:

--- a/docs/sphinx/ome-tiff/tools.rst
+++ b/docs/sphinx/ome-tiff/tools.rst
@@ -28,7 +28,7 @@ If you are looking for a solution in Java, there are several options.
 Bio-Formats can read OME-TIFF files, as well as convert from many
 third-party formats into OME-TIFF format—see the :doc:`example source code
 page <code>` for specific examples. Alternatively, the open
-source `ImageJ <http://rsb.info.nih.gov/ij/>`_ application reads
+source `ImageJ <https://imagej.nih.gov/ij/>`_ application reads
 multi-page TIFF files, storing the TIFF comment into the associated
 FileInfo object's "description" field.
 

--- a/docs/sphinx/ome-xml/index.rst
+++ b/docs/sphinx/ome-xml/index.rst
@@ -49,8 +49,9 @@ The OME-XML file serves as a convenient file format for data migration
 from one site or user to another. The OME-XML file captures all image
 acquisition and experimental metadata, along with the binary image data,
 and packages it into an easily readable package. The
-`paper <http://genomebiology.com/2005/6/5/R47>`_ describing the design
-and implementation of the OME-XML file appeared in Genome Biology.
+`paper <http://genomebiology.biomedcentral.com/articles/10.1186/gb-2005-6-5-r47>`_
+describing the design and implementation of the OME-XML file appeared in
+Genome Biology.
 
 .. note::
 


### PR DESCRIPTION
This updates all the links which are being permanently redirected* by the merge build (https://ci.openmicroscopy.org/view/Docs/job/MODEL-merge-docs/) - builds should be green with only our own links redirected to current versions*) and the staging pages should be unchanged.

N.B. I've replaced the TIFF link altogether because the Adobe link was redirecting somewhere irrelevant and is another site which wants you to identify your country of origin before it'll point you at links - hopefully the wiki is sufficient.


*with the exception of the GELifeSciences link which wants you to pick a country so doesn't play nicely with the linkchecker