### PR TITLE
ome-xml: Performance improvements

### DIFF
--- a/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
+++ b/ome-xml/src/main/cpp/ome/xml/model/OriginalMetadataAnnotation.h
@@ -46,7 +46,6 @@
 #include <ome/common/xml/dom/Document.h>
 #include <ome/common/xml/dom/Element.h>
 #include <ome/common/xml/dom/Node.h>
-#include <ome/common/xml/dom/NodeList.h>
 
 #include <ome/xml/model/XMLAnnotation.h>
 

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
@@ -113,13 +113,12 @@ namespace ome
 
         std::vector<common::xml::dom::Element>
         OMEModelObject::getChildrenByTagName (const common::xml::dom::Element& parent,
-                                              const std::string&          name)
+                                              const std::string&               name)
         {
-          // TODO: May need to be a shared_ptr<element> if element is not refcounting.
           std::vector<common::xml::dom::Element> ret;
 
           common::xml::dom::NodeList children(parent->getChildNodes());
-          // TODO: correct type for iteration.
+          common::xml::String xmlname(name);
           for (auto& pos : children)
             {
               try
@@ -131,7 +130,7 @@ namespace ome
                   if (dynamic_cast<const xercesc::DOMElement *>(pos.get()))
                     {
                       common::xml::dom::Element child(pos.get(), false);
-                      if (child && name == stripNamespacePrefix(common::xml::String(child->getNodeName())))
+                      if (child && xmlname == common::xml::String(child->getNodeName()))
                         {
                           ret.push_back(child);
                         }

--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
@@ -36,7 +36,6 @@
  * #L%
  */
 
-#include <ome/common/xml/dom/NodeList.h>
 #include <ome/common/xml/String.h>
 
 #include <ome/xml/model/detail/OMEModelObject.h>
@@ -117,9 +116,10 @@ namespace ome
         {
           std::vector<common::xml::dom::Element> ret;
 
-          common::xml::dom::NodeList children(parent->getChildNodes());
           common::xml::String xmlname(name);
-          for (auto& pos : children)
+          for (xercesc::DOMNode *pos = parent.get()->getFirstChild();
+               pos != 0;
+               pos = pos->getNextSibling())
             {
               try
                 {
@@ -127,9 +127,9 @@ namespace ome
                   // class would throw; but this avoids the need to
                   // throw and catch many std::logic_error exceptions
                   // during document processing.
-                  if (dynamic_cast<const xercesc::DOMElement *>(pos.get()))
+                  if (dynamic_cast<const xercesc::DOMElement *>(pos))
                     {
-                      common::xml::dom::Element child(pos.get(), false);
+                      common::xml::dom::Element child(pos, false);
                       if (child && xmlname == common::xml::String(child->getNodeName()))
                         {
                           ret.push_back(child);

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -638,7 +638,7 @@ ${customContent}\
 {% end %}\
         }
 {% end %}\
-        const std::string tagName(stripNamespacePrefix(element.getTagName()));
+        const std::string tagName(element.getTagName());
         if (!validElementName(tagName))
           {
             BOOST_LOG_SEV(logger, ome::logging::trivial::warning)

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -58,7 +58,6 @@
 #include <ome/common/xml/dom/Document.h>
 #include <ome/common/xml/dom/Element.h>
 #include <ome/common/xml/dom/Node.h>
-#include <ome/common/xml/dom/NodeList.h>
 
 #include <ome/xml/model/OMEModel.h>
 #include <ome/xml/model/primitives/Quantity.h>

--- a/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
@@ -9,11 +9,12 @@
         params.validationScheme = xercesc::XercesDOMParser::Val_Never;
         common::xml::dom::Document Value_document(ome::xml::createDocument(wrappedValue, params));
         common::xml::dom::Element value_element = document.createElementNS(getXMLNamespace(), "Value");
-        common::xml::dom::NodeList Value_subNodes = Value_document.getDocumentElement().getChildNodes();
 
-        for (auto& elem : Value_subNodes)
+        for (xercesc::DOMNode *elem = Value_document.getDocumentElement().get()->getFirstChild();
+             elem != 0;
+             elem = elem->getNextSibling())
           {
-            common::xml::dom::Node Value_subNode(document->importNode(elem.get(), true), false);
+            common::xml::dom::Node Value_subNode(document->importNode(elem, true), false);
             value_element.appendChild(Value_subNode);
           }
         element.appendChild(value_element);

--- a/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_update_Value.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject_XMLAnnotation_update_Value.template
@@ -8,15 +8,17 @@
         else if (Value_nodeList.size() != 0)
           {
             common::xml::dom::Element elem(Value_nodeList.at(0));
-            common::xml::dom::NodeList nodes(elem.getChildNodes());
 
             std::string text;
 
-            for (auto& e : nodes)
+            for (xercesc::DOMNode *node = elem.get()->getFirstChild();
+                 node != 0;
+                 node = node->getNextSibling())
               {
                 try
                   {
                     std::string textvalue;
+                    common::xml::dom::Node e(node, false);
                     ome::common::xml::dom::writeNode(e, textvalue);
 
                     // Trim leading and trailing whitespace


### PR DESCRIPTION
See [trello card](https://trello.com/c/WR9yB2L9/84-metadata-performance) for more details.

`getTagName()` already returns a tag without a namespace, making this pointless.  Removing the unnecessary stripping is a minor performance enhancement.

The major change here is to remove all use of xerces DOMNodeList (ome::common::xml::dom::NodeList).  This has very inefficient iterator performance--O(n) for every indexed access.  Swapping this with the lower level Node `getFirstChild()` and `getNextSibling()` results in a dramatic speedup (around 2 mins to 4 seconds for the mitocheck data!)

Testing: Check builds remain green.

Check the performance of the ome-files-performance tests; they should be significantly faster, for mitocheck in particular.

Test data: download necromancer:~rleigh/ptest.tar.gz
Run `ome-files info` on the two images.  Without this PR merged you'll get very poor performance; with the PR merged you'll get decent performance.