### PR TITLE
xsd-fu: C++ OMEXMLModelObject template inserts missing links

### DIFF
--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -718,7 +718,7 @@ ${customUpdatePropertyContent[prop.name]}
 {% if prop.isReference or prop.isBackReference %}\
                 typedef OMEModelObject::indexed_container<${prop.langTypeNS}, std::weak_ptr>::type::nth_index<1>::type container_set_type;
                 container_set_type::iterator it(this->impl->${prop.instanceVariableName}.get<1>().find(o_casted));
-                if (it != this->impl->${prop.instanceVariableName}.get<1>().end())
+                if (it == this->impl->${prop.instanceVariableName}.get<1>().end())
                   {
                     this->impl->${prop.instanceVariableName}.push_back(o_casted);
                   }


### PR DESCRIPTION
See https://trello.com/c/BlQrTZf9/1-metadata-bug.  Coupled with https://github.com/ome/ome-files-cpp/pull/57 this allows round-tripping of ROIRefs.

Testing: Run `ome-files info --omexml` on the mitocheck sample.  You'll see ImageRef and ROIRef elements; ROIRef were previously absent.  Anything else missing?