### PR TITLE
OME-TIFF samples: reorganization

### DIFF
--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -108,8 +108,9 @@ according to its dimensional position for easy testing.
 Modulo datasets
 ^^^^^^^^^^^^^^^
 
-Sample files implementing the :doc:`/developers/6d-7d-and-8d-storage` are available from the
-:ometiff_downloads:`Modulo <modulo>` folder of the image downloads resource.
+Sample files implementing the :doc:`/developers/6d-7d-and-8d-storage` are
+available from the :ometiff_downloads:`Modulo <modulo>` folder of the image
+downloads resource.
 
 SPIM
 """"
@@ -141,35 +142,30 @@ FLIM
 Multi-file OME-TIFF filesets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This section lists various examples of OME-TIFF datasets distributed across multiple TIFF files.
+This section lists various examples of OME-TIFF datasets distributed across multiple TIFF files. Both datasets contain a set of 18 by 24 pixel images with black and white text on each plane giving its time, z-depth and channel. Each of the five focal planes is saved as a separate OME-TIFF named :file:`multifile-Zxx.ome.tiff` where `xx` is the index of the focal plane.
 
-The :ometiff_downloads:`master OME-TIFF fileset <binaryonly>` and
-:ometiff_downloads:`companion OME-XML fileset <companion>` both contain a set
-of 18 by 24 pixel images with black and white text on each plane giving
-its time, z-depth and channel. Each of the five focal planes is saved as a
-separate OME-TIFF named :file:`multifile-Zxx.ome.tiff` where `xx` is the index
-of the focal plane.
+.. list-table::
+  :header-rows: 1
 
-.. _master-sample:
+  -  * Dataset
+     * Image dimensions (XYZCT)
+     * Full metadata file*
+     * Partial metadata files†
 
-Master OME-TIFF fileset
-"""""""""""""""""""""""
+  -  * :ometiff_downloads:`Master OME-TIFF fileset <binaryonly>`
+     * 18 x 24 x 5 x 1 x 1
+     * :file:`multifile-Z1.ome.tiff`
+     * :file:`multifile-Z[2-5].ome.tiff`
 
-For this sample, the full OME-XML metadata describing the whole fileset is
-embedded into a
-:ometiff_downloads:`master OME-TIFF file <binaryonly/multifile-Z1.ome.tiff>`.
-Partial OME-XML metadata blocks are embedded into the four other OME-TIFF
-files and refer to the master OME-TIFF file as described in the
-:ref:`specification <binary_only>`.
+  -  * :ometiff_downloads:`Companion OME-XML fileset <companion>`
+     * 18 x 24 x 5 x 1 x 1
+     * :file:`multifile.companion.ome`
+     * :file:`multifile-Z[1-5].ome.tiff`
 
-.. _companion-sample:
-
-Companion OME-XML fileset
-"""""""""""""""""""""""""
-
-For this sample, the full OME-XML metadata describing the whole fileset is
-stored into a separate
-:ometiff_downloads:`companion OME-XML file<companion/multifile.companion.ome>`.
-Partial OME-XML metadata blocks are embedded into the five OME-TIFF
-files and refer to the companion OME-XML file as described in the
-:ref:`specification <binary_only>`.
+\*
+  The full OME-XML metadata describing the whole fileset is either embedded
+  into an OME-TIFF or stored in a companion OME-XML file
+†
+  Partial OME-XML metadata blocks are embedded into the OME-TIFF files
+  and refer to the file containing the full OME-XML metadata as described
+  in the :ref:`specification <binary_only>`.

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -10,17 +10,68 @@ support for OME-TIFF within your software.
 All the OME-TIFF sample data discussed below are available from our
 :ometiff_downloads:`OME-TIFF sample images resource <>`.
 
-Single file OME-TIFF
---------------------
+Biological datasets
+-------------------
 
-This section lists various examples of single file OME-TIFF. For examples of
-OME-TIFF dataset distributed across multiple TIFF files, see
-:ref:`multifile_samples`.
+.. _tubhiswt_samples:
+
+Tubhiswt
+^^^^^^^^
+
+The following OME-TIFF datasets consist of tubulin histone GFP coexpressing
+*C. elegans* embryos. Many thanks to
+`Josh Bembenek <http://loci.wisc.edu/people/josh-bembenek>`_ for preparing
+and imaging this sample data.
+
+The datasets were acquired on a multiphoton workstation (2.1 GHz Athlon
+XP 3200+ with 1GB of RAM) using
+`WiscScan <http://loci.wisc.edu/software/wiscscan>`_. All image
+planes were collected at 512x512 resolution in 8-bit grayscale, with an
+integration value of 2.
+
+The files available for download have been updated to the current schema
+version since their initial creation.
+
+.. list-table::
+  :header-rows: 1
+  :widths: 20, 20, 15, 15, 15, 15
+
+  -  * Fileset
+     * Zipped fileset
+     * Channels
+     * Focal planes
+     * Time points
+     * Number of files
+
+  -  * :ometiff_downloads:`tubhiswt-2D <tubhiswt-2D>`
+     * :ometiff_downloads:`tubhiswt-2D.zip <tubhiswt-2D.zip>`
+     * 2
+     * 1
+     * 1
+     * 2
+
+  -  * :ometiff_downloads:`tubhiswt-3D <tubhiswt-3D>`
+     * :ometiff_downloads:`tubhiswt-3D.zip <tubhiswt-3D.zip>`
+     * 2
+     * 1
+     * 20
+     * 2
+
+  -  * :ometiff_downloads:`tubhiswt-4D <tubhiswt-4D>`
+     * :ometiff_downloads:`tubhiswt-4D.zip <tubhiswt-4D.zip>`
+     * 2
+     * 10
+     * 43
+     * 86
+
 
 .. _artificial-datasets:
 
 Artificial datasets
-^^^^^^^^^^^^^^^^^^^
+-------------------
+
+Bio-Formats generated
+^^^^^^^^^^^^^^^^^^^^^
 
 All datasets in the following table were :source:`artificially
 generated <components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java>`
@@ -113,63 +164,9 @@ FLIM
 .. _multifile_samples:
 
 Multi-file OME-TIFF filesets
-----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This section lists various examples of OME-TIFF datasets distributed across multiple TIFF files.
-
-.. _tubhiswt_samples:
-
-Sample biological dataset
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The following OME-TIFF datasets consist of tubulin histone GFP coexpressing 
-*C. elegans* embryos. Many thanks to
-`Josh Bembenek <http://loci.wisc.edu/people/josh-bembenek>`_ for preparing
-and imaging this sample data.
-
-The datasets were acquired on a multiphoton workstation (2.1 GHz Athlon
-XP 3200+ with 1GB of RAM) using
-`WiscScan <http://loci.wisc.edu/software/wiscscan>`_. All image
-planes were collected at 512x512 resolution in 8-bit grayscale, with an
-integration value of 2.
-
-The files available for download have been updated to the current schema
-version since their initial creation.
-
-.. list-table::
-  :header-rows: 1
-  :widths: 20, 20, 15, 15, 15, 15
-
-  -  * Fileset
-     * Zipped fileset
-     * Channels
-     * Focal planes
-     * Time points
-     * Number of files
-  
-  -  * :ometiff_downloads:`tubhiswt-2D <tubhiswt-2D>`
-     * :ometiff_downloads:`tubhiswt-2D.zip <tubhiswt-2D.zip>`
-     * 2
-     * 1
-     * 1
-     * 2
-
-  -  * :ometiff_downloads:`tubhiswt-3D <tubhiswt-3D>`
-     * :ometiff_downloads:`tubhiswt-3D.zip <tubhiswt-3D.zip>`
-     * 2
-     * 1
-     * 20
-     * 2
-
-  -  * :ometiff_downloads:`tubhiswt-4D <tubhiswt-4D>`
-     * :ometiff_downloads:`tubhiswt-4D.zip <tubhiswt-4D.zip>`
-     * 2
-     * 10
-     * 43
-     * 86
-
-Partial OME-XML metadata filesets
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :ometiff_downloads:`master OME-TIFF fileset <binaryonly>` and
 :ometiff_downloads:`companion OME-XML fileset <companion>` both contain a set

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -26,7 +26,7 @@ and imaging this sample data.
 The datasets were acquired on a multiphoton workstation (2.1 GHz Athlon
 XP 3200+ with 1GB of RAM) using
 `WiscScan <http://loci.wisc.edu/software/wiscscan>`_. All image
-planes were collected at 512x512 resolution in 8-bit grayscale, with an
+planes were collected at 512 × 512 resolution in 8-bit grayscale, with an
 integration value of 2.
 
 The files available for download have been updated to the current schema
@@ -40,15 +40,15 @@ version since their initial creation.
      * Number of files
 
   -  * :ometiff_downloads:`Tubhiswt 2D <tubhiswt-2D>` (:ometiff_downloads:`tubhiswt-2D.zip <tubhiswt-2D.zip>`)
-     * 512 x 512 x 1 x 2 x 1
+     * 512 × 512 × 1 × 2 × 1
      * 2
 
   -  * :ometiff_downloads:`Tubhiswt 3D <tubhiswt-3D>` (:ometiff_downloads:`tubhiswt-3D.zip <tubhiswt-3D.zip>`)
-     * 512 x 512 x 1 x 2 x 20
+     * 512 × 512 × 1 × 2 × 20
      * 2
 
   -  * :ometiff_downloads:`Tubhiswt 4D <tubhiswt-4D>` (:ometiff_downloads:`tubhiswt-4D.zip <tubhiswt-4D.zip>`)
-     * 512 x 512 x 10 x 2 x 43
+     * 512 × 512 × 10 × 2 × 43
      * 86
 
 
@@ -73,35 +73,35 @@ according to its dimensional position for easy testing.
      * Available extensions
   
   -  * Single channel
-     * 439 x 167 x 1 x 1 x 1
+     * 439 × 167 × 1 × 1 × 1
      * :ometiff_downloads:`ome.tif <bioformats-artificial/single-channel.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/single-channel.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/single-channel.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/single-channel.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/single-channel.ome.tf2>`
 
   -  * Multi channel
-     * 439 x 167 x 1 x 3 x 1
+     * 439 × 167 × 1 × 3 × 1
      * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel.ome.tf2>`
 
   -  * Z series
-     * 439 x 167 x 5 x 1 x 1
+     * 439 × 167 × 5 × 1 × 1
      * :ometiff_downloads:`ome.tif <bioformats-artificial/z-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/z-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/z-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/z-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/z-series.ome.tf2>`
 
   -  * Time series
-     * 439 x 167 x 1 x 1 x 7
+     * 439 × 167 × 1 × 1 × 7
      * :ometiff_downloads:`ome.tif <bioformats-artificial/time-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/time-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/time-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/time-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/time-series.ome.tf2>`
 
   -  * Multi channel Z series
-     * 439 x 167 x 5 x 3 x 1
+     * 439 × 167 × 5 × 3 × 1
      * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-z-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-z-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-z-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel-z-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-z-series.ome.tf2>`
 
   -  * Multi channel time series
-     * 439 x 167 x 1 x 3 x 7
+     * 439 × 167 × 1 × 3 × 7
      * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-time-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-time-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-time-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel-time-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-time-series.ome.tf2>`
 
   -  * 4D series
-     * 439 x 167 x 5 x 1 x 7
+     * 439 × 167 × 5 × 1 × 7
      * :ometiff_downloads:`ome.tif <bioformats-artificial/4D-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/4D-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/4D-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/4D-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/4D-series.ome.tf2>`
 
   -  * Multi channel 4D series
-     * 439 x 167 x 5 x 3 x 7
+     * 439 × 167 × 5 × 3 × 7
      * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-4D-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-4D-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-4D-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel-4D-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-4D-series.ome.tf2>`
 
 .. _modulo-datasets:
@@ -122,24 +122,24 @@ resource.
      * Modulo description
 
   -  * :ometiff_downloads:`SPIM-ModuloAlongZ.ome.tiff <modulo/SPIM-ModuloAlongZ.ome.tiff>`
-     * 160 x 220 x 8 x 2 x 12
+     * 160 × 220 × 8 × 2 × 12
      * 4 tiles interleaved as ModuloAlongT each recorded at 4 angles
        interleaved as ModuloAlongZ
 
   -  * :ometiff_downloads:`LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff <modulo/LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff>`
-     * 200 x 200 x 5 x 1 x 10
+     * 200 × 200 × 5 × 1 × 10
      * excitation of 5 wavelength [Λ, big-lambda] interleaved as ModuloAlongZ,
        each recorded at 10 emission wavelength ranges [λ, lambda] interleaved
        as ModuloAlongT
 
   -  * :ometiff_downloads:`FLIM-ModuloAlongT-TSCPC.ome.tiff <modulo/FLIM-ModuloAlongT-TSCPC.ome.tiff>`
-     * 180 x 220 x 1 x 2 x 16
+     * 180 × 220 × 1 × 2 × 16
      * 2 channels and 8 histogram bins each recorded at 2 'real-time' points T,
        with additional relative-time points (time relative to the
        excitation pulse) interleaved as ModuloAlongT
 
   -  * :ometiff_downloads:`FLIM-ModuloAlongC.ome.tiff <modulo/FLIM-ModuloAlongC.ome.tiff>`
-     * 180 x 150 x 1 x 16 x 1
+     * 180 × 150 × 1 × 16 × 1
      * 2 real channels and 8 histogram bins each recorded at 2 timepoints, with
        additional relative-time points interleaved between channels as
        ModuloAlongC
@@ -160,12 +160,12 @@ This section lists various examples of OME-TIFF datasets distributed across mult
      * Partial metadata files†
 
   -  * :ometiff_downloads:`Master OME-TIFF fileset <binaryonly>`
-     * 18 x 24 x 5 x 1 x 1
+     * 18 × 24 × 5 × 1 × 1
      * :file:`multifile-Z1.ome.tiff`
      * :file:`multifile-Z[2-5].ome.tiff`
 
   -  * :ometiff_downloads:`Companion OME-XML fileset <companion>`
-     * 18 x 24 x 5 x 1 x 1
+     * 18 × 24 × 5 × 1 × 1
      * :file:`multifile.companion.ome`
      * :file:`multifile-Z[1-5].ome.tiff`
 

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -2,7 +2,7 @@ OME-TIFF sample data
 ====================
 
 This section provides some sample data in OME-TIFF format. They include data
-produced from an acquisition system as well as artificial sample datasets i.e.
+produced from an acquisition system as well as artificial sample datasets, i.e.
 designed for developer testing that illustrate some possible data
 organizations, which should be useful if you are interested in implementing
 support for OME-TIFF within your software.

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -66,6 +66,7 @@ according to its dimensional position for easy testing.
 
 .. list-table::
   :header-rows: 1
+  :widths: 15 15 20
 
   -  * Name
      * Image dimensions (XYZCT)
@@ -113,6 +114,7 @@ available from the :ometiff_downloads:`modulo` folder of the image downloads
 resource.
 
 .. list-table::
+  :widths: 25 15 40
   :header-rows: 1
 
   -  * Name

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -89,11 +89,11 @@ according to its dimensional position for easy testing.
 
   -  * Multi channel Z series
      * 439 x 167 x 5 x 3 x 1
-     * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-z-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-z-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-z-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/timulti-channel-z-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-z-series.ome.tf2>`
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-z-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-z-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-z-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel-z-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-z-series.ome.tf2>`
 
   -  * Multi channel time series
      * 439 x 167 x 1 x 3 x 7
-     * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-time-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-time-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-time-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel-timee-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-time-series.ome.tf2>`
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-time-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-time-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-time-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel-time-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-time-series.ome.tf2>`
 
   -  * 4D series
      * 439 x 167 x 5 x 1 x 7

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -57,63 +57,51 @@ version since their initial creation.
 Artificial datasets
 -------------------
 
-Bio-Formats generated
-^^^^^^^^^^^^^^^^^^^^^
+5D datasets
+^^^^^^^^^^^
 
-All datasets in the following table were :source:`artificially
-generated <components/formats-bsd/src/loci/formats/tools/MakeTestOmeTiff.java>`
-with each plane labeled according to its dimensional position for easy
-testing. Each one consists of a single OME-TIFF file (2016-06 schema
-version) containing every constituent image plane. 
+All datasets in the following table are single OME-TIFF files generated using
+Bio-Formats ``loci.formats.tools.MakeTestOmeTiff``. Each plane is labeled
+according to its dimensional position for easy testing.
 
 .. list-table::
   :header-rows: 1
-  :widths: 40, 20, 20, 20
 
-  -  * Sample
-     * Channels
-     * Focal planes
-     * Time points
+  -  * Name
+     * Image dimensions (XYZCT)
+     * Available extensions
   
-  -  * :ometiff_downloads:`single-channel.ome.tif <bioformats-artificial/single-channel.ome.tif>`
-     * 1
-     * 1
-     * 1
+  -  * Single channel
+     * 439 x 167 x 1 x 1 x 1
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/single-channel.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/single-channel.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/single-channel.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/single-channel.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/single-channel.ome.tf2>`
 
-  -  * :ometiff_downloads:`multi-channel.ome.tif <bioformats-artificial/multi-channel.ome.tif>`
-     * 3
-     * 1
-     * 1
+  -  * Multi channel
+     * 439 x 167 x 1 x 3 x 1
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel.ome.tf2>`
 
-  -  * :ometiff_downloads:`z-series.ome.tif <bioformats-artificial/z-series.ome.tif>`
-     * 1
-     * 5
-     * 1
+  -  * Z series
+     * 439 x 167 x 5 x 1 x 1
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/z-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/z-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/z-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/z-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/z-series.ome.tf2>`
 
-  -  * :ometiff_downloads:`time-series.ome.tif <bioformats-artificial/time-series.ome.tif>`
-     * 1
-     * 1
-     * 7
+  -  * Time series
+     * 439 x 167 x 1 x 1 x 7
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/time-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/time-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/time-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/time-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/time-series.ome.tf2>`
 
-  -  * :ometiff_downloads:`multi-channel-z-series.ome.tif <bioformats-artificial/multi-channel-z-series.ome.tif>`
-     * 3
-     * 5
-     * 1
+  -  * Multi channel Z series
+     * 439 x 167 x 5 x 3 x 1
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-z-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-z-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-z-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/timulti-channel-z-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-z-series.ome.tf2>`
 
-  -  * :ometiff_downloads:`multi-channel-time-series.ome.tif <bioformats-artificial/multi-channel-time-series.ome.tif>`
-     * 3
-     * 1
-     * 7
+  -  * Multi channel time series
+     * 439 x 167 x 1 x 3 x 7
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-time-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-time-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-time-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel-timee-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-time-series.ome.tf2>`
 
-  -  * :ometiff_downloads:`4D-series.ome.tif <bioformats-artificial/4D-series.ome.tif>`
-     * 1
-     * 5
-     * 7
+  -  * 4D series
+     * 439 x 167 x 5 x 1 x 7
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/4D-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/4D-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/4D-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/4D-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/4D-series.ome.tf2>`
 
-  -  * :ometiff_downloads:`multi-channel-4D-series.ome.tif <bioformats-artificial/multi-channel-4D-series.ome.tif>`
-     * 3
-     * 5
-     * 7
+  -  * Multi channel 4D series
+     * 439 x 167 x 5 x 3 x 7
+     * :ometiff_downloads:`ome.tif <bioformats-artificial/multi-channel-4D-series.ome.tif>`, :ometiff_downloads:`ome.tiff <bioformats-artificial/multi-channel-4D-series.ome.tiff>`, :ometiff_downloads:`ome.tf8 <bioformats-artificial/multi-channel-4D-series.ome.tf8>`, :ometiff_downloads:`ome.btf <bioformats-artificial/multi-channel-4D-series.ome.btf>`, :ometiff_downloads:`ome.tf2 <bioformats-artificial/multi-channel-4D-series.ome.tf2>`
 
 .. _modulo-datasets:
 

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -109,33 +109,38 @@ Modulo datasets
 ^^^^^^^^^^^^^^^
 
 Sample files implementing the :doc:`/developers/6d-7d-and-8d-storage` are
-available from the :ometiff_downloads:`Modulo <modulo>` folder of the image
-downloads resource.
+available from the :ometiff_downloads:`modulo` folder of the image downloads
+resource.
 
-SPIM
-""""
+.. list-table::
+  :header-rows: 1
 
-- :ometiff_downloads:`SPIM-ModuloAlongZ.ome.tiff <modulo/SPIM-ModuloAlongZ.ome.tiff>` - 4 tiles each recorded at 4 angles.
+  -  * Name
+     * Image dimensions (XYZCT)
+     * Modulo description
 
-Big lambda
-""""""""""
+  -  * :ometiff_downloads:`SPIM-ModuloAlongZ.ome.tiff <modulo/SPIM-ModuloAlongZ.ome.tiff>`
+     * 160 x 220 x 8 x 2 x 12
+     * 4 tiles interleaved as ModuloAlongT each recorded at 4 angles
+       interleaved as ModuloAlongZ
 
-- :ometiff_downloads:`LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff <modulo/LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff>` -
-  excitation of 5 wavelength [Λ, big-lambda] each recorded at 10 emission
-  wavelength ranges [λ, lambda].
+  -  * :ometiff_downloads:`LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff <modulo/LAMBDA-ModuloAlongZ-ModuloAlongT.ome.tiff>`
+     * 200 x 200 x 5 x 1 x 10
+     * excitation of 5 wavelength [Λ, big-lambda] interleaved as ModuloAlongZ,
+       each recorded at 10 emission wavelength ranges [λ, lambda] interleaved
+       as ModuloAlongT
 
-FLIM
-""""
+  -  * :ometiff_downloads:`FLIM-ModuloAlongT-TSCPC.ome.tiff <modulo/FLIM-ModuloAlongT-TSCPC.ome.tiff>`
+     * 180 x 220 x 1 x 2 x 16
+     * 2 channels and 8 histogram bins each recorded at 2 'real-time' points T,
+       with additional relative-time points (time relative to the
+       excitation pulse) interleaved as ModuloAlongT
 
-- :ometiff_downloads:`FLIM-ModuloAlongT-TSCPC.ome.tiff <modulo/FLIM-ModuloAlongT-TSCPC.ome.tiff>` -
-  2 channels and 8 histogram bins each recorded at 2 'real-time' points T,
-  with additional relative-time points (time relative to the
-  excitation pulse) interleaved as ModuloAlongT.
-
-- :ometiff_downloads:`FLIM-ModuloAlongC.ome.tiff <modulo/FLIM-ModuloAlongC.ome.tiff>` -
-  2 real channels and 8 histogram bins each recorded at 2 timepoints, with
-  additional relative-time points interleaved between channels as
-  ModuloAlongC. 
+  -  * :ometiff_downloads:`FLIM-ModuloAlongC.ome.tiff <modulo/FLIM-ModuloAlongC.ome.tiff>`
+     * 180 x 150 x 1 x 16 x 1
+     * 2 real channels and 8 histogram bins each recorded at 2 timepoints, with
+       additional relative-time points interleaved between channels as
+       ModuloAlongC
 
 .. _multifile_samples:
 

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -149,7 +149,7 @@ resource.
 Multi-file OME-TIFF filesets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This section lists various examples of OME-TIFF datasets distributed across multiple TIFF files. Both datasets contain a set of 18 by 24 pixel images with black and white text on each plane giving its time, z-depth and channel. Each of the five focal planes is saved as a separate OME-TIFF named :file:`multifile-Zxx.ome.tiff` where `xx` is the index of the focal plane.
+This section lists various examples of OME-TIFF datasets distributed across multiple TIFF files. Both datasets contain a set of 18 × 24 pixel images with black and white text on each plane giving its time, z-depth and channel. Each of the five focal planes is saved as a separate OME-TIFF named :file:`multifile-Zxx.ome.tiff` where `xx` is the index of the focal plane.
 
 .. list-table::
   :header-rows: 1

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -2,7 +2,7 @@ OME-TIFF sample data
 ====================
 
 This section provides some sample data in OME-TIFF format. They include data
-produced from an acquisition system as well as artificial sample datasets (i.e.
+produced from an acquisition system as well as artificial sample datasets i.e.
 designed for developer testing that illustrate some possible data
 organizations, which should be useful if you are interested in implementing
 support for OME-TIFF within your software.
@@ -34,34 +34,21 @@ version since their initial creation.
 
 .. list-table::
   :header-rows: 1
-  :widths: 20, 20, 15, 15, 15, 15
 
-  -  * Fileset
-     * Zipped fileset
-     * Channels
-     * Focal planes
-     * Time points
+  -  * Dataset (zip bundle)
+     * Image dimensions (XYZCT)
      * Number of files
 
-  -  * :ometiff_downloads:`tubhiswt-2D <tubhiswt-2D>`
-     * :ometiff_downloads:`tubhiswt-2D.zip <tubhiswt-2D.zip>`
-     * 2
-     * 1
-     * 1
+  -  * :ometiff_downloads:`Tubhiswt 2D <tubhiswt-2D>` (:ometiff_downloads:`tubhiswt-2D.zip <tubhiswt-2D.zip>`)
+     * 512 x 512 x 1 x 2 x 1
      * 2
 
-  -  * :ometiff_downloads:`tubhiswt-3D <tubhiswt-3D>`
-     * :ometiff_downloads:`tubhiswt-3D.zip <tubhiswt-3D.zip>`
-     * 2
-     * 1
-     * 20
+  -  * :ometiff_downloads:`Tubhiswt 3D <tubhiswt-3D>` (:ometiff_downloads:`tubhiswt-3D.zip <tubhiswt-3D.zip>`)
+     * 512 x 512 x 1 x 2 x 20
      * 2
 
-  -  * :ometiff_downloads:`tubhiswt-4D <tubhiswt-4D>`
-     * :ometiff_downloads:`tubhiswt-4D.zip <tubhiswt-4D.zip>`
-     * 2
-     * 10
-     * 43
+  -  * :ometiff_downloads:`Tubhiswt 4D <tubhiswt-4D>` (:ometiff_downloads:`tubhiswt-4D.zip <tubhiswt-4D.zip>`)
+     * 512 x 512 x 10 x 2 x 43
      * 86
 
 

--- a/docs/sphinx/ome-tiff/file-structure.rst
+++ b/docs/sphinx/ome-tiff/file-structure.rst
@@ -73,9 +73,8 @@ is possible to store partial OME-XML metadata blocks in some or all of the
 TIFF files pointing to a master file containing the full OME-XML metadata (see
 the :ref:`technical specification<binary_only>` for more details).
 
-The master file can be either a master OME-TIFF file  (see the
-:ref:`master-sample`) or a companion OME-XML file (see the
-:ref:`companion-sample`).
+The master file can be either a master OME-TIFF file or a companion OME-XML
+file (see the :ref:`multifile_samples`).
 
 Using a companion OME-XML file allows information that can only be generated
 at the end of the acquisition to be easily appended without the need to

--- a/docs/sphinx/ome-tiff/file-structure.rst
+++ b/docs/sphinx/ome-tiff/file-structure.rst
@@ -53,7 +53,7 @@ Common reasons for this situation include:
 - having many structured annotations in the OME-XML.
 
 For example, if you have a dataset with 1,000 time points, with each plane
-recorded at 512x512 as uint8 pixel type, storing each plane in its own file
+recorded at 512 × 512 as uint8 pixel type, storing each plane in its own file
 uncompressed requires ~256KB of disk per file, and ~256MB total. But if you
 have 5MB of corresponding OME-XML metadata, embedding a copy of that metadata
 in every file would result in a dataset nearly 20 times larger than before,

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -429,9 +429,7 @@ OME-XML metadata  block and
 :schema_doc:`UUID <ome_xsd.html#OME_OME_BinaryOnly_UUID>`
 should contain the UUID of this master file.
 
-The master file containing the full OME-XML metadata should be:
-
-- either an OME-XML companion file with the extension :file:`.companion.ome`
-  (see the :ref:`companion-sample`)
-- or a master OME-TIFF file containing the full metadata (see the
-  :ref:`master-sample`)
+The master file containing the full OME-XML metadata should be either an
+OME-XML companion file with the extension :file:`.companion.ome` or a master
+OME-TIFF file containing the full metadata (see :ref:`multifile_samples` for
+representative samples).


### PR DESCRIPTION
In preparation of the addition of the new OME-TIFF filesets, this PR reviews the content of the existing page with the following modifications:

- the sections are reorganized to differentiate artificial from biological (real-world?) datasets
- the Bio-Formats generated table is updated to list all the extensions
- all tables are updated to use a unified `Image Dimensions (XYZCT)` column
- the final paragraph about multi-file OME-TIFF filesets is collapsed into a single descriptive table

A few questions to be answered as part of the review:
- does the new layout make sense/simplify the addition of new datasets
- is the content of the new tables informative
- should the `Modulo` section be reorganized as a table (most of the information is quite row-specific)
- any better suggestions than `Biological` (`Real world`?) and `5D datasets`?