### PR TITLE
Add BBBC & MitoCheck datasets to the OME-TIFF samples page

### DIFF
--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -58,7 +58,8 @@ BBBC
 
 An OME-TIFF dataset representative of the
 :doc:`High Content Screening </developers/screen-plate-well>` section of the
-OME Data Model were derived from the public `Broad Bioimage Benchmark Collection <https://data.broadinstitute.org/bbbc/>`_.
+OME Data Model, derived from the public
+`Broad Bioimage Benchmark Collection <https://data.broadinstitute.org/bbbc/>`_.
 
 .. list-table::
   :header-rows: 1
@@ -79,7 +80,8 @@ MitoCheck
 ^^^^^^^^^
 
 An OME-TIFF dataset representative of the :doc:`ROI </developers/roi>`
-section of the OME Data Model was derived from the public `MitoCheck <http://www.mitocheck.org/>`_ project.
+section of the OME Data Model, derived from the public
+`MitoCheck <http://www.mitocheck.org/>`_ project.
 
 .. list-table::
   :header-rows: 1

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -60,9 +60,6 @@ An OME-TIFF dataset representative of the
 :doc:`High Content Screening </developers/screen-plate-well>` section of the
 OME Data Model were derived from the public `Broad Bioimage Benchmark Collection <https://data.broadinstitute.org/bbbc/>`_.
 
-See `Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput microscopy image sets for validation. Nature Methods 9(7):637 <http://www.nature.com/nmeth/journal/v9/n7/full/nmeth.2083.html>`__.
-
-
 .. list-table::
   :header-rows: 1
 
@@ -76,13 +73,13 @@ See `Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput micr
      * `BBBC017 <https://data.broadinstitute.org/bbbc/BBBC017/>`_
      * `CC-BY-NC-SA 3.0 <https://creativecommons.org/licenses/by-nc-sa/3.0>`_
 
+See `Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput microscopy image sets for validation. Nature Methods 9(7):637 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3627348/>`__.
+
 MitoCheck
 ^^^^^^^^^
 
 An OME-TIFF dataset representative of the :doc:`ROI </developers/roi>`
 section of the OME Data Model was derived from the public `MitoCheck <http://www.mitocheck.org/>`_ project.
-
-See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-lapse microscopy reveals cell division genes. Nature464(7289):721 <http://www.nature.com/nature/journal/v464/n7289/full/nature08869.html>`__.
 
 .. list-table::
   :header-rows: 1
@@ -97,6 +94,7 @@ See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-l
      * `IDR <http://idr-demo.openmicroscopy.org/webclient/?show=well-771034>`_
      * `Public Domain <https://creativecommons.org/publicdomain/mark/1.0/>`_
 
+See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-lapse microscopy reveals cell division genes. Nature 464(7289):721 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3108885/>`__.
 
 .. _artificial-datasets:
 

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -9,7 +9,7 @@ support for OME-TIFF within your software.
 
 All the OME-TIFF sample data discussed below are available from our
 :ometiff_downloads:`OME-TIFF sample images resource <>` and licensed under
-`Creative Commons Attribution 4.0 International License <http://creativecommons.org/licenses/by/4.0/>`_
+`Creative Commons Attribution 4.0 International License <https://creativecommons.org/licenses/by/4.0/>`_
 unless specified otherwise.
 
 Biological datasets
@@ -95,7 +95,7 @@ See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-l
   -  * :ometiff_downloads:`00001_01.ome.tiff <MitoCheck/00001_01.ome.tiff>`
      * 1344 × 1024 × 1 × 1 × 93
      * `IDR <http://idr-demo.openmicroscopy.org/webclient/?show=well-771034>`_
-     * `Public Domain <http://creativecommons.org/publicdomain/mark/1.0/>`_
+     * `Public Domain <https://creativecommons.org/publicdomain/mark/1.0/>`_
 
 
 .. _artificial-datasets:

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -60,7 +60,8 @@ An OME-TIFF dataset representative of the
 :doc:`High Content Screening </developers/screen-plate-well>` section of the
 OME Data Model were derived from the public `Broad Bioimage Benchmark Collection <https://data.broadinstitute.org/bbbc/>`_.
 
-See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-lapse microscopy reveals cell division genes. Nature464(7289):721 <http://www.nature.com/nature/journal/v464/n7289/full/nature08869.html>`__.
+See `Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput microscopy image sets for validation. Nature Methods 9(7):637 <http://www.nature.com/nmeth/journal/v9/n7/full/nmeth.2083.html>`__.
+
 
 .. list-table::
   :header-rows: 1
@@ -81,7 +82,7 @@ MitoCheck
 An OME-TIFF dataset representative of the :doc:`ROI </developers/roi>`
 section of the OME Data Model was derived from the public `MitoCheck <http://www.mitocheck.org/>`_ project.
 
-See `Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput microscopy image sets for validation. Nature Methods 9(7):637 <http://www.nature.com/nmeth/journal/v9/n7/full/nmeth.2083.html>`__.
+See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-lapse microscopy reveals cell division genes. Nature464(7289):721 <http://www.nature.com/nature/journal/v464/n7289/full/nature08869.html>`__.
 
 .. list-table::
   :header-rows: 1

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -69,7 +69,7 @@ OME Data Model, derived from the public
      * Provenance
      * Copyright
 
-  -  * :ometiff_downloads:`BBBC/NIRHTa-001.ome.tiff`
+  -  * :ometiff_downloads:`NIRHTa-001.ome.tiff <BBBC/NIRHTa-001.ome.tiff>`
      * 512 × 512 × 1 × 3 × 1
      * `BBBC017 <https://data.broadinstitute.org/bbbc/BBBC017/>`_
      * `CC-BY-NC-SA 3.0 <https://creativecommons.org/licenses/by-nc-sa/3.0>`_

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -51,6 +51,24 @@ version since their initial creation.
      * 512 × 512 × 10 × 2 × 43
      * 86
 
+BBBC
+^^^^
+
+OME-TIFF datasets representative of the :doc:`High Content Screening </developers/screen-plate-well>` section of the OME Data Model were derived from the public `Broad Bioimage Benchmark Collection <https://data.broadinstitute.org/bbbc/>`_. See Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput microscopy image sets for validation. Nature Methods 9(7):637.
+
+
+.. list-table::
+  :header-rows: 1
+
+  -  * Dataset
+     * Image dimensions (XYZCT)
+     * Provenance
+     * Copyright
+
+  -  * :ometiff_downloads:`BBBC/NIRHTa-001.ome.tiff`
+     * 512 × 512 × 1 × 3 × 1
+     * `BBBC017 <https://data.broadinstitute.org/bbbc/BBBC017/>`_
+     * `CC-BY-NC-SA 3.0 <https://creativecommons.org/licenses/by-nc-sa/3.0>`_
 
 .. _artificial-datasets:
 

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -8,7 +8,9 @@ organizations, which should be useful if you are interested in implementing
 support for OME-TIFF within your software.
 
 All the OME-TIFF sample data discussed below are available from our
-:ometiff_downloads:`OME-TIFF sample images resource <>`.
+:ometiff_downloads:`OME-TIFF sample images resource <>` and licensed under
+`Creative Commons Attribution 4.0 International License <http://creativecommons.org/licenses/by/4.0/>`_
+unless specified otherwise.
 
 Biological datasets
 -------------------
@@ -54,8 +56,11 @@ version since their initial creation.
 BBBC
 ^^^^
 
-OME-TIFF datasets representative of the :doc:`High Content Screening </developers/screen-plate-well>` section of the OME Data Model were derived from the public `Broad Bioimage Benchmark Collection <https://data.broadinstitute.org/bbbc/>`_. See Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput microscopy image sets for validation. Nature Methods 9(7):637.
+An OME-TIFF dataset representative of the
+:doc:`High Content Screening </developers/screen-plate-well>` section of the
+OME Data Model were derived from the public `Broad Bioimage Benchmark Collection <https://data.broadinstitute.org/bbbc/>`_.
 
+See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-lapse microscopy reveals cell division genes. Nature464(7289):721 <http://www.nature.com/nature/journal/v464/n7289/full/nature08869.html>`__.
 
 .. list-table::
   :header-rows: 1
@@ -69,6 +74,28 @@ OME-TIFF datasets representative of the :doc:`High Content Screening </developer
      * 512 × 512 × 1 × 3 × 1
      * `BBBC017 <https://data.broadinstitute.org/bbbc/BBBC017/>`_
      * `CC-BY-NC-SA 3.0 <https://creativecommons.org/licenses/by-nc-sa/3.0>`_
+
+MitoCheck
+^^^^^^^^^
+
+An OME-TIFF dataset representative of the :doc:`ROI </developers/roi>`
+section of the OME Data Model was derived from the public `MitoCheck <http://www.mitocheck.org/>`_ project.
+
+See `Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput microscopy image sets for validation. Nature Methods 9(7):637 <http://www.nature.com/nmeth/journal/v9/n7/full/nmeth.2083.html>`__.
+
+.. list-table::
+  :header-rows: 1
+
+  -  * Dataset
+     * Image dimensions (XYZCT)
+     * Provenance
+     * Copyright
+
+  -  * :ometiff_downloads:`00001_01.ome.tiff <MitoCheck/00001_01.ome.tiff>`
+     * 1344 × 1024 × 1 × 1 × 93
+     * `IDR <http://idr-demo.openmicroscopy.org/webclient/?show=well-771034>`_
+     * `Public Domain <http://creativecommons.org/publicdomain/mark/1.0/>`_
+
 
 .. _artificial-datasets:
 


### PR DESCRIPTION
This PR aims at registering the converted BBBC & MitoCheck datasets used for the [benchmark work](https://github.com/openmicroscopy/ome-files-performance) into the official OME-TIFF documentation as public OME-TIFF samples representative of HCS and ROI data.

A few questions while working on the initial draft:
- is there other representative data we should add to the tables (columns/rows/fields, ROIs)
- with regard to the data layout, we currently have a single plate converted. There was a brief discussion of converting other plates to test some scaling with @rleigh-codelibre. Is there a case for anticipating and starting to organize into subfolders e.g. `BBBC/BBBC0017/NIRHTa-0001.ome.tiff` or should we consider this when the use case shows up?

/cc @hflynn @AnneCarpenter