### PR TITLE
Fix bigTIFF link to match BF

### DIFF
--- a/docs/sphinx/ome-tiff/code.rst
+++ b/docs/sphinx/ome-tiff/code.rst
@@ -65,7 +65,7 @@ with:
 
 .. seealso::
 
-    `BigTIFF file format specification <http://bigtiff.org/#FILE_FORMAT>`__
+    `BigTIFF file format specification <http://www.awaresystems.be/imaging/tiff/bigtiff.html>`__
 
 Modifying a TIFF comment
 ------------------------

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -9,7 +9,8 @@ format. It assumes familiarity with both the
 An OME-TIFF dataset consists of:
 
 - one or more files in standard TIFF format with the file extension
-  ``.ome.tif`` or ``.ome.tiff`` or `BigTIFF format <http://bigtiff.org/>`_
+  ``.ome.tif`` or ``.ome.tiff`` or
+  `BigTIFF format <http://www.awaresystems.be/imaging/tiff/bigtiff.html>`_
   with one of these same file extensions or a BigTIFF-specific
   extension ``.ome.tf2``, ``.ome.tf8`` or ``.ome.btf``
 - a string of OME-XML metadata embedded in the ImageDescription tag of the
@@ -45,8 +46,8 @@ specification) shows the organization of a TIFF header along with the
 placement of the OME-XML metadata block.  Note this is for the TIFF
 standard specification only; the header structure is slightly
 different for BigTIFF; see the `BigTIFF file format specification
-<http://bigtiff.org/#FILE_FORMAT>`__. A TIFF file can contain any
-number of IFDs, with each one specifying an image plane along with
+<http://www.awaresystems.be/imaging/tiff/bigtiff.html>`__. A TIFF file can
+contain any number of IFDs, with each one specifying an image plane along with
 certain accompanying metadata such as pixel dimensions, physical
 dimensions, bit depth, color table, etc. One of the fields an IFD can
 contain is ImageDescription, which provides a place to write a comment


### PR DESCRIPTION
See https://ci.openmicroscopy.org/view/Failing/job/MODEL-merge-docs/84/console

This updates the BigTIFF links to match the one used in Bio-Formats docs and should make the build green again.

Staged at http://www.openmicroscopy.org/site/support/ome-model-staging/ome-tiff/specification.html and http://www.openmicroscopy.org/site/support/ome-model-staging/ome-tiff/code.html