### PR TITLE
xsd-fu: Correct C++ model object template using wrong element

### DIFF
--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -903,7 +903,7 @@ ${customUpdatePropertyContent[prop.name]}
         std::vector<common::xml::dom::Element> ${prop.name}_nodeList(getChildrenByTagName("${prop.name}"));
         for (auto& elem : ${prop.name}_nodeList)
           {
-            std::string text(element.getTextContent()); /// @todo should this be elem?
+            std::string text(elem.getTextContent());
             std::shared_ptr<${prop.methodName}> object(${prop.langTypeNS}::create(text, model));
             add${prop.methodName}(object);
           }


### PR DESCRIPTION
[Trello](https://trello.com/c/S7fIcUi9/7-correct-xsd-fu-template-mistake)

Compare with the Java template, line 433.  We make it use each element for the NodeList we are iterating over, rather than the current element.

Testing: Looking at the generated sources, this codepath appears to be unused at present.  Maybe simply confirming we match the Java behaviour is sufficient to check?