### PR TITLE
Generate pybind11 bindings (enums)

### DIFF
--- a/xsd-fu/python/ome/modeltools/language.py
+++ b/xsd-fu/python/ome/modeltools/language.py
@@ -430,6 +430,16 @@ class CXX(Language):
         return sig
 
 
+class Pybind11(CXX):
+
+    def __init__(self, namespace, templatepath):
+        super(Pybind11, self).__init__(namespace, templatepath)
+        self.template_dir = "templates-pybind11"
+
+    def generatedFilename(self, name, type):
+        return super(Pybind11, self).generatedFilename(name, type).lower()
+
+
 def create(language, namespace, templatepath):
     """
     Create a language by name.
@@ -441,6 +451,8 @@ def create(language, namespace, templatepath):
         lang = Java(namespace, templatepath)
     elif language == "C++":
         lang = CXX(namespace, templatepath)
+    elif language == "pybind11":
+        lang = Pybind11(namespace, templatepath)
     else:
         raise ModelProcessingError(
             "Invalid language: %s" % language)

--- a/xsd-fu/templates-pybind11/OMEXMLModelAllEnums.template
+++ b/xsd-fu/templates-pybind11/OMEXMLModelAllEnums.template
@@ -1,0 +1,59 @@
+/*
+ * #%L
+ * OME-FILES Python library for image IO.
+ * Copyright (c) 2016-2017 University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+/*─────────────────────────────────────────────────────────────────────────────
+ *
+ * THIS IS AUTOMATICALLY GENERATED CODE.  DO NOT MODIFY.
+ *
+ *─────────────────────────────────────────────────────────────────────────────
+ */
+
+{% if fu.SOURCE_TYPE == "header" %}\
+#pragma once
+
+{% for header in fu.HEADERS %}\
+#include "${header.rsplit('/', 1)[-1].lower()}"
+{% end %}\
+
+
+void init_enums(pybind11::module &m);
+{% end %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+#include "enums.h"
+
+
+namespace py = pybind11;
+
+
+void init_enums(py::module &m) {
+  py::module subm = m.def_submodule("enums");
+{% for header in fu.HEADERS %}\
+  init_${header.rsplit('/', 1)[-1].rsplit('.', 1)[0].lower()}(subm);
+{% end %}\
+}
+{% end %}\

--- a/xsd-fu/templates-pybind11/OMEXMLModelEnum.template
+++ b/xsd-fu/templates-pybind11/OMEXMLModelEnum.template
@@ -1,0 +1,91 @@
+/*
+ * #%L
+ * OME-FILES Python library for image IO.
+ * Copyright (c) 2016-2017 University of Dundee
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+/*─────────────────────────────────────────────────────────────────────────────
+ *
+ * THIS IS AUTOMATICALLY GENERATED CODE.  DO NOT MODIFY.
+ *
+ *─────────────────────────────────────────────────────────────────────────────
+ */
+
+{% if fu.SOURCE_TYPE == "header" %}\
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+
+void init_${klass.langType.lower()}(pybind11::module &m);
+{% end %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+#include <string>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <ome/xml/model/enums/${klass.langType}.h>
+
+#include "${klass.langType.lower()}.h"
+
+
+namespace py = pybind11;
+using ome::xml::model::enums::${klass.langType};
+
+
+void init_${klass.langType.lower()}(py::module &m) {
+  py::class_<${klass.langType}> ${klass.langType}Wrapper(m, "${klass.langType}");
+  ${klass.langType}Wrapper
+    .def(py::init<${klass.langType}::enum_value>())
+    .def(py::init<const std::string&, bool>(), "",
+	 py::arg().noconvert(), py::arg("strict") = false)
+    .def("__str__", [](const ${klass.langType} &t) {
+	return static_cast<std::string>(t);
+      })
+    .def("__repr__", [](const ${klass.langType} &t) {
+	return "${klass.langType}('" + static_cast<std::string>(t) + "')";
+      })
+    .def(py::self == py::self)
+    .def(py::self != py::self)
+    .def_property_readonly("value", [](const ${klass.langType} &t) {
+	return static_cast<${klass.langType}::enum_value>(t);
+      })
+    .def_static("strings", []() { return ${klass.langType}::strings(); },
+		"Get a map of valid string names and enum values.")
+    .def_static("values", []() { return ${klass.langType}::values(); },
+		"Get a map of valid enum values and string names.");
+  py::enum_<${klass.langType}::enum_value> EnumValue(${klass.langType}Wrapper, "enum_value");
+  EnumValue
+{% for value in klass.possibleValues %}\
+{% if klass.enumProperties is not None and value in klass.enumProperties and klass.enumProperties[value].get('enum', None) is not None %}\
+    .value("${klass.enumProperties[value].enum}", ${klass.langType}::enum_value::${klass.enumProperties[value].enum})
+{% end %}\
+{% if klass.enumProperties is None or not value in klass.enumProperties or klass.enumProperties[value].get('enum', None) is None %}\
+    .value("${enum_value_name(value, False).upper()}", ${klass.langType}::enum_value::${enum_value_name(value, False).upper()})
+{% end %}\
+{% end %}\
+    .export_values();
+  ${klass.langType}Wrapper.attr("__members__") = EnumValue.attr("__members__");
+}
+{% end %}\

--- a/xsd-fu/xsd-fu
+++ b/xsd-fu/xsd-fu
@@ -358,12 +358,12 @@ def enumTypesIncludeAll(model, opts):
     used_files.add(os.path.realpath(opts.lang.templatepath('ENUM_INCLUDEALL')))
     headers = model.getEnumHeaders()
 
-    fullname = opts.lang.generatedFilename("enums", language.TYPE_HEADER)
+    fullname = opts.lang.generatedFilename("enums", opts.filetype)
     fullname = os.path.join("ome", "xml", "model", fullname)
 
     fu.GUARD = guard(fullname)
     fu.CLASS_PREFIX = class_prefix(fullname)
-    fu.SOURCE_TYPE = language.TYPE_HEADER;
+    fu.SOURCE_TYPE = opts.filetype;
     fu.HEADERS = sorted(headers);
 
     fullname = os.path.join(opts.outdir, fullname)

--- a/xsd-fu/xsd-fu
+++ b/xsd-fu/xsd-fu
@@ -85,6 +85,8 @@ def usage(error):
     """
     java = language.create("Java", config.DEFAULT_NAMESPACE, "/path/to/schemas")
     cpp = language.create("C++", config.DEFAULT_NAMESPACE, "/path/to/schemas")
+    pybind11 = language.create("pybind11", config.DEFAULT_NAMESPACE,
+                               "/path/to/schemas")
 
     cmd = sys.argv[0]
     print("""Error: %s
@@ -135,9 +137,16 @@ Default C++ OME-XML quantity package: "%s"
 Default C++ metadata package: "%s"
 Default C++ OME-XML metadata package: "%s"
 
+Default pybind11 OME-XML package: "%s"
+Default pybind11 OME-XML enum package: "%s"
+Default pybind11 OME-XML quantity package: "%s"
+Default pybind11 metadata package: "%s"
+Default pybind11 OME-XML metadata package: "%s"
+
 Examples:
   %s -l Java -n '%s' --ome-xml-model-package=%s -o omexml /path/to/schemas/ome.xsd
   %s -l C++ -n '%s' --ome-xml-model-package=%s -o omexml /path/to/schemas/ome.xsd
+  %s -l pybind11 -n '%s' --ome-xml-model-package=%s -o omexml /path/to/schemas/ome.xsd
 
 Report bugs to OME Devel <ome-devel@lists.openmicroscopy.org.uk>""" % \
     (error,
@@ -145,8 +154,10 @@ Report bugs to OME Devel <ome-devel@lists.openmicroscopy.org.uk>""" % \
      java.modelNamespace,
      java.omexml_model_package, java.omexml_model_enums_package, java.omexml_model_omexml_model_enum_handlers_package, java.metadata_package, java.omexml_metadata_package,
      cpp.omexml_model_package, cpp.omexml_model_enums_package, cpp.omexml_model_quantity_package, cpp.metadata_package, cpp.omexml_metadata_package,
+     pybind11.omexml_model_package, pybind11.omexml_model_enums_package, pybind11.omexml_model_quantity_package, pybind11.metadata_package, pybind11.omexml_metadata_package,
      cmd, java.modelNamespace, java.omexml_model_package,
-     cmd, cpp.modelNamespace, cpp.omexml_model_package))
+     cmd, cpp.modelNamespace, cpp.omexml_model_package,
+     cmd, pybind11.modelNamespace, pybind11.omexml_model_package))
     sys.exit(2)
 
 def main(model, opts):


### PR DESCRIPTION
Adds the logic and templates for generating pybind11 bindings for enums. This should be eventually extended to the generation of bindings for the whole model.

```
cd xsd-fu
for target in omexml_model_enum{s,_includeall}; do
  for type in header source; do
    ./xsd-fu ${target} --file-type=${type} --language=pybind11 --output-directory=/tmp/output ../specification/src/main/resources/released-schema/2016-06/ome.xsd
  done
done
```

See https://github.com/ome/ome-files-py/pull/23 for an example of manual integration in `ome-files-py`.