### PR TITLE
Update URLs & copyright years

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -153,6 +153,8 @@ extlinks = {
     'ome-files' : (oo_root + '/ome-files/%s', ''), 
     'partners' : (oo_root + '/commercial-partners/%s', ''),
     'schema' : (oo_root + '/Schemas/%s', ''),
+    # Old plone links still to be copied to new site
+    'about_plone' : (oo_site_root + '/about/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -128,6 +128,7 @@ oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'http://downloads.openmicroscopy.org'
 help_root = 'http://help.openmicroscopy.org'
+docs_root = 'http://docs.openmicroscopy.org'
 
 # Edit on GitHub prefix
 edit_on_github_prefix = 'docs/sphinx'
@@ -146,22 +147,12 @@ extlinks = {
     'ome-users' : (lists_root + '/pipermail/ome-users/%s' ,''),
     'ome-devel' : (lists_root + '/pipermail/ome-devel/%s' ,''),
     'forum' : (oo_root + '/community/%s', ''),
-    # Plone links. Separating them out so that we can add prefixes and
-    # suffixes during testing.
-    'community_plone' : (oo_site_root + '/community/%s', ''),
-    'legacy_plone' : (oo_site_root + '/support/previous/%s', ''),
-    'about_plone' : (oo_site_root + '/about/%s', ''),
-    'team_plone' : (oo_site_root + '/team/%s', ''),
-    'schema_plone' : (oo_root + '/Schemas/%s', ''),
-    'omero_plone' : (oo_site_root + '/products/omero/%s', ''),
-    'secvuln' : (oo_root + '/info/vulnerabilities/%s', ''),
-    'bf_plone' : (oo_site_root + '/products/bio-formats/%s', ''),
-    'partner_plone' : (oo_site_root + '/products/partner/%s', ''),
-    'cpp_plone' : (oo_site_root + '/products/ome-files-cpp/%s', ''),
-    # One branch only doc links. Branched docs links in conf.py files for
-    # individual doc sets
-    'model_doc' : (oo_site_root + '/support/ome-model/%s', ''),
-    'devs_doc' : (oo_site_root + '/support/contributing/%s', ''),
+    # Website links
+    'omero' : (oo_root + '/omero/%s', ''),
+    'bf' : (oo_root + '/bio-formats/%s', ''),
+    'ome-files' : (oo_root + '/ome-files/%s', ''), 
+    'partners' : (oo_root + '/commercial-partners/%s', ''),
+    'schema' : (oo_root + '/Schemas/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links
@@ -180,8 +171,9 @@ extlinks = {
     # API
     'javadoc' : (downloads_root + '/latest/bio-formats/api/%s', ''),
     # Doc links
-    'omero_doc' : (oo_site_root + '/support/omero/%s', ''),
-    'bf_doc' : (oo_site_root + '/support/bio-formats/%s', ''),
+    'devs_doc' : (docs_root + '/contributing/%s', ''),
+    'omero_doc' : (docs_root + '/latest/omero/%s', ''),
+    'bf_doc' : (docs_root + '/latest/bio-formats/%s', ''),
     'schema_doc' : (oo_root + '/Schemas/Documentation/Generated/OME-' + model_version + '/%s', ''),
     # Downloads
     'bf_downloads' : (downloads_root + '/latest/bio-formats/%s', ''),

--- a/docs/sphinx/developers/index.rst
+++ b/docs/sphinx/developers/index.rst
@@ -81,7 +81,7 @@ MetadataRetrieve interfaces) to greatly simplify OME-XML-related
 development tasks.
 
 The following program edits the "image name" metadata value for the file
-given on the command line. It requires the :bf_plone:`Bio-Formats <>` and 
+given on the command line. It requires the :bf:`Bio-Formats <>` and 
 :doc:`OME-XML Java </ome-xml/java-library>` libraries.
 
 :bf_source:`EditImageName.java <components/formats-gpl/utils/EditImageName.java>`

--- a/docs/sphinx/developers/sample-files.rst
+++ b/docs/sphinx/developers/sample-files.rst
@@ -6,7 +6,7 @@ Sample OME-XML and OME-TIFF files can be found here:
 
 Each schema version's samples are located in a folder named after the schema's
 date e.g. folder :image_downloads:`OME-TIFF/2016-06/` has samples using schema
-version :schema_plone:`OME/2016-06`.
+version :schema:`OME/2016-06`.
 
 See the :doc:`/ome-tiff/data` section for more information about the sample
 TIFF files. The OME-XML files contained in the :image_downloads:`OME-XML`

--- a/docs/sphinx/developers/using-ome-xml.rst
+++ b/docs/sphinx/developers/using-ome-xml.rst
@@ -7,7 +7,7 @@ This sections explains how to use OME schema elements in your own XML files.
     The correct attribution for work derived from our schema files under the 
     Creative Commons licence is:
     **"This work is derived in part from the OME specification.
-    Copyright (C) 2002-2016 Open Microscopy Environment"**
+    Copyright (C) 2002-2017 Open Microscopy Environment"**
 
 We encourage people to make use of the OME Data Model as a
 whole by using the OME-XML and OME-TIFF formats directly. If you need to
@@ -117,7 +117,7 @@ model, there are two approaches:
     including in the appropriate place in your software or project
     documentation:
     **"This work is derived in part from the OME specification.
-    Copyright (C) 2002-2015 Open Microscopy Environment"**
+    Copyright (C) 2002-2017 Open Microscopy Environment"**
 
 Worked examples
 ---------------

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -21,16 +21,16 @@ appeared in Genome Biology.
 The OME consortium currently provides three major tools capable of working
 with OME-XML and OME-TIFF:
 
--  The :bf_plone:`Bio-Formats <>` library is a full-featured library with many
+-  The :bf:`Bio-Formats <>` library is a full-featured library with many
    features related to OME-XML, including conversion of third party file
    format metadata into OME-XML structures. It can write image data to the
    OME-TIFF format.
 
--  :cpp_plone:`OME Files C++ <>` is a reference implementation of the OME
+-  :omeo-files:`OME Files C++ <>` is a reference implementation of the OME
    data model and OME-TIFF for C++ developers wishing to support these in 
    their own software. It can read and write OME-TIFF data.
 
--  The :omero_plone:`OMERO server <>` works directly with OME-XML. It can
+-  The :omero:`OMERO server <>` works directly with OME-XML. It can
    import data from OME-XML and OME-TIFF, as well as export to OME-TIFF.
 
 
@@ -39,7 +39,7 @@ use the :about_plone:`correct citations <licensing-attribution/citing-ome>` to
 acknowledge us.
 
 We have received support from several companies who use our file formats, for
-details see our list of :about_plone:`Partners <partners>`.
+details see our list of :partners:`Partners <>`.
 
 
 ********

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -26,7 +26,7 @@ with OME-XML and OME-TIFF:
    format metadata into OME-XML structures. It can write image data to the
    OME-TIFF format.
 
--  :omeo-files:`OME Files C++ <>` is a reference implementation of the OME
+-  :ome-files:`OME Files C++ <>` is a reference implementation of the OME
    data model and OME-TIFF for C++ developers wishing to support these in 
    their own software. It can read and write OME-TIFF data.
 

--- a/docs/sphinx/ome-tiff/code.rst
+++ b/docs/sphinx/ome-tiff/code.rst
@@ -87,7 +87,7 @@ the file, it overwrites the old data in place.
 The following program extracts comments from TIFF files, prompts the
 user to alter the comments on the command line, and writes updated
 comments back to the files. It requires the
-:bf_plone:`Bio-Formats library <>`.
+:bf:`Bio-Formats library <>`.
 
 :bf_source:`EditTiffComment.java <components/formats-gpl/utils/EditTiffComment.java>`
 
@@ -116,7 +116,7 @@ the conversion from proprietary third-party metadata into OME-XML—a task
 that Bio-Formats greatly simplifies.
 
 The following program converts the files given on the command line into
-OME-TIFF format. It requires the :bf_plone:`Bio-Formats <>` and :doc:`OME-XML
+OME-TIFF format. It requires the :bf:`Bio-Formats <>` and :doc:`OME-XML
 Java </ome-xml/java-library>` libraries.
 
 :bf_source:`ConvertToOmeTiff.java <components/formats-gpl/utils/ConvertToOmeTiff.java>`
@@ -138,5 +138,7 @@ regarding the OME-XML conversion relating to any specific format. If
 there is any metadata missing or converted incorrectly, please let us
 know.
 
-.. seealso:: :bf_doc:`Exporting raw pixel data to OME-TIFF files <developers/export2.html>` 
+.. seealso::
+    
+    :bf_doc:`Exporting raw pixel data to OME-TIFF files <developers/export2.html>` 
     and :bf_doc:`Converting files from FV1000 OIB/OIF to OME-TIFF <developers/conversion.html>`

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -4,7 +4,7 @@ OME-TIFF specification
 The following provides technical details on the OME-TIFF
 format. It assumes familiarity with both the
 `TIFF <https://en.wikipedia.org/wiki/TIFF>`_ and
-:schema_plone:`OME-XML <>` formats, although there is some review of both.
+:schema:`OME-XML <>` formats, although there is some review of both.
 
 An OME-TIFF dataset consists of:
 

--- a/docs/sphinx/ome-xml/index.rst
+++ b/docs/sphinx/ome-xml/index.rst
@@ -79,7 +79,7 @@ Some specific features of the OME-XML file format:
    :doc:`/developers/structured-annotations` XML Schema section.
 
 The OME-XML Schema .xsd files and technical documentation are available on the 
-:schema_plone:`Schema pages <>`.
+:schema:`Schema pages <>`.
 
 
 Migrating or sharing data with OME-XML

--- a/docs/sphinx/ome-xml/java-library.rst
+++ b/docs/sphinx/ome-xml/java-library.rst
@@ -5,12 +5,7 @@ OME-XML Java library
 The OME-XML Java library is a collection of Java packages for
 manipulating OME-XML metadata structures. The OME-XML Java library's
 metadata processing facilities form the backbone of the
-:bf_plone:`Bio-Formats <>` library's support for OME-XML conversion.
-
-It is not to be confused with the 
-:legacy_plone:`OME-Java API <ome-server/developer/java-api>`
-for communicating with an :legacy_plone:`OME Server <ome-server>`
-from Java.
+:bf:`Bio-Formats <>` library's support for OME-XML conversion.
 
 Download
 --------

--- a/docs/sphinx/schemas/index.rst
+++ b/docs/sphinx/schemas/index.rst
@@ -108,7 +108,7 @@ Technical schema descriptions
 
 Auto-generated documentation is available for each release of the
 schema, including information on each attribute and element. These are
-published as :schema_plone:`XSD files <>` on the OME website. They are usually
+published as :schema:`XSD files <>` on the OME website. They are usually
 read by XML validators and parsers but are viewable as text files.
 Alternatively, you can browse the
 :schema_doc:`current version of the entire Schema <ome.html>` online.
@@ -116,5 +116,5 @@ Alternatively, you can browse the
 Transforms are available which convert between the the different versions
 of the schemas. They can be downloaded from:
 
-:schema_plone:`http://www.openmicroscopy.org/Schemas/Transforms/ <Transforms/>`
+:schema:`http://www.openmicroscopy.org/Schemas/Transforms/ <Transforms/>`
 


### PR DESCRIPTION
Removes old plone URLs (except the citation page cf. https://trello.com/c/DR1L8nDA/100-add-citations) and updates copyright years