### PR TITLE
Add versioning note & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ OME data model specification, code generator and implementation.
 Links
 -----
 
-- [Documentation](http://www.openmicroscopy.org/site/support/ome-model/)
+- [Documentation](https://docs.openmicroscopy.org/latest/ome-model/)
 - [C++ API reference](http://www.openmicroscopy.org/site/support/ome-files-cpp/ome-xml/api/html/namespaces.html)
 - [Java API reference](http://javadoc.io/doc/org.openmicroscopy/ome-xml/)
 - [OME-TIFF sample images](http://downloads.openmicroscopy.org/images/OME-TIFF/)
@@ -18,7 +18,7 @@ Links
 More information
 ----------------
 
-For more information, see the [OME Model documentation](http://www.openmicroscopy.org/site/support/ome-model/).
+For more information, see the [OME Model documentation](https://docs.openmicroscopy.org/latest/ome-model/).
 
 Pull request testing
 --------------------

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -41,6 +41,10 @@ acknowledge us.
 We have received support from several companies who use our file formats, for
 details see our list of :partners:`Partners <>`.
 
+.. note:: The versioning for this documentation reflects updates to any of the
+    components it covers and is therefore incremented more frequently than the
+    Schema version, which only covers the Data Model and for which a version
+    history is provided below.
 
 ********
 OME-TIFF


### PR DESCRIPTION
Discussed with Seb earlier that the new versioning of the Model docs is a bit confusing because the only versioning discussed within the docs is the Schema versioning which is different, so I've added a note to try and clarify if anyone else is confused.

While I was here I noticed I'd missed the docs links in the README when I updated them in the docs. Note that I can't update the C++ API docs as they haven't been migrated, as noted on https://trello.com/c/aKaDecyV/78-link-to-c-api-docs