### PR TITLE
cmake: Remove REQUIRED from exported configuration

### DIFF
--- a/ome-xml/src/main/cpp/ome/xml/OMEXMLConfig.cmake.in
+++ b/ome-xml/src/main/cpp/ome/xml/OMEXMLConfig.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(OMECommon REQUIRED)
+find_dependency(OMECommon)
 
 include(${CMAKE_CURRENT_LIST_DIR}/OMEXMLInternal.cmake)
 


### PR DESCRIPTION
This is added implicitly by find_dependency.

See https://github.com/ome/ome-common-cpp/pull/51 for context.