### PR TITLE
Move OMERO pyramid specification to model documentation

### DIFF
--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -73,9 +73,9 @@ OME-XML
     ome-tiff/tools
     ome-xml/java-library
 
-**************
-OMERO Pyramids
-**************
+*************
+OMERO Pyramid
+*************
 
 .. toctree::
     :maxdepth: 1

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -73,6 +73,16 @@ OME-XML
     ome-tiff/tools
     ome-xml/java-library
 
+**************
+OMERO Pyramids
+**************
+
+.. toctree::
+    :maxdepth: 1
+    :titlesonly:
+
+    omero-pyramid/index
+
 *******************
 File specifications
 *******************

--- a/docs/sphinx/omero-pyramid/index.rst
+++ b/docs/sphinx/omero-pyramid/index.rst
@@ -1,12 +1,15 @@
 The OMERO pyramid format
 ========================
 
+The OMERO pyramid format is a way of storing very large images for easier visualization.
+Currently only v1.0.0 is currently defined.
+
+.. seealso::
+
+  :bf_doc:`Working with whole slide images <developers/wsi.html>`
+
 v1.0.0
 ------
-
-For files that contain very large images and are not in a format that supports pyramids, OMERO will generate its own
-image pyramid to improve visualization performance.  Bio-Formats can read these generated pyramids, but cannot
-currently write them outside of OMERO.  For details of how to read image pyramids with Bio-Formats, see :bf_doc:`Working with whole slide images <developers/wsi.html>`
 
 The OMERO pyramid format is a :bf_doc:`TIFF <formats/tiff.html>` file containing JPEG-2000 compressed image tiles.  All resolutions for a tile
 are encoded in the same JPEG-2000 stream, using the "decompression levels" feature of JPEG-2000.

--- a/docs/sphinx/omero-pyramid/index.rst
+++ b/docs/sphinx/omero-pyramid/index.rst
@@ -17,9 +17,3 @@ Z sections, and/or timepoints.
 
 Each pyramid contains 5 resolutions for each image plane, with each resolution stored in descending order from largest to smallest XY size.
 Each resolution is half the width and height of the previous resolution.
-
-OMERO handles pyramid generation automatically for files that do not already have a stored pyramid, use a supported pixel type,
-and have images that exceed a specific XY size.  The default XY size threshold is 3192×3192, but this can be configured in OMERO if necessary.
-Common formats for which a pyramid will be generated include :bf_doc:`Gatan DM3 <formats/gatan-digital-micrograph.html>`,
-:bf_doc:`MRC <formats/mrc.html>`, and :bf_doc:`TIFF <formats/tiff.html>`.  Dedicated whole slide imaging formats such as :bf_doc:`SVS <formats/aperio-svs-tiff.html>`
-typically contain their own image pyramid, in which case an OMERO pyramid will not be generated.

--- a/docs/sphinx/omero-pyramid/index.rst
+++ b/docs/sphinx/omero-pyramid/index.rst
@@ -1,0 +1,22 @@
+Internal OMERO pyramid format v1.0.0
+====================================
+
+For files that contain very large images and are not in a format that supports pyramids, OMERO will generate its own
+image pyramid to improve visualization performance.  Bio-Formats can read these generated pyramids, but cannot
+currently write them outside of OMERO.  For details of how to read image pyramids with Bio-Formats, see :bf_doc:`Working with whole slide images <developers/wsi.html>`
+
+The OMERO pyramid format is a :bf_doc:`TIFF <formats/tiff.html>` file containing JPEG-2000 compressed image tiles.  All resolutions for a tile
+are encoded in the same JPEG-2000 stream, using the "decompression levels" feature of JPEG-2000.
+As a result, only data types supported by the JPEG-2000 standard (``uint8`` and ``uint16``) are supported.
+Images with pixel type ``uint32``, ``float`` (32-bit floating point), or ``double`` (64-bit floating point) cannot be converted to
+an OMERO pyramid.  Pyramid files larger than 4 gigabytes are supported, as are pyramids containing multiple channels,
+Z sections, and/or timepoints.
+
+Each pyramid contains 5 resolutions for each image plane, with each resolution stored in descending order from largest to smallest XY size.
+Each resolution is half the width and height of the previous resolution.
+
+OMERO handles pyramid generation automatically for files that do not already have a stored pyramid, use a supported pixel type,
+and have images that exceed a specific XY size.  The default XY size threshold is 3192×3192, but this can be configured in OMERO if necessary.
+Common formats for which a pyramid will be generated include :bf_doc:`Gatan DM3 <formats/gatan-digital-micrograph.html>`,
+:bf_doc:`MRC <formats/mrc.html>`, and :bf_doc:`TIFF <formats/tiff.html>`.  Dedicated whole slide imaging formats such as :bf_doc:`SVS <formats/aperio-svs-tiff.html>`
+typically contain their own image pyramid, in which case an OMERO pyramid will not be generated.

--- a/docs/sphinx/omero-pyramid/index.rst
+++ b/docs/sphinx/omero-pyramid/index.rst
@@ -2,7 +2,7 @@ The OMERO pyramid format
 ========================
 
 The OMERO pyramid format is a way of storing very large images for easier visualization.
-Currently only v1.0.0 is currently defined.
+Currently only v1.0.0 is defined.
 
 .. seealso::
 

--- a/docs/sphinx/omero-pyramid/index.rst
+++ b/docs/sphinx/omero-pyramid/index.rst
@@ -18,5 +18,10 @@ Images with pixel type ``uint32``, ``float`` (32-bit floating point), or ``doubl
 an OMERO pyramid.  Pyramid files larger than 4 gigabytes are supported, as are pyramids containing multiple channels,
 Z sections, and/or timepoints.
 
-Each pyramid contains 5 resolutions for each image plane, with each resolution stored in descending order from largest to smallest XY size.
-Each resolution is half the width and height of the previous resolution.
+Each pyramid contains multiple resolutions for each image plane, with each resolution stored in descending order from largest to smallest XY size.
+Each resolution is half the width and height of the previous resolution.  OMERO by default writes 5 resolutions, but this is an implementation
+detail and not a limitation of the file format.
+
+One IFD is required to be stored for each image plane, but every resolution for a given plane is encapsulated in that plane's single IFD.
+Additional IFDs for each resolution are not expected; any IFDs that do not represent a JPEG-2000 stream with multiple decompression
+levels will be ignored.

--- a/docs/sphinx/omero-pyramid/index.rst
+++ b/docs/sphinx/omero-pyramid/index.rst
@@ -1,5 +1,8 @@
-Internal OMERO pyramid format v1.0.0
-====================================
+The OMERO pyramid format
+========================
+
+v1.0.0
+------
 
 For files that contain very large images and are not in a format that supports pyramids, OMERO will generate its own
 image pyramid to improve visualization performance.  Bio-Formats can read these generated pyramids, but cannot


### PR DESCRIPTION
See https://trello.com/c/XGsjTdcc/5-omero-pyramid-specification

```docs/sphinx/omero-pyramid/index.rst``` should be effectively the same as https://github.com/openmicroscopy/bioformats/blob/develop/docs/sphinx/developers/wsi.rst#internal-omero-pyramid-format-v100 - the only difference is the ```bf_doc``` links.