### PR TITLE
Fix & update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Links
 - [Documentation](https://docs.openmicroscopy.org/latest/ome-model/)
 - [C++ API reference](http://www.openmicroscopy.org/site/support/ome-files-cpp/ome-xml/api/html/namespaces.html)
 - [Java API reference](http://javadoc.io/doc/org.openmicroscopy/ome-xml/)
-- [OME-TIFF sample images](http://downloads.openmicroscopy.org/images/OME-TIFF/)
-- [OME-XML sample images](http://downloads.openmicroscopy.org/images/OME-XML/)
+- [OME-TIFF sample images](https://downloads.openmicroscopy.org/images/OME-TIFF/)
+- [OME-XML sample images](https://downloads.openmicroscopy.org/images/OME-XML/)
 
 More information
 ----------------
@@ -30,7 +30,7 @@ following before submitting a pull request:
  * verify that the branch compiles using Maven
  * verify that the branch does not use syntax or API specific to Java 1.8+
  * internal developers only: [run the data
-   tests](http://www.openmicroscopy.org/site/support/bio-formats/developers/commit-testing.html)
+   tests](https://docs.openmicroscopy.org/latest/bio-formats/developers/commit-testing.html)
    against directories corresponding to the affected format(s)
  * make sure that your commits contain the correct authorship information and,
    if necessary, a signed-off-by line

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -124,7 +124,6 @@ jenkins_view_root = jenkins_root + '/view'
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
 trac_root = 'https://trac.openmicroscopy.org/ome'
 oo_root = 'https://www.openmicroscopy.org'
-oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
 downloads_root = 'https://downloads.openmicroscopy.org'
 help_root = 'http://help.openmicroscopy.org'
@@ -191,7 +190,7 @@ rst_epilog = """
 .. _Jenkins: http://jenkins-ci.org
 .. _roadmap: https://trac.openmicroscopy.org/ome/roadmap
 .. _OME artifactory: http://artifacts.openmicroscopy.org
-.. _Open Microscopy Environment: http://www.openmicroscopy.org/site
+.. _Open Microscopy Environment: https://www.openmicroscopy.org/
 .. _Glencoe Software, Inc.: http://www.glencoesoftware.com/
 .. _Pillow: http://pillow.readthedocs.org
 .. _Matplotlib: http://matplotlib.org/

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -153,8 +153,7 @@ extlinks = {
     'ome-files' : (oo_root + '/ome-files/%s', ''), 
     'partners' : (oo_root + '/commercial-partners/%s', ''),
     'schema' : (oo_root + '/Schemas/%s', ''),
-    # Old plone links still to be copied to new site
-    'about_plone' : (oo_site_root + '/about/%s', ''),
+    'citing' : (oo_root + '/citing-ome/%s', ''),
     # Help links
     'help' : (help_root + '/%s', ''),
     # Miscellaneous links
@@ -178,8 +177,8 @@ extlinks = {
     'bf_doc' : (docs_root + '/latest/bio-formats/%s', ''),
     'schema_doc' : (oo_root + '/Schemas/Documentation/Generated/OME-' + model_version + '/%s', ''),
     # Downloads
-    'bf_downloads' : (downloads_root + '/latest/bio-formats/%s', ''),
-    'cpp_downloads' : (downloads_root + '/latest/ome-files-cpp/%s', ''),
+    'bf_downloads' : (oo_root + '/bio-formats/downloads/%s', ''),
+    'cpp_downloads' : (oo_root + '/ome-files/downloads/%s', ''),
     'image_downloads' : (downloads_root + '/images/%s', ''),
     'ometiff_downloads' : (downloads_root + '/images/OME-TIFF/' + model_version + '/%s', ''),
     'omexml_downloads' : (downloads_root + '/images/OME-XML/' + model_version + '/%s', ''),

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -123,12 +123,12 @@ jenkins_view_root = jenkins_root + '/view'
 # Variables used to define other extlinks
 cvs_root = 'http://cvs.openmicroscopy.org.uk'
 trac_root = 'https://trac.openmicroscopy.org/ome'
-oo_root = 'http://www.openmicroscopy.org'
+oo_root = 'https://www.openmicroscopy.org'
 oo_site_root = oo_root + '/site'
 lists_root = 'http://lists.openmicroscopy.org.uk'
-downloads_root = 'http://downloads.openmicroscopy.org'
+downloads_root = 'https://downloads.openmicroscopy.org'
 help_root = 'http://help.openmicroscopy.org'
-docs_root = 'http://docs.openmicroscopy.org'
+docs_root = 'https://docs.openmicroscopy.org'
 
 # Edit on GitHub prefix
 edit_on_github_prefix = 'docs/sphinx'

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -35,8 +35,7 @@ with OME-XML and OME-TIFF:
 
 
 If you have used OME-XML, OME-TIFF, Bio-Formats or OMERO in your work please
-use the :about_plone:`correct citations <licensing-attribution/citing-ome>` to
-acknowledge us.
+use the :citing:`correct citations <>` to acknowledge us.
 
 We have received support from several companies who use our file formats, for
 details see our list of :partners:`Partners <>`.

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -15,7 +15,7 @@ OME-TIFF is a multi-plane tiff file that contains OME metadata in the header,
 in the form of OME-XML. This allows the pixels to be read with any
 TIFF-compatible program, and the metadata to be extracted with any OME-aware
 application. Our `paper describing the design and implementation of the OME-XML file 
-<http://genomebiology.biomedcentral.com/articles/10.1186/gb-2005-6-5-r47>`_
+<https://genomebiology.biomedcentral.com/articles/10.1186/gb-2005-6-5-r47>`_
 appeared in Genome Biology.
 
 The OME consortium currently provides three major tools capable of working

--- a/docs/sphinx/ome-tiff/code.rst
+++ b/docs/sphinx/ome-tiff/code.rst
@@ -65,7 +65,7 @@ with:
 
 .. seealso::
 
-    `BigTIFF file format specification <http://www.awaresystems.be/imaging/tiff/bigtiff.html>`__
+    `BigTIFF file format specification <https://www.awaresystems.be/imaging/tiff/bigtiff.html>`__
 
 Modifying a TIFF comment
 ------------------------

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -93,7 +93,7 @@ section of the OME Data Model, derived from the public
 
   -  * :ometiff_downloads:`00001_01.ome.tiff <MitoCheck/00001_01.ome.tiff>`
      * 1344 × 1024 × 1 × 1 × 93
-     * `IDR <http://idr-demo.openmicroscopy.org/webclient/?show=well-771034>`_
+     * `IDR <http://idr.openmicroscopy.org/webclient/?show=well-771034>`_
      * `Public Domain <https://creativecommons.org/publicdomain/mark/1.0/>`_
 
 See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-lapse microscopy reveals cell division genes. Nature 464(7289):721 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3108885/>`__.

--- a/docs/sphinx/ome-tiff/index.rst
+++ b/docs/sphinx/ome-tiff/index.rst
@@ -30,7 +30,7 @@ Support
 OME-TIFF is supported by:
 
 * `Accelrys Inc. <http://accelrys.com/>`_
-* `GE Healthcare Life Sciences (formerly Applied Precision) <http://www.gelifesciences.com/webapp/wcs/stores/servlet/catalog/en/GELifeSciences-UK/brands/deltavision/>`_
+* `GE Healthcare Life Sciences (formerly Applied Precision) <http://www.gelifesciences.com/webapp/wcs/stores/servlet/catalog/en/GELifeSciences/brands/deltavision/>`_
 * `Bitplane AG <http://www.bitplane.com/>`_
 * `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
 * `Definiens <http://www.definiens.com>`_
@@ -38,7 +38,7 @@ OME-TIFF is supported by:
 * `iMagic <http://www.imagic.ch/index.php?id=15&L=2/>`_
 * `Intelligent Imaging Innovations, Inc. <https://www.intelligent-imaging.com>`_
 * `Leica Inc. <http://www.leica-microsystems.com/>`_
-* `Mayachitra Inc. <http://www.mayachitra.com/>`_
+* `Mayachitra Inc. <http://mayachitra.com/>`_
 * `Micro-Manager <https://micro-manager.org/wiki/>`_
 * `Molecular Devices Inc. <https://www.moleculardevices.com>`_
 * `PerkinElmer <http://www.perkinelmer.com/>`_

--- a/docs/sphinx/ome-tiff/index.rst
+++ b/docs/sphinx/ome-tiff/index.rst
@@ -34,7 +34,7 @@ OME-TIFF is supported by:
 * `Bitplane AG <http://www.bitplane.com/>`_
 * `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
 * `Definiens <http://www.definiens.com>`_
-* `DRVision Technologies LLC <http://www.svisionllc.com/>`_
+* `DRVision Technologies LLC <https://www.drvtechnologies.com>`_
 * `iMagic <http://www.imagic.ch/index.php?id=15&L=2/>`_
 * `Intelligent Imaging Innovations, Inc. <https://www.intelligent-imaging.com>`_
 * `Leica Inc. <http://www.leica-microsystems.com/>`_

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -100,8 +100,8 @@ preface it with the following informative comment:
     <!-- Warning: this comment is an OME-XML metadata block, which contains
     crucial dimensional parameters and other important metadata. Please edit
     cautiously (if at all), and back up the original data before doing so.
-    For more information, see the OME-TIFF web site:
-    http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/ -->
+    For more information, see the OME-TIFF documentation:
+    https://docs.openmicroscopy.org/latest/ome-model/ome-tiff/ -->
 
 .. _tiffdata:
 

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -10,7 +10,7 @@ An OME-TIFF dataset consists of:
 
 - one or more files in standard TIFF format with the file extension
   ``.ome.tif`` or ``.ome.tiff`` or
-  `BigTIFF format <http://www.awaresystems.be/imaging/tiff/bigtiff.html>`_
+  `BigTIFF format <https://www.awaresystems.be/imaging/tiff/bigtiff.html>`_
   with one of these same file extensions or a BigTIFF-specific
   extension ``.ome.tf2``, ``.ome.tf8`` or ``.ome.btf``
 - a string of OME-XML metadata embedded in the ImageDescription tag of the
@@ -46,7 +46,7 @@ specification) shows the organization of a TIFF header along with the
 placement of the OME-XML metadata block.  Note this is for the TIFF
 standard specification only; the header structure is slightly
 different for BigTIFF; see the `BigTIFF file format specification
-<http://www.awaresystems.be/imaging/tiff/bigtiff.html>`__. A TIFF file can
+<https://www.awaresystems.be/imaging/tiff/bigtiff.html>`__. A TIFF file can
 contain any number of IFDs, with each one specifying an image plane along with
 certain accompanying metadata such as pixel dimensions, physical
 dimensions, bit depth, color table, etc. One of the fields an IFD can

--- a/docs/sphinx/ome-xml/index.rst
+++ b/docs/sphinx/ome-xml/index.rst
@@ -49,7 +49,7 @@ The OME-XML file serves as a convenient file format for data migration
 from one site or user to another. The OME-XML file captures all image
 acquisition and experimental metadata, along with the binary image data,
 and packages it into an easily readable package. The
-`paper <http://genomebiology.biomedcentral.com/articles/10.1186/gb-2005-6-5-r47>`_
+`paper <https://genomebiology.biomedcentral.com/articles/10.1186/gb-2005-6-5-r47>`_
 describing the design and implementation of the OME-XML file appeared in
 Genome Biology.
 

--- a/docs/sphinx/ome-xml/java-library.rst
+++ b/docs/sphinx/ome-xml/java-library.rst
@@ -12,7 +12,7 @@ Download
 
 **ome-xml.jar** is included in **bioformats_package.jar** available to
 download from the :bf_downloads:`Bio-Formats download page <>`. Alternatively,
-the individual artifact **ome-xml.jar** is hosted at `Maven Central <http://search.maven.org/`_ under the group ``org.openmicroscopy``. The
+the individual artifact **ome-xml.jar** is hosted at `Maven Central <http://search.maven.org/>`_ under the group ``org.openmicroscopy``. The
 license is `LGPL <http://www.gnu.org/licenses/lgpl.html>`_.
 
 Installation

--- a/docs/sphinx/ome-xml/java-library.rst
+++ b/docs/sphinx/ome-xml/java-library.rst
@@ -10,8 +10,9 @@ metadata processing facilities form the backbone of the
 Download
 --------
 
-You can download **ome-xml.jar** from the 
-:bf_downloads:`Bio-Formats downloads <>` page. The
+**ome-xml.jar** is included in **bioformats_package.jar** available to
+download from the :bf_downloads:`Bio-Formats download page <>`. Alternatively,
+you can download **ome-xml.jar** as a single jar from `Maven <http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.openmicroscopy%22%20AND%20a%3A%22ome-xml%22>`_. The
 license is `LGPL <http://www.gnu.org/licenses/lgpl.html>`_.
 
 Installation

--- a/docs/sphinx/ome-xml/java-library.rst
+++ b/docs/sphinx/ome-xml/java-library.rst
@@ -12,7 +12,7 @@ Download
 
 **ome-xml.jar** is included in **bioformats_package.jar** available to
 download from the :bf_downloads:`Bio-Formats download page <>`. Alternatively,
-you can download **ome-xml.jar** as a single jar from `Maven <http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.openmicroscopy%22%20AND%20a%3A%22ome-xml%22>`_. The
+the individual artifact **ome-xml.jar** is hosted at `Maven Central <http://search.maven.org/`_ under the group ``org.openmicroscopy``. The
 license is `LGPL <http://www.gnu.org/licenses/lgpl.html>`_.
 
 Installation

--- a/docs/sphinx/pom.xml
+++ b/docs/sphinx/pom.xml
@@ -20,7 +20,7 @@
 
   <name>OME Model documentation</name>
   <description>Documentation for the OME imaging metadata model specification and implementation.</description>
-  <url>http://www.openmicroscopy.org/site/support/ome-model/ome-xml/java-library.html</url>
+  <url>https://docs.openmicroscopy.org/latest/ome-model/</url>
   <inceptionYear>2006</inceptionYear>
 
   <licenses>


### PR DESCRIPTION
The old http://www.svisionllc.com/ link isn't resolving to anything but https://www.drvtechnologies.com looks to be the right company (google has cached results to link them together as well as the name being right).

Also fixed the remaining plone link that is now migrated to the new website and updated the downloads links for BF & OME Files to just use the new pages on the website as they only need to link to the latest version anyway, and readme links to use https for downloads, website and docs.