### PR TITLE
Remove sphinx-ignore-links & cleanup conf.py

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -350,38 +350,3 @@ if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = []
-try:
-    if sys.version_info[0] >= 3:
-        from urllib.request import urlopen
-    else:
-        from urllib import urlopen
-    brokenfiles_url = 'https://raw.github.com/openmicroscopy/sphinx-ignore-links/master/broken_links.txt'
-    brokenlinks = urlopen(brokenfiles_url)
-    linkcheck_ignore.extend(brokenlinks.read().splitlines())
-except IOError:
-    print("Could not open list of broken links.")
-
-# -- Custom roles for the OMERO documentation -----------------------------------------------
-
-from docutils import nodes
-from sphinx import addnodes
-
-def omero_command_role(typ, rawtext, etext, lineno, inliner,
-                     options={}, content=[]):
-    """Role for CLI commands that generates an index entry."""
-
-    env = inliner.document.settings.env
-    targetid = 'cmd-%s' % env.new_serialno('index')
-
-    # Create index and target nodes
-    indexnode = addnodes.index()
-    targetnode = nodes.target('', '', ids=[targetid])
-    inliner.document.note_explicit_target(targetnode)
-    indexnode['entries'] = [('single', "omero " + "; ".join(etext.split(" ")), targetid, '')]
-
-    # Mark the text using literal node
-    sn = nodes.literal('omero ' + etext, 'omero ' +  etext)
-    return [indexnode, targetnode, sn], []
-
-def setup(app):
-    app.add_role('omerocmd', omero_command_role)


### PR DESCRIPTION
Re: https://github.com/openmicroscopy/sphinx-ignore-links/issues/1
This removes use of the separate repo for listing links to be ignored (in future any links needing listed can be added to this file instead), also cleaned up omero role stuff which had been migrated to this repo and isn't used.