### PR TITLE
Fix GE Healthcare Life Sciences link

### DIFF
--- a/docs/sphinx/ome-tiff/index.rst
+++ b/docs/sphinx/ome-tiff/index.rst
@@ -30,7 +30,7 @@ Support
 OME-TIFF is supported by:
 
 * `Accelrys Inc. <http://accelrys.com/>`_
-* `GE Healthcare Life Sciences (formerly Applied Precision) <http://www.gelifesciences.com/webapp/wcs/stores/servlet/catalog/en/GELifeSciences/brands/deltavision/>`_
+* `GE Healthcare Life Sciences (formerly Applied Precision) <https://www.gelifesciences.com>`_
 * `Bitplane AG <http://www.bitplane.com/>`_
 * `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
 * `Definiens <http://www.definiens.com>`_


### PR DESCRIPTION
This link was breaking the build this morning - see https://ci.openmicroscopy.org/view/Failing/job/MODEL-merge-docs/312/console and their website has a banner saying they are upgrading it so I've gone for just linking to the main page for now - there's no nice Deltavision landing page at the moment and I don't want to use a URL that then gets broken again as they upgrade.