### PR TITLE
Remove leica-microsystems.com from ignore list

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -347,4 +347,4 @@ if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
     linkcheck_timeout = 30
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = []
+linkcheck_ignore = ["https://micro-manager.org/wiki/"]

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -347,4 +347,4 @@ if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
     linkcheck_timeout = 30
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = ["https://www.leica-microsystems.com"]
+linkcheck_ignore = []

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -347,4 +347,4 @@ if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
     linkcheck_timeout = 30
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = ["https://micro-manager.org/wiki/"]
+linkcheck_ignore = []


### PR DESCRIPTION
@sbesson notes on #63 that this URL seems to be working again now so this PR removes it from the ignore list. 