### PR TITLE
build: Unify component version property names

### DIFF
--- a/ome-xml/pom.xml
+++ b/ome-xml/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.openmicroscopy</groupId>
       <artifactId>ome-common</artifactId>
-      <version>${ome_common.version}</version>
+      <version>${ome-common.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <logback.version>1.1.1</logback.version>
     <slf4j.version>1.7.6</slf4j.version>
     <testng.version>6.8</testng.version>
-    <ome_common.version>5.3.1</ome_common.version>
+    <ome-common.version>5.3.1</ome-common.version>
 
     <ome.model.schemaver>2016-06</ome.model.schemaver>
     <ome.model.schemapath>specification/src/main/resources/released-schema/${ome.model.schemaver}</ome.model.schemapath>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,8 @@
     <logback.version>1.1.1</logback.version>
     <slf4j.version>1.7.6</slf4j.version>
     <testng.version>6.8</testng.version>
-    <ome-common.version>5.3.1</ome-common.version>
+    <ome_common.version>5.3.1</ome_common.version> <!-- For backward compatibility only -->
+    <ome-common.version>${ome_common.version}</ome-common.version>
 
     <ome.model.schemaver>2016-06</ome.model.schemaver>
     <ome.model.schemapath>specification/src/main/resources/released-schema/${ome.model.schemaver}</ome.model.schemapath>


### PR DESCRIPTION
This is to allow `-Dome-common.version=...` or rewriting the configuration to work the same for all components.  This one was different for some reason.

Testing: check builds are green.