### PR TITLE
Update dodgy link in OME-TIFF docs

### DIFF
--- a/docs/sphinx/ome-tiff/index.rst
+++ b/docs/sphinx/ome-tiff/index.rst
@@ -35,7 +35,7 @@ OME-TIFF is supported by:
 * `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
 * `Definiens <http://www.definiens.com>`_
 * `DRVision Technologies LLC <https://www.drvtechnologies.com>`_
-* `iMagic <http://www.imagic.ch/en>`_
+* `iMagic <https://www.imagic.ch/en>`_
 * `Intelligent Imaging Innovations, Inc. <https://www.intelligent-imaging.com>`_
 * `Leica Inc. <https://www.leica-microsystems.com/>`_
 * `Mayachitra Inc. <http://mayachitra.com/>`_

--- a/docs/sphinx/ome-tiff/index.rst
+++ b/docs/sphinx/ome-tiff/index.rst
@@ -35,7 +35,7 @@ OME-TIFF is supported by:
 * `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
 * `Definiens <http://www.definiens.com>`_
 * `DRVision Technologies LLC <https://www.drvtechnologies.com>`_
-* `iMagic <http://www.imagic.ch/index.php?id=15&L=2/>`_
+* `iMagic <http://www.imagic.ch/en>`_
 * `Intelligent Imaging Innovations, Inc. <https://www.intelligent-imaging.com>`_
 * `Leica Inc. <https://www.leica-microsystems.com/>`_
 * `Mayachitra Inc. <http://mayachitra.com/>`_


### PR DESCRIPTION
This link upset the build this morning and when I checked it, although it was working, it was pointing at content in German so thought I might as well update it.