### PR TITLE
AffineTransform: Add createRotationTransform static method

### DIFF
--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -55,6 +55,10 @@
 
 #include <ome/common/log.h>
 
+{% if klass.name == "AffineTransform" %}\
+#include <ome/common/units/angle.h>
+
+{% end class is AffineTransform %}\
 #include <ome/common/xml/dom/Document.h>
 #include <ome/common/xml/dom/Element.h>
 #include <ome/common/xml/dom/Node.h>
@@ -66,6 +70,9 @@
 {% end for%}\
 {% end header%}\
 {% if fu.SOURCE_TYPE == "source" %}\
+{% if klass.name == "AffineTransform" %}\
+#include <cmath>
+{% end class is AffineTransform %}\
 #include <sstream>
 
 {% if klass.hasPrimitiveBase %}\
@@ -268,6 +275,30 @@ namespace ome
       }
 
 {% end source %}\
+{% if klass.name == "AffineTransform" %}\
+{% if fu.SOURCE_TYPE == "header" %}\
+        /**
+         * Construct an AffineTransform corresponding to
+         * the given angle.
+         *
+         * @param theta the angle of rotation in radians
+         */
+        AffineTransform(ome::common::units::radian_quantity theta);
+{% end header %}\
+{% if fu.SOURCE_TYPE == "source" %}\
+      AffineTransform::AffineTransform(ome::common::units::radian_quantity theta)
+      {
+        double v = ome::common::units::quantity_cast<double>(theta);
+        setA02(0.0);
+        setA12(0.0);
+        setA00(cos(v));
+        setA11(cos(v));
+        setA01(sin(v));
+        setA10(-1.0 * sin(v));
+      }
+
+{% end source %}\
+{% end class is AffineTransform %}\
 {% if fu.SOURCE_TYPE == "header" %}\
         /**
          * Copy constructor.

--- a/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -139,6 +139,25 @@ public class ${klass.name} extends ${klass.parentName}
 {% end class is AffineTransform %}\
   }
 
+{% if klass.name == "AffineTransform" %}\
+  /**
+   * Construct an AffineTransform corresponding to
+   * the given angle.
+   * @param theta the angle of rotation in radians
+   */
+  public static AffineTransform createRotationTransform(double theta) {
+    AffineTransform transform = new AffineTransform();
+    transform.setA02(0.0);
+    transform.setA12(0.0);
+    transform.setA00(Math.cos(theta));
+    transform.setA11(Math.cos(theta));
+    transform.setA01(Math.sin(theta));
+    transform.setA10(-1 * Math.sin(theta));
+    return transform;
+  }
+{% end class is AffineTransform %}\
+
+
   /**
    * Constructs ${klass.name} recursively from an XML DOM tree.
    * @param element Root of the XML DOM tree to construct a model object


### PR DESCRIPTION
Move `[SubResolution]FormatReader.getRotationTransform` to the `AffineTransform` class itself.  Use a static method for Java, and a regular constructor for C++ (where it can be specialised on a radian unit).

Testing: Check builds remain green for both Java and C++.

This will permit dropping of this implementation from `FormatReader` once released, and complete removal from `SubResolutionFormatReader`.