### PR TITLE
Link fixes

### DIFF
--- a/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
+++ b/ome-xml/src/main/cpp/ome/xml/model/detail/OMEModelObject.cpp
@@ -38,6 +38,7 @@
 
 #include <ome/common/xml/String.h>
 
+#include <ome/xml/model/Reference.h>
 #include <ome/xml/model/detail/OMEModelObject.h>
 
 namespace ome
@@ -104,9 +105,14 @@ namespace ome
         }
 
         bool
-        OMEModelObject::link (std::shared_ptr<Reference>&                         /* reference */,
-                              std::shared_ptr<::ome::xml::model::OMEModelObject>& /* object */)
+        OMEModelObject::link (std::shared_ptr<Reference>&                         reference,
+                              std::shared_ptr<::ome::xml::model::OMEModelObject>& object)
         {
+          BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+            << elementName()
+            << " unable to handle reference of type "
+            << reference->elementName()
+            << " for " << object->elementName();
           return false;
         }
 

--- a/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
+++ b/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
@@ -44,11 +44,18 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * @author callan
  *
  */
 public abstract class AbstractOMEModelObject implements OMEModelObject {
+
+  /** Logger for this class. */
+  protected static final Logger LOGGER =
+    LoggerFactory.getLogger(AbstractOMEModelObject.class);
 
   /* (non-Javadoc)
    * @see ome.xml.r201004.OMEModelObject#update(org.w3c.dom.Element, ome.xml.r201004.OMEModel)
@@ -82,6 +89,8 @@ public abstract class AbstractOMEModelObject implements OMEModelObject {
    */
   @Override
   public boolean link(Reference reference, OMEModelObject o) {
+    LOGGER.debug("{} unable to handle reference of type {} for {}",
+                 getClass(), reference.getClass(), o.getClass());
     return false;
   }
 

--- a/xsd-fu/templates-cpp/OMEXMLMetadata.template
+++ b/xsd-fu/templates-cpp/OMEXMLMetadata.template
@@ -197,10 +197,9 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% choose %}\
 {% when is_abstract(parent) and prop.isReference %}\
         // ${prop.name} is abstract and is a reference
-        std::shared_ptr<${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared<${prop.instanceTypeNS}>());
-        ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
+        std::shared_ptr<ome::xml::model::Reference> ref(std::static_pointer_cast<ome::xml::model::reference>(std::make_shared<${prop.instanceTypeNS}>()));
+        ref->setID(${prop.argumentName});
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> o_base(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex)[:-1], setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
-        std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(o_base, ref);
         // ${parent} is abstract
@@ -269,10 +268,9 @@ OMEXMLMetadata::${getPropMethod(is_multi_path[o.name], parent, obj.name, prop)}(
 {% end %}\
 {% when prop.isReference %}\
         // ${prop.name} is reference and occurs more than once
-        std::shared_ptr<${prop.instanceTypeNS}> ${prop.instanceVariableName}_reference(std::make_shared<${prop.instanceTypeNS}>());
-        ${prop.instanceVariableName}_reference->setID(${prop.argumentName});
+        std::shared_ptr<ome::xml::model::Reference> ref(std::static_pointer_cast<ome::xml::model::Reference>(std::make_shared<${prop.instanceTypeNS}>()));
+        ref->setID(${prop.argumentName});
         std::shared_ptr<::${lang.omexml_model_package}::OMEModelObject> modelObject(std::static_pointer_cast<::${lang.omexml_model_package}::OMEModelObject>(${safe_accessor([{'accessor':'root'}]+accessor(obj.name, parent, prop, func=accessor_string_complex), setPropMethod(is_multi_path[o.name], parent, obj.name, prop))}));
-        std::shared_ptr<::${lang.omexml_model_package}::Reference> ref(std::static_pointer_cast<::${lang.omexml_model_package}::Reference>(${prop.instanceVariableName}_reference));
 
         model->addReference(modelObject, ref);
 {% end %}\

--- a/xsd-fu/templates-cpp/OMEXMLModelObject.template
+++ b/xsd-fu/templates-cpp/OMEXMLModelObject.template
@@ -82,6 +82,7 @@
 
 #include <ome/xml/Document.h>
 #include <ome/xml/model/ModelException.h>
+#include <ome/xml/model/Reference.h>
 #include <ome/xml/model/detail/Parse.h>
 
 #include <boost/format.hpp>
@@ -727,10 +728,6 @@ ${customUpdatePropertyContent[prop.name]}
       ${klass.name}::link (std::shared_ptr<Reference>& reference,
                            std::shared_ptr<${lang.omexml_model_package}::OMEModelObject>& object)
       {
-        if (${klass.parentName}::link(reference, object))
-          {
-            return true;
-          }
 {% for prop in klass.properties.values() %}\
 {% if prop.isReference %}\
         if (std::dynamic_pointer_cast<${prop.name}>(reference))
@@ -771,10 +768,7 @@ ${customUpdatePropertyContent[prop.name]}
           }
 {% end %}\
 {% end %}\
-        BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
-          << "Unable to handle reference of type: "
-          << typeid(reference).name();
-        return false;
+        return ${klass.parentName}::link(reference, object);
       }
 {% end source %}\
 {% if klass.langBaseType is not None %}\

--- a/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -465,11 +465,6 @@ ${customUpdatePropertyContent[prop.name]}
 
   public boolean link(Reference reference, OMEModelObject o)
   {
-    boolean wasHandledBySuperClass = super.link(reference, o);
-    if (wasHandledBySuperClass)
-    {
-      return true;
-    }
 {% for prop in klass.properties.values() %}\
 {% if prop.isReference %}\
     if (reference instanceof ${prop.name})
@@ -493,8 +488,7 @@ ${customUpdatePropertyContent[prop.name]}
     }
 {% end %}\
 {% end %}\
-    LOGGER.debug("Unable to handle reference of type: {}", reference.getClass());
-    return false;
+    return super.link(reference, o);
   }
 {% if klass.langBaseType != 'Object' %}\
   // Element's text data getter


### PR DESCRIPTION
Closes: https://github.com/ome/ome-files-cpp/issues/98

This corrects some long-standing issues in both the C++ and Java reference processing implementations.

- `OMEModelObject::link` implementations always chained up to their parent before handling the linking themselves.  This works, but would result in the parent issuing a warning if it couldn't handle it, despite the child later handling the link.  We now chain up only if the child can't handle the link, and issue a warning right at the top if nothing handled it.  This solves a number of annoying Java model serialisation warnings which are completely bogus.  The same applies for C++.
- C++ `OMEXMLMetadataStore` `addReference` calls in `setXXXAnnotationRef` methods updated to match the Java templates more closely.  There are no functional changes.  A shared pointer copy is replaced by a cast.

In effect, you will see that setting an `AnnotationRef` on `Detector` or any other element derived from `ManufacturerSpec` will no longer have `ManufacturerSpec::link` issue a bogus warning.  The ome-files-cpp `metadata-formatwriter` example will no longer issue spurious warnings.  This applies to any model object which is derived from another model object, e.g. LightSource, where the reference is handled by the most derived type, or any derived type after the first, where the chaining up will trigger the spurious warning.

For OMERO import, this should remove a large number of the bogus import warnings related to OME-XML metadata which we have seen on e.g. the QA system and other channels over the last few years.  `LightSource` and `Shape` are notable culprits.

Testing:

- Check the C++ build logs; they will no longer contain `[warning] Unable to handle reference of type` messages for any of the unit tests.
- Run `ome-files` `examples/metadatastore-formatwriter test.ome.tiff` and then `tiffinfo` or `tiffcomment` on `test.ome.tiff`.  Check that you get three `AnnotationRef` elements linking to the three annotations, demonstrating that the reference processing and subsequent serialisation worked correctly.
- Run `ome-files info test.ome.tiff --omexml` to check this round-trips.
- Check Java with a similar sample for `metadata-formatwriter`, creating an `AnnotationRef` on `Detector` or similar.  You'll see the warnings go when built against this ome-model snapshot, but otherwise no other functional changes.

/cc @joshmoore 