### PR TITLE
ome-xml: Javadoc fixes

### DIFF
--- a/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
@@ -57,7 +57,7 @@ import ome.units.UNITS;
  * <p>This technique allows conversion between two different storage media.
  * For example, it can be used to convert an <code>OMEROMetadataStore</code>
  * (OMERO's metadata store implementation) into an
- * {@link ome.xml.OMEXMLMetadata}, thus generating OME-XML from
+ * {@link ome.xml.meta.OMEXMLMetadataImpl}, thus generating OME-XML from
  * information in an OMERO database.
  *
  * @author Curtis Rueden ctrueden at wisc.edu

--- a/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
+++ b/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
@@ -69,7 +69,7 @@ public abstract class AbstractOMEModelObject implements OMEModelObject {
    * Takes the entire object hierarchy and produced an XML DOM tree taking
    * into account class hierarchy.
    * @param document Destination document for element creation, etc.
-   * @param element Element from the subclass. If </code>null</code> a new
+   * @param element Element from the subclass. If <code>null</code> a new
    * element will be created of this class.
    * @return <code>element</code> populated with properties from this class.
    */

--- a/specification/src/main/java/ome/specification/XMLMockObjects.java
+++ b/specification/src/main/java/ome/specification/XMLMockObjects.java
@@ -139,7 +139,7 @@ import ome.units.quantity.Time;
  * @author Jean-Marie Burel &nbsp;&nbsp;&nbsp;&nbsp;
  * <a href="mailto:j.burel@dundee.ac.uk">j.burel@dundee.ac.uk</a>
  * @author Chris Allan &nbsp;&nbsp;&nbsp;&nbsp;
- * Chris Allan <callan at blackcat dot ca>
+ * Chris Allan callan at blackcat dot ca
  * @version 3.0
  * <small>
  * (<b>Internal version:</b> $Revision: $Date: $)

--- a/xsd-fu/templates-java/MetadataStore.template
+++ b/xsd-fu/templates-java/MetadataStore.template
@@ -159,7 +159,7 @@ import ${lang.units_package}.unit.Unit;
  * <code>imageIndex</code>, an inner loop should iterate across
  * <code>pixelsIndex</code>, and an innermost loop should handle
  * <code>planeIndex</code>. For an illustration of the ideal traversal order,
- * see {@link loci.formats.meta.MetadataConverter#convertMetadata}.</p>
+ * see {@link ome.xml.meta.MetadataConverter#convertMetadata}.</p>
  *
  * @author Chris Allan callan at blackcat.ca
  * @author Curtis Rueden ctrueden at wisc.edu


### PR DESCRIPTION
Four javadoc fixes.  Two are broken internal links.  Two are invalid markup (`<` and `>` in an email address interpreted as invalid XML, and a `</>` in an opening tag).

Testing: Check builds are green.