### PR TITLE
ignore null references rather than noting them for resolution

### DIFF
--- a/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
@@ -99,6 +99,9 @@ public class OMEModelImpl implements OMEModel {
    */
   @Override
   public boolean addReference(OMEModelObject a, Reference b) {
+    if (b != null && b.getID() == null) {
+      return false;
+    }
     List<Reference> bList = references.get(a);
     if (bList == null) {
       bList = new ArrayList<Reference>();


### PR DESCRIPTION
`convertMetadata` seems to copy `null` property values then when resolving references we get lots of,

> ... reference to null missing from object hierarchy.

For instance, see https://www.openmicroscopy.org/qa2/qa/feedback/21779/ or a server log from [OMERO-DEV-merge-integration](https://ci.openmicroscopy.org/job/OMERO-DEV-merge-integration/).

I suspect that these null referents are valueless and should be ignored in the first place so this PR adjusts `addReference` accordingly. If we really want to track them then perhaps we could instead adjust `resolveReferences()` to not WARN about them or change `MetadataConverter` to not set them.

I do not see where the return value of `addReference` is documented so I guessed.

Really it looks as if `references` should be a [SetMultimap](https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/collect/SetMultimap.html) but that is outwith this PR.