### PR TITLE
Remove DatatypeConverter usage for JDK 11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ cache:
 jdk:
   - oraclejdk11
   - oraclejdk8
-  - openjdk7
 
 matrix:
   fast_finish: true

--- a/xsd-fu/templates-java/OMEXMLModelObject.template
+++ b/xsd-fu/templates-java/OMEXMLModelObject.template
@@ -66,7 +66,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 {% if klass.hasPrimitiveBase %}\
 
-import javax.xml.bind.DatatypeConverter;
+import java.util.Base64;
 
 {% end %}\
 import ${lang.units_package}.quantity.Angle;
@@ -247,7 +247,7 @@ ${customUpdatePropertyContent[prop.name]}
     String value_textContent = element.getTextContent();
     if (value_textContent.trim().length() > 0) {
 {% if prop.type == 'base64Binary' %}\
-      byte[] rawBytes = DatatypeConverter.parseBase64Binary(value_textContent);
+      byte[] rawBytes = Base64.getDecoder().decode(value_textContent);
       set${prop.methodName}(rawBytes);
 {% end if prop.type %}\
 {% if not prop.type == 'base64Binary' %}\
@@ -707,7 +707,7 @@ ${customAsXMLElementPropertyContent[prop.name]}
       ${klass.name}_element.setTextContent(${prop.instanceVariableName}.toString());
 {% end if not prop.type %}\
 {% if prop.type == 'base64Binary' %}\
-      String encodedString = DatatypeConverter.printBase64Binary(${prop.instanceVariableName});
+      String encodedString = Base64.getEncoder().encodeToString(${prop.instanceVariableName});
       ${klass.name}_element.setTextContent(encodedString);
 {% end if prop.type %}\
 {% end when %}\


### PR DESCRIPTION
Replace DatatypeConverter usage in order to fix JDK 11 build.

* cF
  - https://docs.oracle.com/javase/8/docs/api/java/util/Base64.Encoder.html
  - https://github.com/http-kit/http-kit/issues/356#issuecomment-369982659
* Tested with Dockerfile:
```
FROM maven:3-jdk-11
MAINTAINER ome-devel@lists.openmicroscopy.org.uk

RUN useradd -m ome
COPY --chown=ome:ome . /opt/ome-model/

USER ome
WORKDIR /opt/ome-model
RUN mvn clean install
```

(needs sphinx added)