### PR TITLE
Add experimental OME-XML generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+.*un~
 .DS_Store
 target
 .idea
+
+# Python files
+*.pyc
+build
+dist
+ome_model.egg-info

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+# Generate companion files
+
+import os
+import re
+import sys
+import uuid
+import xml.etree.ElementTree as ET
+
+
+OME_ATTRIBUTES = {
+    'xmlns': 'http://www.openmicroscopy.org/Schemas/OME/2016-06',
+    'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+    'xmlns:OME': 'http://www.openmicroscopy.org/Schemas/OME/2016-06',
+    'xsi:schemaLocation': 'http://www.openmicroscopy.org/Schemas/OME/2016-06 \
+http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd',
+}
+
+TIFF_PARSER = "^.*?" # Ignore prefix
+TIFF_PARSER += "(?:[-_]+|"  # Skip separators
+TIFF_PARSER += "[Cc]_?(?P<channel>[^-_]+)|"  # Channel section
+TIFF_PARSER += "[TtHhRr]_?(?P<time>[^-_]+)|"  # "Time" section
+TIFF_PARSER += "[Zz]_?(?P<slice>[^-_]+)"  # Z-slices
+TIFF_PARSER += ")+"  # As many of those three as needed
+TIFF_PARSER += ".*?[.].*?" # Ignore the rest, but don't slurp the file ending
+TIFF_PARSER = re.compile(TIFF_PARSER)
+
+
+class Channel(object):
+
+    ID = 0
+
+    def __init__(self,
+        image,
+        name,
+        color,
+        samplesPerPixel=1,
+    ):
+        self.data = {
+            'ID': 'Channel:%s:%s' % (image, self.ID),
+            'Name': name,
+            'Color': str(color),
+            'SamplesPerPixel': str(samplesPerPixel),
+        }
+        self.ID += 1
+
+
+class Image(object):
+
+    ID = 0
+
+    def __init__(self,
+        name,
+        sizeX, sizeY, sizeZ, sizeC, sizeT,
+        tiffs,
+        order="XYZTC",
+        type="uint16",
+    ):
+        self.data = {
+            'Image': {'ID': 'Image:%s' % self.ID, 'Name': name},
+            'Pixels': {
+                'ID': 'Pixels:%s:%s' % (self.ID, self.ID),
+                'DimensionOrder': order,
+                'Type': type,
+                'SizeX': str(sizeX),
+                'SizeY': str(sizeY),
+                'SizeZ': str(sizeZ),
+                'SizeT': str(sizeT),
+                'SizeC': str(sizeC),
+            },
+            'Channels': [],
+            'TIFFData': tiffs,
+        }
+        Image.ID += 1
+
+    def add_channel(self, name, color, samplesPerPixel=1):
+        self.data["Channels"].append(
+            Channel(
+                self, name, color, samplesPerPixel
+            ))
+
+    def validate(self):
+        assert len(self.data["Channels"]) == int(self.data["Pixels"]["SizeC"]), \
+               str(self.data)
+        return self.data
+
+
+def parse_tiff(tiff):
+    """
+    Extracts (c, t, z) from a tiff filename.
+    """
+    m = TIFF_PARSER.match(tiff)
+    return (m.group("channel"), m.group("time"), m.group("slice"))
+
+
+def create_companion(images):
+    """
+    Create a companion OME-XML for a given experiment.
+    Assumes 2D TIFFs
+    """
+    root = ET.Element("OME", attrib=OME_ATTRIBUTES)
+    for img in images:
+        i = img.validate()
+        image = ET.SubElement(root, "Image", attrib=i["Image"])
+        pixels = ET.SubElement(image, "Pixels", attrib=i["Pixels"])
+        for channel in i["Channels"]:
+            c = channel.data  # TODO: validation?
+            ET.SubElement(pixels, "Channel", attrib=c)
+
+        tiffs = i["TIFFData"]
+        for tiff in tiffs:
+            c, t, z = parse_tiff(tiff)
+            tiffdata = ET.SubElement(pixels, "TiffData", attrib={
+                "FirstC": c,
+                "FirstT": t,
+                "FirstZ": z,
+                "PlaneCount": "1",
+                "IFD": '0'})
+            ET.SubElement(tiffdata, "UUID", attrib={
+                "FileName": tiff}).text = str(uuid.uuid4())
+
+    # https://stackoverflow.com/a/48671499/56887
+    xmlstr = ET.tostring(root).decode()
+    sys.stdout.write(xmlstr)
+
+
+def fake_image():
+    tiffs = [
+        "foo_c0_t0_z0.tiff",
+        "bar_t0_c1_z0.tiff",
+        "baz_z0_t0_c2.tiff",
+    ]
+    image = Image("test", 64, 64, 1, 3, 1, tiffs)
+    image.add_channel("red", 0)
+    image.add_channel("green", 0)
+    image.add_channel("blue", 0)
+    return image
+
+
+if __name__ == "__main__":
+    image = fake_image()
+    create_companion([image])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 University of Dundee.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+import os
+import sys
+
+from setuptools import setup
+
+
+version = '5.6.4.dev1'
+url = "https://github.com/ome/ome-model/"
+
+setup(
+    version=version,
+    packages=["ome_model"],
+    name='ome-model',
+    description="Core OME model library (EXPERIMENTAL)",
+    long_description="TBD",
+    classifiers=[
+          'Development Status :: 2 - Pre-Alpha',
+          'Intended Audience :: Developers',
+          'License :: OSI Approved :: GNU General Public License v2 '
+          'or later (GPLv2+)',
+          'Natural Language :: English',
+          'Operating System :: OS Independent',
+          'Programming Language :: Python :: 2',
+          'Topic :: Software Development :: Libraries :: Python Modules',
+      ],  # Get strings from
+          # http://pypi.python.org/pypi?%3Aaction=list_classifiers
+    author='The Open Microscopy Team',
+    author_email='ome-devel@lists.openmicroscopy.org.uk',
+    license='GPL-2.0+',
+    url='%s' % url,
+    zip_safe=False,
+    download_url='%s/v%s.tar.gz' % (url, version),
+    keywords=['OME', 'Model'],
+)


### PR DESCRIPTION
Combining work on/for:

 * https://github.com/IDR/idr0047-neuert-yeastmRNA/pull/1
 * https://github.com/spacetx/starfish/issues/603

this adds a simple Python interface (ome_model.experimental)
that will be deployed to PyPI for building OME-XML companion
files. Longer-term: these classes and methods should be code-
generated.