### PR TITLE
Have link checker ignore documentation links to Imagic.

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -349,4 +349,4 @@ if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
     linkcheck_retries = int(os.environ.get("SPHINX_LINKCHECK_RETRIES", 5))
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
-linkcheck_ignore = ["http://www.definiens.com"]
+linkcheck_ignore = ["http://www.definiens.com", "https://www.imagic.ch/"]


### PR DESCRIPTION
Imagic's HTTP redirects to HTTPS but their nginx configuration offers a certificate whose chain omits DigiCert's verification of their RapidSSL certificate: see [MODEL-merge-docs](https://ci.openmicroscopy.org/job/MODEL-merge-docs/).