### PR TITLE
Extend Travis configuration to test OpenJDK8 and OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: java
 
 sudo: false
@@ -5,10 +6,12 @@ sudo: false
 # http://docs.travis-ci.com/user/caching/#Arbitrary-directories
 cache:
   directories:
-  - $HOME/.m2
+    - $HOME/.m2
 
 jdk:
+  - openjdk11
   - oraclejdk11
+  - openjdk8
   - oraclejdk8
 
 matrix:


### PR DESCRIPTION
See https://github.com/ome/ome-common-java/pull/37 and https://github.com/openmicroscopy/bioformats/pull/3286#discussion_r240145628

Same testing procedure: Travis green is the only thing to check here