### PR TITLE
ome_model: add support for generating companion with multi-page TIFFs

### DIFF
--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -86,6 +86,7 @@ class Image(object):
     def __init__(self,
                  name,
                  sizeX, sizeY, sizeZ, sizeC, sizeT,
+                 tiffs=[],
                  order="XYZTC",
                  type="uint16",
                  ):
@@ -105,6 +106,8 @@ class Image(object):
             'TIFFs': [],
         }
         Image.ID += 1
+        for tiff in tiffs:
+            self.add_tiff(tiff)
 
     def add_channel(self, name, color, samplesPerPixel=1):
         self.data["Channels"].append(
@@ -242,12 +245,10 @@ def fake_image(basename="test", sizeX=64, sizeY=64, sizeZ=1, sizeC=3, sizeT=1):
     tiffs = ["%s_z%s_c%s_t%s.tiff" % (basename, z, c, t)
              for z in range(sizeZ) for c in range(sizeC)
              for t in range(sizeT)]
-    image = Image("test", sizeX, sizeY, sizeZ, sizeC, sizeT)
+    image = Image("test", sizeX, sizeY, sizeZ, sizeC, sizeT, tiffs)
     image.add_channel("red", 0)
     image.add_channel("green", 0)
     image.add_channel("blue", 0)
-    for tiff in tiffs:
-        image.add_tiff(tiff)
     return image
 
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -79,7 +79,6 @@ class TiffData(object):
             self.data["PlaneCount"] = str(planeCount)
 
 
-
 class Image(object):
 
     ID = 0
@@ -231,7 +230,7 @@ def create_companion(plates=[], images=[], out=None):
     # https://stackoverflow.com/a/48671499/56887
     kwargs = dict(encoding="UTF-8")
     if PYTHON >= 3:
-        kwargs["xml_declaration"]=True
+        kwargs["xml_declaration"] = True
         if not out:
             out = sys.stdout.buffer
     elif not out:

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -63,7 +63,7 @@ class TiffData(object):
                  firstC=0,
                  firstT=0,
                  firstZ=0,
-                 ifd=0,
+                 ifd=None,
                  planeCount=None,
                  uuid=None
                  ):
@@ -113,20 +113,20 @@ class Image(object):
                 self, name, color, samplesPerPixel
             ))
 
-    def add_tiffs(self, tiffs):
+    def add_tiff(self, filename, c=None, t=None, z=None, ifd=None,
+                 planeCount=None):
 
-        for tiff in tiffs:
-            uuid = UUID(tiff)
-            c, t, z = parse_tiff(tiff)
-            self.data["TIFFs"].append(
-                TiffData(
-                    firstC=c,
-                    firstT=t,
-                    firstZ=z,
-                    ifd=0,
-                    planeCount=1,
-                    uuid=uuid)
-            )
+        if c is None and t is None and z is None:
+            # If no mapping specified, assume single plane TIFF which name
+            # contain the z,c,t indices
+            c, t, z = parse_tiff(filename)
+        self.data["TIFFs"].append(TiffData(
+            firstC=c,
+            firstT=t,
+            firstZ=z,
+            ifd=ifd,
+            planeCount=planeCount,
+            uuid=UUID(filename)))
 
     def validate(self):
         assert (len(self.data["Channels"]) ==
@@ -245,7 +245,8 @@ def fake_image(basename="test", sizeX=64, sizeY=64, sizeZ=1, sizeC=3, sizeT=1):
     image.add_channel("red", 0)
     image.add_channel("green", 0)
     image.add_channel("blue", 0)
-    image.add_tiffs(tiffs)
+    for tiff in tiffs:
+        image.add_tiff(tiff)
     return image
 
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -230,10 +230,12 @@ def create_companion(plates=[], images=[], out=None):
 
     # https://stackoverflow.com/a/48671499/56887
     kwargs = dict(encoding="UTF-8")
-    out = sys.stdout
     if PYTHON >= 3:
         kwargs["xml_declaration"]=True
-        out = sys.stdout.buffer
+        if not out:
+            out = sys.stdout.buffer
+    elif not out:
+        out = sys.stdout
     ET.ElementTree(root).write(out, **kwargs)
 
 


### PR DESCRIPTION
Follow up of #92, this expands the logic of the experimental Python module to generate companion OME-XML files using from any set of TIFF files including multi-page TIFFs.

To do so, two new objects are defined to handle [TiffData](https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#TiffData) and [UUID](https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#TiffData_UUID) elements allowing notably to pass the `TiffData` attributes.

An example of consumption of this API will be opened in the context of the `idr0053` study. Proposing this as `6.0.0a3`. 