### PR TITLE
Pyramidal OME-TIFF specification addition

### DIFF
--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -501,7 +501,7 @@ using typical downsampling factors:
 Storage
 ^^^^^^^
 
-Full-resolution image planes must reamin stored as described above using a valid TIFF IFD and referenced from the OME-XML metadata using the
+Full-resolution image planes must remain stored as described above using a valid TIFF IFD and referenced from the OME-XML metadata using the
 :ref:`TiffData <tiffdata>` element.
 
 Each sub-resolution must be stored in a valid IFD of the same TIFF file as the full-resolution image plane. Additionally:
@@ -518,7 +518,7 @@ Each sub-resolution must be stored in a valid IFD of the same TIFF file as the f
 The planes of largest resolutions should be organized into tiles rather than
 strips as described in the TIFF_ specification and may be compressed using any
 of the officially supported schemes including LZW, JPEG, JPEG2000.
-Sub-resolution image planes may chose to use different compression algorithms
+Sub-resolution image planes may choose to use different compression algorithms
 than the one used by the full resolution plane. For example the full
 resolution image may use no compression or lossless compression while the
 sub-resolution images use lossy compression.

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -506,7 +506,8 @@ Storage
 Full-resolution image planes must remain stored as described above using a valid TIFF IFD and referenced from the OME-XML metadata using the
 :ref:`TiffData <tiffdata>` element.
 
-Each sub-resolution must be stored in a valid IFD of the same TIFF file as the full-resolution image plane. Additionally:
+Each sub-resolution must be stored in the same IFD as the full-resolution
+image plane. Additionally:
 
 - the offsets of all sub-resolutions IFDs must be referenced from the IFD of
   the full-resolution plane using the SubIFDs TIFF extension tag 330 as

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -1,4 +1,5 @@
 .. _TIFF: https://www.adobe.io/open/standards/TIFF.html
+.. _RFC 2119: https://www.ietf.org/rfc/rfc2119.txt
 
 OME-TIFF specification
 ======================
@@ -6,6 +7,8 @@ OME-TIFF specification
 The following provides technical details on the OME-TIFF
 format. It assumes familiarity with both the TIFF_ specification and
 the :schema:`OME Data Model <>`, although there is some review of both.
+
+The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, MAY, and OPTIONAL in this specification are to be interpreted as described in `RFC 2119`_.
 
 An OME-TIFF dataset consists of:
 

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -439,35 +439,37 @@ OME-XML companion file with the extension :file:`.companion.ome` or a master
 OME-TIFF file containing the full metadata (see :ref:`multifile_samples` for
 representative samples).
 
-Pyramidal OME-TIFF
-------------------
+Sub-resolutions
+---------------
 
 .. versionadded:: 6.0.0
 
-The OME-TIFF specification supports multi-resolution images or pyramidal
-images where individual planes are stored at different levels of resolution.
-The intermediate downsampled image planes are called pyramidal levels,
-sub-resolution image planes or sub-resolutions.
+OME-TIFF supports multi-resolution images or pyramidal images where individual
+planes are stored at different levels of resolution.
+The downsampled image planes are called pyramidal levels, sub-resolution image
+planes or sub-resolutions.
 
 Supported resolutions
 ^^^^^^^^^^^^^^^^^^^^^
 
-OME-TIFF planes can be reduced alongside the X and Y dimensions. Each pyramidal
+OME-TIFF planes can be reduced along the X and Y dimensions. Each pyramidal
 level must be a downsampling of the full-resolution plane in the X and Y
 dimensions and the resolution should stay unchanged in the other dimensions.
-The downsampling factor should be an integer value, identical alongside the X
-and the Y dimensions and stay the same between each consecutive pyramidal
-level.
+The downsampling factor:
 
-The following table below shows two examples of pyramidal level dimensions
+- should be an integer value,
+- should be identical along the X and the Y dimensions,
+- should stay the same between each consecutive pyramid level.
+
+The following table below shows two examples of pyramid level dimensions
 using typical downsampling factors:
 
 .. list-table::
   :header-rows: 1
 
   -  *
-     * Example 1
-     * Example 2
+     * Example 1 (X × Y × Z × C × T)
+     * Example 2 (X × Y × Z × C × T)
 
   -  * Downsampling factor
      * 3
@@ -475,27 +477,27 @@ using typical downsampling factors:
 
   -  * Level 0 (full-resolution)
      * 9234 × 6075 × 1 × 1 × 10
-     * 38912 × 25600 × 1 × 3 × 1
+     * 38912 × 25600 × 200 × 3 × 1
 
   -  * Level 1
      * 3078 × 2025 × 1 × 1 × 10
-     * 9728 × 6400 × 1 × 3 × 1
+     * 9728 × 6400 × 200 × 3 × 1
 
   -  * Level 2
      * 1026 × 675 × 1 × 1 × 10
-     * 2432 × 1600 × 1 × 3 × 1
+     * 2432 × 1600 × 200 × 3 × 1
 
   -  * Level 3
      * 342 × 225 × 1 × 1 × 10
-     * 608 × 400 × 1 × 3 × 1
+     * 608 × 400 × 200 × 3 × 1
 
   -  * Level 4
      * 114 × 74 × 1 × 1 × 10
-     * 152 × 100 × 1 × 3 × 1
+     * 152 × 100 × 200 × 3 × 1
 
   -  * Level 5
      * 38 × 25 × 1 × 1 × 10
-     * 38 × 25 × 1 × 3 × 1
+     * 
 
 
 Storage
@@ -517,7 +519,7 @@ Each sub-resolution must be stored in a valid IFD of the same TIFF file as the f
 
 The planes of largest resolutions should be organized into tiles rather than
 strips as described in the TIFF_ specification and may be compressed using any
-of the officially supported schemes including LZW, JPEG, JPEG2000.
+of the officially supported schemes including LZW, JPEG or JPEG2000.
 Sub-resolution image planes may choose to use different compression algorithms
 than the one used by the full resolution plane. For example the full
 resolution image may use no compression or lossless compression while the

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -509,12 +509,14 @@ Full-resolution image planes must remain stored as described above using a valid
 Each sub-resolution must be stored in a valid IFD of the same TIFF file as the full-resolution image plane. Additionally:
 
 - the offsets of all sub-resolutions IFDs must be referenced from the IFD of
-  the full-resolution plane using the `SubIFDs` TIFF extension tag. The list 
-  of sub-resolution offsets must be ordered by plane size from largest to
-  smallest,
+  the full-resolution plane using the SubIFDs TIFF extension tag 330 as
+  defined in the TIFF Tech Note 1 of the
+  `Adobe PageMaker® 6.0 TIFF Technical Notes <https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFFPM6.pdf>`_.
+  The list of sub-resolution offsets must be ordered by plane size from
+  largest to smallest,
 - the IFD offsets of pyramidal levels must not be referenced in the primary
   chain of IFDs derived from the first IFD of the TIFF file,
-- the NewSubFileType TIFF tag for each pyramidal level should be set to 1
+- the NewSubFileType TIFF tag 254 for each pyramidal level should be set to 1
   to distinguish full-resolution planes from downsampled planes.
 
 The planes of largest resolutions should be organized into tiles rather than

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -515,8 +515,9 @@ image plane. Additionally:
   `Adobe PageMaker® 6.0 TIFF Technical Notes <https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFFPM6.pdf>`_.
   The list of sub-resolution offsets must be ordered by plane size from
   largest to smallest,
-- the IFD offsets of pyramidal levels must not be referenced in the primary
-  chain of IFDs derived from the first IFD of the TIFF file,
+- the IFD offsets of pyramidal levels must neither be referenced in the primary
+  chain of IFDs derived from the first IFD of the TIFF file nor be referenced
+  in a :ref:`TiffData <tiffdata>` element of the OME-XML metadata,
 - the NewSubFileType TIFF tag 254 for each pyramidal level should be set to 1
   to distinguish full-resolution planes from downsampled planes.
 

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -501,38 +501,30 @@ using typical downsampling factors:
 Storage
 ^^^^^^^
 
-Full-resolution image planes must be stored as described above using a valid
-TIFF IFD and referenced from the OME-XML metadata using the
-:ref:`TiffData <tiffdata>` element. When sub-resolutions are present:
+Full-resolution image planes must reamin stored as described above using a valid TIFF IFD and referenced from the OME-XML metadata using the
+:ref:`TiffData <tiffdata>` element.
 
--  the `SubIFDs` TIFF extension tag must be used to specify the sub-resolution
-   image directories (see below),
--  the reduced image bit of the `NewSubfileType` Baseline TIFF tag should be
-   set to 1 to distinguish full-resolution planes from reduced planes
--  the page bit may optionally be set when appropriate.
+Each sub-resolution must be stored in a valid IFD of the same TIFF file as the full-resolution image plane. Additionally:
 
-Each sub-resolution level must be stored in a valid IFD of the same TIFF file as the full-resolution image plane. Additionally:
+- the offsets of all sub-resolutions IFDs must be referenced from the IFD of
+  the full-resolution plane using the `SubIFDs` TIFF extension tag. The list 
+  of sub-resolution offsets must be ordered by plane size from largest to
+  smallest,
+- the IFD offsets of pyramidal levels must not be referenced in the primary
+  chain of IFDs derived from the first IFD of the TIFF file,
+- the NewSubFileType TIFF tag for each pyramidal level should be set to 1
+  to distinguish full-resolution planes from downsampled planes.
 
-- the IFD offsets of all subresolutions must be referenced using the `SubIFDs` 
-  TIFF extension tag of the full-resolution plane IFD. The list of SubIFDs
-  must be ordered by plane size from largest to smallest,
-- the IFD offsets of all pyramidal levels must not be referenced in the chain
-  of IFDs derived from the first IFD of the TIFF file,
-- the reduced image bit of the `NewSubfileType` Baseline TIFF tag should be set
-  to 2 (TODO: check) to distinguish full-resolution planes from reduced planes
-- the page bit may optionally be set when appropriate.
+The planes of largest resolutions should be organized into tiles rather than
+strips as described in the TIFF_ specification and may be compressed using any
+of the officially supported schemes including LZW, JPEG, JPEG2000.
+Sub-resolution image planes may chose to use different compression algorithms
+than the one used by the full resolution plane. For example the full
+resolution image may use no compression or lossless compression while the
+sub-resolution images use lossy compression.
 
-Multi-resolution images especially the largest resolutions should used a tiled
-image organization following the TIFF specification (reference) and may be
-compressed using any of the algorithms officially supported by the TIFF_
-standard including LZW, JPEG, JPEG2000. Sub-resolution image planes may chose
-to use different compression algorithms than the one used by the full
-resolution image. For example the full resolution image may use no
-compression or lossless compression while the sub-resolution images use lossy
-compression.
-
-BigTIFF is recommended for large images, while Baseline TIFF may suffice for
-smaller images.
+While baseline TIFF may suffice for smaller pyramidal images, BigTIFF is
+recommended for large images.
 
 .. seealso::
 

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -434,3 +434,112 @@ The master file containing the full OME-XML metadata should be either an
 OME-XML companion file with the extension :file:`.companion.ome` or a master
 OME-TIFF file containing the full metadata (see :ref:`multifile_samples` for
 representative samples).
+
+Multi-resolution images
+-----------------------
+
+.. versionadded:: 5.7.0
+
+The OME-TIFF specification supports multi-resolution images also called
+pyramidal images i.e. images where individual planes are stored at different
+levels of resolution. The intermediate downsampled image planes are called
+sub-resolution image planes, sub-resolutions or pyramidal levels.
+
+Supported resolutions
+^^^^^^^^^^^^^^^^^^^^^
+
+Image planes can be reduced alongside the X and Y dimensions. Each pyramidal
+level must be a downsampling of the full-resolution plane in the X and Y
+dimensions and the resolution must stay unchanged in the other dimensions. The
+downsampling factor must be an integer value, identical alongside the X and
+the Y dimensions and stay the same between each consecutive pyramidal level.
+
+The following table below shows two examples of pyramidal level dimensions
+supported by the OME-TIFF specification:
+
+.. list-table::
+  :header-rows: 1
+
+  -  *
+     * Example 1
+     * Example 2
+
+  -  * Downsampling factor
+     * 3
+     * 4
+
+  -  * Level 0 (full-resolution)
+     * 9234 × 6075 × 1 × 1 × 10
+     * 38912 × 25600 × 1 × 3 × 1
+
+  -  * Level 1
+     * 3078 × 2025 × 1 × 1 × 10
+     * 9728 × 6400 × 1 × 3 × 1
+
+  -  * Level 2
+     * 1026 × 675 × 1 × 1 × 10
+     * 2432 × 1600 × 1 × 3 × 1
+
+  -  * Level 3
+     * 342 × 225 × 1 × 1 × 10
+     * 608 × 400 × 1 × 3 × 1
+
+  -  * Level 4
+     * 114 × 74 × 1 × 1 × 10
+     * 152 × 100 × 1 × 3 × 1
+
+  -  * Level 5
+     * 38 × 25 × 1 × 1 × 10
+     * 38 × 25 × 1 × 3 × 1
+
+Q: what about rounding?
+
+Storage
+^^^^^^^
+
+Full-resolution image planes must be stored as described above using a valid
+TIFF IFDand referenced from the OME-XML metadata using the
+:ref:`TiffData <tiffdata>` element. In addition when sub-resolutions are
+present:
+
+-  the `SubIFDs` TIFF extension tag must be used to specify the sub-resolution
+   image directories (see below),
+-  the reduced image bit of the `NewSubfileType` Baseline TIFF tag must be set
+   to 1 (TODO: check) to distinguish full-resolution planes from reduced planes
+-  the page bit may optionally be set when appropriate.
+
+Sub-resolution levels must be stored in a valid IFD of the same TIFF file as
+the full-resolution image plane. Additionally:
+
+- the IFD offsets of all pyramidal levels must be listed in the `SubIFDs` TIFF
+  extension tag of the full-resolution plane IFD. The listing must be ordered
+  by size of the sub-resolution image planes from largest to smallest,
+- the IFD offsets of all pyramidal levels must not be referenced in the chain
+  of IFDs derived from the first IFD of the TIFF file,
+- the reduced image bit of the `NewSubfileType` Baseline TIFF tag must be set
+  to 2 (TODO: check) to distinguish full-resolution planes from reduced planes
+- the page bit may optionally be set when appropriate.
+
+Multi-resolution images especially the largest resolutions should used a tiled
+image organization following the TIFF specification (reference) and may be
+compressed using any of the techniques officially supported by the TIFF
+standard including LZW, JPEG, JPEG2000). Sub-resolution image planes may chose
+to use different compression algorithms than the one used by the full
+resolution image. For example the full resolution image may use no
+compression or lossless compression while the sub-resolution images use lossy
+compression.
+
+BigTIFF is recommended for large images, while Baseline TIFF may suffice for
+smaller images.
+
+TODO: ref to valid sample showing multi-resolution OME-TIFF images.
+
+Q: ref to the TIFF spec
+Q: constraints/recommendation on compression/tile size consistency across
+pyramidal levels?
+
+.. seealso::
+
+  https://openmicroscopy.github.io/design/OME005/
+    Official design proposal for the addition of sub-resolution support to the
+    OME-TIFF specification.

--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -1,14 +1,15 @@
+.. _TIFF: https://www.adobe.io/open/standards/TIFF.html
+
 OME-TIFF specification
 ======================
 
 The following provides technical details on the OME-TIFF
-format. It assumes familiarity with both the
-`TIFF <https://en.wikipedia.org/wiki/TIFF>`_ and
-:schema:`OME-XML <>` formats, although there is some review of both.
+format. It assumes familiarity with both the TIFF_ specification and
+the :schema:`OME Data Model <>`, although there is some review of both.
 
 An OME-TIFF dataset consists of:
 
-- one or more files in standard TIFF format with the file extension
+- one or more files in standard TIFF_ format with the file extension
   ``.ome.tif`` or ``.ome.tiff`` or
   `BigTIFF format <https://www.awaresystems.be/imaging/tiff/bigtiff.html>`_
   with one of these same file extensions or a BigTIFF-specific
@@ -435,27 +436,28 @@ OME-XML companion file with the extension :file:`.companion.ome` or a master
 OME-TIFF file containing the full metadata (see :ref:`multifile_samples` for
 representative samples).
 
-Multi-resolution images
------------------------
+Pyramidal OME-TIFF
+------------------
 
-.. versionadded:: 5.7.0
+.. versionadded:: 6.0.0
 
-The OME-TIFF specification supports multi-resolution images also called
-pyramidal images i.e. images where individual planes are stored at different
-levels of resolution. The intermediate downsampled image planes are called
-sub-resolution image planes, sub-resolutions or pyramidal levels.
+The OME-TIFF specification supports multi-resolution images or pyramidal
+images where individual planes are stored at different levels of resolution.
+The intermediate downsampled image planes are called pyramidal levels,
+sub-resolution image planes or sub-resolutions.
 
 Supported resolutions
 ^^^^^^^^^^^^^^^^^^^^^
 
-Image planes can be reduced alongside the X and Y dimensions. Each pyramidal
+OME-TIFF planes can be reduced alongside the X and Y dimensions. Each pyramidal
 level must be a downsampling of the full-resolution plane in the X and Y
-dimensions and the resolution must stay unchanged in the other dimensions. The
-downsampling factor must be an integer value, identical alongside the X and
-the Y dimensions and stay the same between each consecutive pyramidal level.
+dimensions and the resolution should stay unchanged in the other dimensions.
+The downsampling factor should be an integer value, identical alongside the X
+and the Y dimensions and stay the same between each consecutive pyramidal
+level.
 
 The following table below shows two examples of pyramidal level dimensions
-supported by the OME-TIFF specification:
+using typical downsampling factors:
 
 .. list-table::
   :header-rows: 1
@@ -492,38 +494,35 @@ supported by the OME-TIFF specification:
      * 38 × 25 × 1 × 1 × 10
      * 38 × 25 × 1 × 3 × 1
 
-Q: what about rounding?
 
 Storage
 ^^^^^^^
 
 Full-resolution image planes must be stored as described above using a valid
-TIFF IFDand referenced from the OME-XML metadata using the
-:ref:`TiffData <tiffdata>` element. In addition when sub-resolutions are
-present:
+TIFF IFD and referenced from the OME-XML metadata using the
+:ref:`TiffData <tiffdata>` element. When sub-resolutions are present:
 
 -  the `SubIFDs` TIFF extension tag must be used to specify the sub-resolution
    image directories (see below),
--  the reduced image bit of the `NewSubfileType` Baseline TIFF tag must be set
-   to 1 (TODO: check) to distinguish full-resolution planes from reduced planes
+-  the reduced image bit of the `NewSubfileType` Baseline TIFF tag should be
+   set to 1 to distinguish full-resolution planes from reduced planes
 -  the page bit may optionally be set when appropriate.
 
-Sub-resolution levels must be stored in a valid IFD of the same TIFF file as
-the full-resolution image plane. Additionally:
+Each sub-resolution level must be stored in a valid IFD of the same TIFF file as the full-resolution image plane. Additionally:
 
-- the IFD offsets of all pyramidal levels must be listed in the `SubIFDs` TIFF
-  extension tag of the full-resolution plane IFD. The listing must be ordered
-  by size of the sub-resolution image planes from largest to smallest,
+- the IFD offsets of all subresolutions must be referenced using the `SubIFDs` 
+  TIFF extension tag of the full-resolution plane IFD. The list of SubIFDs
+  must be ordered by plane size from largest to smallest,
 - the IFD offsets of all pyramidal levels must not be referenced in the chain
   of IFDs derived from the first IFD of the TIFF file,
-- the reduced image bit of the `NewSubfileType` Baseline TIFF tag must be set
+- the reduced image bit of the `NewSubfileType` Baseline TIFF tag should be set
   to 2 (TODO: check) to distinguish full-resolution planes from reduced planes
 - the page bit may optionally be set when appropriate.
 
 Multi-resolution images especially the largest resolutions should used a tiled
 image organization following the TIFF specification (reference) and may be
-compressed using any of the techniques officially supported by the TIFF
-standard including LZW, JPEG, JPEG2000). Sub-resolution image planes may chose
+compressed using any of the algorithms officially supported by the TIFF_
+standard including LZW, JPEG, JPEG2000. Sub-resolution image planes may chose
 to use different compression algorithms than the one used by the full
 resolution image. For example the full resolution image may use no
 compression or lossless compression while the sub-resolution images use lossy
@@ -531,12 +530,6 @@ compression.
 
 BigTIFF is recommended for large images, while Baseline TIFF may suffice for
 smaller images.
-
-TODO: ref to valid sample showing multi-resolution OME-TIFF images.
-
-Q: ref to the TIFF spec
-Q: constraints/recommendation on compression/tile size consistency across
-pyramidal levels?
 
 .. seealso::
 


### PR DESCRIPTION
See https://trello.com/c/gMg5Miz9/23-ome-tiff-pyramid-specification

As we are converging towards a release of Bio-Formats 6, this PR proposes the set of changes to the OME-TIFF specification page to formalize the file format extension allowing to support pyramidal levels as proposed in https://openmicroscopy.github.io/design/OME005/. 

Summary of changes:

- reference to RFC 2119 and the Adobe TIFF specification
- definition of pyramidal terms and the scope of the pyramidal support in OME-TIFF
- definition of the storage of pyramidal levels using subIFDs