### PR TITLE
OME-XML: Update python in pom to python3

### DIFF
--- a/ome-xml/pom.xml
+++ b/ome-xml/pom.xml
@@ -79,7 +79,7 @@
 
   <properties>
     <project.rootdir>${basedir}/..</project.rootdir>
-    <python>python</python>
+    <python>python3</python>
     <xsdfu.script>../xsd-fu/xsd-fu</xsdfu.script>
     <xsdfu.modelpath>${basedir}/target/generated-sources/xsd-fu</xsdfu.modelpath>
     <xsdfu.metadatapath>${basedir}/target/generated-sources/xsd-fu</xsdfu.metadatapath>


### PR DESCRIPTION
This is a supplementary PR to https://github.com/ome/ome-model/pull/105 and should fix the broken build as seen in https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-build/jdk=JDK8,label=testintegration/248/console