### PR TITLE
Linkcheck fixes

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -354,3 +354,7 @@ linkcheck_ignore = [
     "https://github.com/ome/",
     "https://strandls.com", # SSL certificate verify failed
 ]
+
+# Some websites e.g. NCBI PMC URLs will return a 403 error code with the
+# default Sphinx user agent
+user_agent = "Mozilla/5.0"

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -356,4 +356,5 @@ linkcheck_ignore = [
     # See https://www.ncbi.nlm.nih.gov/pmc/about/copyright/
     # The PMC web site restricts access by the default Sphinx agent
     "https://www.ncbi.nlm.nih.gov/pmc/.*",
+    "https://eliceirilab.org/.*", # ConnectTimeoutError
 ]

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -353,8 +353,6 @@ linkcheck_ignore = [
     "https://www.imagic.ch/",
     "https://github.com/ome/",
     "https://strandls.com", # SSL certificate verify failed
-]
-
-# Some websites e.g. NCBI PMC URLs will return a 403 error code with the
-# default Sphinx user agent
-user_agent = "Mozilla/5.0"
+    # See https://www.ncbi.nlm.nih.gov/pmc/about/copyright/
+    # The PMC web site restricts access by the default Sphinx agent
+    "https://www.ncbi.nlm.nih.gov/pmc/.*",

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -356,3 +356,4 @@ linkcheck_ignore = [
     # See https://www.ncbi.nlm.nih.gov/pmc/about/copyright/
     # The PMC web site restricts access by the default Sphinx agent
     "https://www.ncbi.nlm.nih.gov/pmc/.*",
+]

--- a/docs/sphinx/ome-tiff/index.rst
+++ b/docs/sphinx/ome-tiff/index.rst
@@ -52,7 +52,6 @@ Public image repositories allowing image downloads as OME-TIFF
 
 * `ASCB CELL Image Library <http://www.cellimagelibrary.org/>`_
 * `Harvard Medical School LINCS Project <http://lincs.hms.harvard.edu/>`_
-* `JCB DataViewer <http://jcb-dataviewer.rupress.org/>`_
 * `Stowers Institute Original Data Repository <http://www.stowers.org/research/publications/odr>`_
 
 |

--- a/docs/sphinx/specifications/index.rst
+++ b/docs/sphinx/specifications/index.rst
@@ -56,7 +56,7 @@ Definitions of values stored
 The figure :ref:`figure-spec-stored` is ©2010 Linkert et al. Figure originally
 published as Figure 2, 
 Linkert et al (2010), J. Cell Biol. 189(5):777-782
-(http://jcb.rupress.org/content/189/5/777)
+(https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2878938/)
 
 .. note:: AcquiredDate was renamed to AcquisitionDate in June 2012
 


### PR DESCRIPTION
- Ignores external links blocked or timing out
- update JCB links 

Background: the NCBI PMC HEAD requests have some user-based agent filtering into place and reject the default agent set by Sphinx:

```
>>> requests.head('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6774793/')
<Response [403]>
>>> requests.head('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6774793/', headers={'User-Agent': 'Mozilla/5.0'})
<Response [200]>
>>> requests.head('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6774793/', headers={'User-Agent': 'Sphinx/3.1.2 requests/2.23.0 python/3.7.6'})
<Response [403]>
>>> requests.head('https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6774793/', headers={'User-Agent': 'Mozilla/4.0'})
<Response [200]>
```
