### PR TITLE
Fix hyperlink to idr0013 URL

### DIFF
--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -93,7 +93,7 @@ section of the OME Data Model, derived from the public
 
   -  * :ometiff_downloads:`00001_01.ome.tiff <MitoCheck/00001_01.ome.tiff>`
      * 1344 × 1024 × 1 × 1 × 93
-     * `IDR <http://idr.openmicroscopy.org/webclient/?show=well-771034>`_
+     * `IDR <https://idr.openmicroscopy.org/search/?query=Name:mitocheck>`_
      * `Public Domain <https://creativecommons.org/publicdomain/mark/1.0/>`_
 
 See `Neumann B et al. (2010). Phenotypic profiling of the human genome by time-lapse microscopy reveals cell division genes. Nature 464(7289):721 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3108885/>`__.


### PR DESCRIPTION
See https://merge-ci.openmicroscopy.org/jenkins/job/OME-MODEL-linkcheck/19/console

The latest release of Sphinx now fails the linkcheck for individual well URLs due a redirect excess. This can be reproduced using

```
$ curl -IL https://idr.openmicroscopy.org/webclient/?show=well-771034
...
curl: (47) Maximum (50) redirects followed
```

This PR  fixes the issue by using the canonical gallery study URL for the dataset provenance rather than the individual well.

There might be a large issue with the recursive IDR nginx redirects and I am unclear how this resolves in the web browser. @manics worth turning into an IDR/deployment issue or do you have a feeling for the source of the problem?

