### PR TITLE
Add PyPI deployment to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,4 @@ deploy:
   distributions: sdist
   on:
     tags: true
+    jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,11 @@ install:
 
 script:
   - mvn test -B -Dpython="$PYTHON"
+
+deploy:
+  provider: pypi
+  user: $PYPI_USER
+  password: $PYPI_PASSWORD
+  distributions: sdist
+  on:
+    tags: true

--- a/setup.py
+++ b/setup.py
@@ -16,18 +16,24 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-#
-import os
-import sys
 
 from setuptools import setup
 
 
-version = '6.1.1.dev'
+def get_version():
+    import xml.etree.ElementTree as ElementTree
+    tree = ElementTree.parse('pom.xml')
+    ns = {'maven': 'http://maven.apache.org/POM/4.0.0'}
+    version = tree.find('maven:version', ns).text
+    print(version)
+    return version.replace('-SNAPSHOT', '.dev0')
+
+
+version = get_version()
 url = "https://github.com/ome/ome-model/"
 
 setup(
-    version=version,
+    version=get_version(),
     packages=["ome_model"],
     name='ome-model',
     description="Core OME model library (EXPERIMENTAL)",


### PR DESCRIPTION
In preparation of the 6.1.2 release, this PR is meant to reduce the management of the Python component of this repository:

- the `ome-model` version is now read directly from `pom.xml` and converted into a PEP440 compliant suffix for SNAPSHOTS
- a Travis CI provider is now declared which should upload to PyPI on tags. 

With these changes, I'd expect to simplify the release process and have the steps describe in https://docs.openmicroscopy.org/contributing/java-development.html#release-process also covering the release of the Python component. There is still a manual post Sonatype deployment step to unzip the documentation artifact under https://docs.openmicroscopy.org/ome-model/.