### PR TITLE
ome_model: channel fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 ---
+os: linux
+dist: bionic
 language: java
 
-sudo: false
-
-# http://docs.travis-ci.com/user/caching/#Arbitrary-directories
 cache:
   directories:
     - $HOME/.m2
@@ -13,25 +12,27 @@ addons:
     packages:
       - python3-pip
 
-jdk:
-  - openjdk11
-  - openjdk8
+before_install: pip3 install --user -r requirements.txt
 
-env:
-  - PYTHON=python3
-
-matrix:
+jobs:
   fast_finish: true
-
-before_install:
-  - python3 --version
-  - pip3 install --user -r requirements.txt
-
-install:
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dpython="$PYTHON"
-
-script:
-  - mvn test -B -Dpython="$PYTHON"
+  include:
+    - name: jdk8
+      language: java
+      jdk: openjdk8
+      install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dpython=python3
+      script: mvn test -B -Dpython=python3
+    - name: JDK11
+      language: java
+      jdk: openjdk11
+      install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dpython=python3
+      script: mvn test -B -Dpython=python3
+    - name: Python36
+      python: "3.6"
+      install: pip3 install --upgrade pip wheel pytest tox virtualenv
+      script:
+        - ulimit -n 4096
+        - tox -e py36
 
 deploy:
   provider: pypi
@@ -40,4 +41,4 @@ deploy:
   distributions: sdist
   on:
     tags: true
-    jdk: openjdk8
+    python: "3.6"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.md
+include pom.xml

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -47,7 +47,7 @@ class Channel(object):
         if name:
             self.data["Name"] = name
         if color:
-            self.data["Color"] = str(color),
+            self.data["Color"] = str(color)
         Channel.ID += 1
 
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -131,8 +131,11 @@ class Image(object):
             uuid=UUID(filename)))
 
     def validate(self):
-        assert (len(self.data["Channels"]) <=
-                int(self.data["Pixels"]["SizeC"])), str(self.data)
+        sizeC = int(self.data["Pixels"]["SizeC"])
+        assert (len(self.data["Channels"]) <= sizeC), str(self.data)
+        channel_samples = sum([int(x.data['SamplesPerPixel'])
+                             for x in self.data["Channels"]])
+        assert channel_samples < sizeC, str(self.data)
         return self.data
 
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -36,16 +36,18 @@ class Channel(object):
 
     def __init__(self,
                  image,
-                 name,
-                 color,
+                 name=None,
+                 color=None,
                  samplesPerPixel=1,
                  ):
         self.data = {
             'ID': 'Channel:%s' % self.ID,
-            'Name': name,
-            'Color': str(color),
             'SamplesPerPixel': str(samplesPerPixel),
         }
+        if name:
+            self.data["Name"] = name
+        if color:
+            self.data["Color"] = str(color),
         Channel.ID += 1
 
 
@@ -108,10 +110,10 @@ class Image(object):
         for tiff in tiffs:
             self.add_tiff(tiff)
 
-    def add_channel(self, name, color, samplesPerPixel=1):
+    def add_channel(self, name=None, color=None, samplesPerPixel=1):
         self.data["Channels"].append(
             Channel(
-                self, name, color, samplesPerPixel
+                self, name=name, color=color, samplesPerPixel=samplesPerPixel
             ))
 
     def add_tiff(self, filename, c=0, t=0, z=0, ifd=None, planeCount=None):

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -131,7 +131,7 @@ class Image(object):
             uuid=UUID(filename)))
 
     def validate(self):
-        assert (len(self.data["Channels"]) ==
+        assert (len(self.data["Channels"]) <=
                 int(self.data["Pixels"]["SizeC"])), str(self.data)
         return self.data
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -135,7 +135,7 @@ class Image(object):
         assert (len(self.data["Channels"]) <= sizeC), str(self.data)
         channel_samples = sum([int(x.data['SamplesPerPixel'])
                               for x in self.data["Channels"]])
-        assert channel_samples < sizeC, str(self.data)
+        assert channel_samples <= sizeC, str(self.data)
         return self.data
 
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -134,7 +134,7 @@ class Image(object):
         sizeC = int(self.data["Pixels"]["SizeC"])
         assert (len(self.data["Channels"]) <= sizeC), str(self.data)
         channel_samples = sum([int(x.data['SamplesPerPixel'])
-                             for x in self.data["Channels"]])
+                              for x in self.data["Channels"]])
         assert channel_samples < sizeC, str(self.data)
         return self.data
 

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -57,7 +57,7 @@ class TestImage(object):
     @pytest.mark.parametrize('name', [None, '', 'channel-test'])
     @pytest.mark.parametrize('color', [None, '-1', '65535'])
     def test_channel(self, tmpdir, name, color):
-        f = str(tmpdir.join('image.companion.ome'))
+        f = str(tmpdir.join('3channels.companion.ome'))
 
         i = Image("test", 256, 512, 3, 4, 5)
         i.add_channel()
@@ -93,3 +93,28 @@ class TestImage(object):
         else:
             assert 'Color' not in channels[2].attrib
         assert channels[2].attrib['SamplesPerPixel'] == '1'
+
+
+    def test_rgb_channel(self, tmpdir):
+        f = str(tmpdir.join('rgb.companion.ome'))
+
+        i = Image("test", 256, 512, 3, 4, 5)
+        i.add_channel(samplesPerPixel=3)
+        create_companion(images=[i], out=f)
+
+        root = ElementTree.parse(f).getroot()
+        images = root.findall('OME:Image', namespaces=NS)
+        assert len(images) == 1
+        assert images[0].attrib['Name'] == 'test'
+        pixels = images[0].findall('OME:Pixels', namespaces=NS)
+        assert len(pixels) == 1
+        assert pixels[0].attrib['SizeX'] == '256'
+        assert pixels[0].attrib['SizeY'] == '512'
+        assert pixels[0].attrib['SizeZ'] == '3'
+        assert pixels[0].attrib['SizeC'] == '4'
+        assert pixels[0].attrib['SizeT'] == '5'
+        channels = pixels[0].findall('OME:Channel', namespaces=NS)
+        assert len(channels) == 1
+        assert 'Name' not in channels[0].attrib
+        assert 'Color' not in channels[0].attrib
+        assert channels[0].attrib['SamplesPerPixel'] == '3'

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -153,7 +153,7 @@ class TestChannel(object):
     def test_rgb_channel(self, tmpdir):
         f = str(tmpdir.join('rgb.companion.ome'))
 
-        i = Image("test", 256, 512, 3, 4, 5)
+        i = Image("test", 256, 512, 1, 3, 1)
         i.add_channel(samplesPerPixel=3)
         create_companion(images=[i], out=f)
 
@@ -165,9 +165,9 @@ class TestChannel(object):
         assert len(pixels) == 1
         assert pixels[0].attrib['SizeX'] == '256'
         assert pixels[0].attrib['SizeY'] == '512'
-        assert pixels[0].attrib['SizeZ'] == '3'
-        assert pixels[0].attrib['SizeC'] == '4'
-        assert pixels[0].attrib['SizeT'] == '5'
+        assert pixels[0].attrib['SizeZ'] == '1'
+        assert pixels[0].attrib['SizeC'] == '3'
+        assert pixels[0].attrib['SizeT'] == '1'
         assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
         assert pixels[0].attrib['Type'] == 'uint16'
         channels = pixels[0].findall('OME:Channel', namespaces=NS)

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -56,7 +56,7 @@ class TestImage(object):
         channels = pixels[0].findall('OME:Channel', namespaces=NS)
         assert len(channels) == 0
 
-    @pytest.mark.parametrize('dimension_order' , [
+    @pytest.mark.parametrize('dimension_order', [
         'XYZCT', 'XYZTC', 'XYCZT', 'XYCTZ', 'XYTZC', 'XYTCZ'])
     def test_dimensionorder(self, tmpdir, dimension_order):
         f = str(tmpdir.join('image.companion.ome'))
@@ -80,10 +80,10 @@ class TestImage(object):
         channels = pixels[0].findall('OME:Channel', namespaces=NS)
         assert len(channels) == 0
 
-    @pytest.mark.parametrize('pixel_type' , [
+    @pytest.mark.parametrize('pixel_type', [
         'int8', 'int16', 'int32', 'uint8', 'uint16', 'uint32',
         'float', 'double', 'complex', 'double-complex', 'bit'])
-    def test_dimensionorder(self, tmpdir, pixel_type):
+    def test_pixeltypes(self, tmpdir, pixel_type):
         f = str(tmpdir.join('image.companion.ome'))
 
         i = Image("test", 256, 512, 3, 4, 5, type=pixel_type)

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -1,0 +1,54 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+
+
+from ome_model.experimental import Image, create_companion
+import xml.etree.ElementTree as ElementTree
+
+NS = {'OME': 'http://www.openmicroscopy.org/Schemas/OME/2016-06'}
+ElementTree.register_namespace('OME', NS['OME'])
+
+
+class TestImage(object):
+
+    def test_minimal_image(self, tmpdir):
+        f = str(tmpdir.join('image.companion.ome'))
+
+        i = Image("test", 256, 512, 3, 4, 5)
+        create_companion(images=[i], out=f)
+
+        root = ElementTree.parse(f).getroot()
+        images = root.findall('OME:Image', namespaces=NS)
+        assert len(images) == 1
+        assert images[0].attrib['Name'] == 'test'
+        pixels = images[0].findall('OME:Pixels', namespaces=NS)
+        assert len(pixels) == 1
+        assert pixels[0].attrib['SizeX'] == '256'
+        assert pixels[0].attrib['SizeY'] == '512'
+        assert pixels[0].attrib['SizeZ'] == '3'
+        assert pixels[0].attrib['SizeC'] == '4'
+        assert pixels[0].attrib['SizeT'] == '5'
+        channels = pixels[0].findall('OME:Channel', namespaces=NS)
+        assert len(channels) == 0

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -51,6 +51,57 @@ class TestImage(object):
         assert pixels[0].attrib['SizeZ'] == '3'
         assert pixels[0].attrib['SizeC'] == '4'
         assert pixels[0].attrib['SizeT'] == '5'
+        assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
+        assert pixels[0].attrib['Type'] == 'uint16'
+        channels = pixels[0].findall('OME:Channel', namespaces=NS)
+        assert len(channels) == 0
+
+    @pytest.mark.parametrize('dimension_order' , [
+        'XYZCT', 'XYZTC', 'XYCZT', 'XYCTZ', 'XYTZC', 'XYTCZ'])
+    def test_dimensionorder(self, tmpdir, dimension_order):
+        f = str(tmpdir.join('image.companion.ome'))
+
+        i = Image("test", 256, 512, 3, 4, 5, order=dimension_order)
+        create_companion(images=[i], out=f)
+
+        root = ElementTree.parse(f).getroot()
+        images = root.findall('OME:Image', namespaces=NS)
+        assert len(images) == 1
+        assert images[0].attrib['Name'] == 'test'
+        pixels = images[0].findall('OME:Pixels', namespaces=NS)
+        assert len(pixels) == 1
+        assert pixels[0].attrib['SizeX'] == '256'
+        assert pixels[0].attrib['SizeY'] == '512'
+        assert pixels[0].attrib['SizeZ'] == '3'
+        assert pixels[0].attrib['SizeC'] == '4'
+        assert pixels[0].attrib['SizeT'] == '5'
+        assert pixels[0].attrib['DimensionOrder'] == dimension_order
+        assert pixels[0].attrib['Type'] == 'uint16'
+        channels = pixels[0].findall('OME:Channel', namespaces=NS)
+        assert len(channels) == 0
+
+    @pytest.mark.parametrize('pixel_type' , [
+        'int8', 'int16', 'int32', 'uint8', 'uint16', 'uint32',
+        'float', 'double', 'complex', 'double-complex', 'bit'])
+    def test_dimensionorder(self, tmpdir, pixel_type):
+        f = str(tmpdir.join('image.companion.ome'))
+
+        i = Image("test", 256, 512, 3, 4, 5, type=pixel_type)
+        create_companion(images=[i], out=f)
+
+        root = ElementTree.parse(f).getroot()
+        images = root.findall('OME:Image', namespaces=NS)
+        assert len(images) == 1
+        assert images[0].attrib['Name'] == 'test'
+        pixels = images[0].findall('OME:Pixels', namespaces=NS)
+        assert len(pixels) == 1
+        assert pixels[0].attrib['SizeX'] == '256'
+        assert pixels[0].attrib['SizeY'] == '512'
+        assert pixels[0].attrib['SizeZ'] == '3'
+        assert pixels[0].attrib['SizeC'] == '4'
+        assert pixels[0].attrib['SizeT'] == '5'
+        assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
+        assert pixels[0].attrib['Type'] == pixel_type
         channels = pixels[0].findall('OME:Channel', namespaces=NS)
         assert len(channels) == 0
 
@@ -79,6 +130,8 @@ class TestChannel(object):
         assert pixels[0].attrib['SizeZ'] == '3'
         assert pixels[0].attrib['SizeC'] == '4'
         assert pixels[0].attrib['SizeT'] == '5'
+        assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
+        assert pixels[0].attrib['Type'] == 'uint16'
         channels = pixels[0].findall('OME:Channel', namespaces=NS)
         assert len(channels) == 3
         assert 'Name' not in channels[0].attrib
@@ -115,6 +168,8 @@ class TestChannel(object):
         assert pixels[0].attrib['SizeZ'] == '3'
         assert pixels[0].attrib['SizeC'] == '4'
         assert pixels[0].attrib['SizeT'] == '5'
+        assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
+        assert pixels[0].attrib['Type'] == 'uint16'
         channels = pixels[0].findall('OME:Channel', namespaces=NS)
         assert len(channels) == 1
         assert 'Name' not in channels[0].attrib

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -54,6 +54,9 @@ class TestImage(object):
         channels = pixels[0].findall('OME:Channel', namespaces=NS)
         assert len(channels) == 0
 
+
+class TestChannel(object):
+
     @pytest.mark.parametrize('name', [None, '', 'channel-test'])
     @pytest.mark.parametrize('color', [None, '-1', '65535'])
     def test_channel(self, tmpdir, name, color):
@@ -94,7 +97,6 @@ class TestImage(object):
             assert 'Color' not in channels[2].attrib
         assert channels[2].attrib['SamplesPerPixel'] == '1'
 
-
     def test_rgb_channel(self, tmpdir):
         f = str(tmpdir.join('rgb.companion.ome'))
 
@@ -118,3 +120,21 @@ class TestImage(object):
         assert 'Name' not in channels[0].attrib
         assert 'Color' not in channels[0].attrib
         assert channels[0].attrib['SamplesPerPixel'] == '3'
+
+    def test_too_many_channels(self, tmpdir):
+        f = str(tmpdir.join('invalid.companion.ome'))
+
+        i = Image("test", 512, 512, 1, 2, 1)
+        i.add_channel()
+        i.add_channel()
+        i.add_channel()
+        with pytest.raises(AssertionError):
+            create_companion(images=[i], out=f)
+
+    def test_too_many_channel_samples(self, tmpdir):
+        f = str(tmpdir.join('invalid.companion.ome'))
+
+        i = Image("test", 512, 512, 1, 2, 1)
+        i.add_channel(samplesPerPixel=3)
+        with pytest.raises(AssertionError):
+            create_companion(images=[i], out=f)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py36
+# https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# Ensure pip is new enough
+requires = pip >= 19.0.0
+           virtualenv >= 16.0.0
+
+[testenv]
+# For environment markers see
+# https://www.python.org/dev/peps/pep-0508/#environment-markers
+deps =
+    pytest-rerunfailures
+    pytest-xdist
+    restructuredtext-lint
+commands =
+    python setup.py install
+    pytest {posargs:-n4  --reruns 5 -rf test -s}

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,7 @@ requires = pip >= 19.0.0
 # For environment markers see
 # https://www.python.org/dev/peps/pep-0508/#environment-markers
 deps =
-    pytest-rerunfailures
     pytest-xdist
-    restructuredtext-lint
 commands =
     python setup.py install
-    pytest {posargs:-n4  --reruns 5 -rf test -s}
+    pytest {posargs:-n4 -rf test -s}

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@ requires = pip >= 19.0.0
 # For environment markers see
 # https://www.python.org/dev/peps/pep-0508/#environment-markers
 deps =
+    flake8
     pytest-xdist
 commands =
+    flake8 ome_model test
     python setup.py install
     pytest {posargs:-n4 -rf test -s}


### PR DESCRIPTION
This PR inclues a set of improvements for the `Image/Pixels/Channel` created by the `ome_model` library driven by in-progress IDR work on HCS RGB companion files /cc @dominikl 

## Changes

- the [Channel.Name](https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Channel_Name) and [Channel.Color](https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Channel_Color) attributes are optional as per the OME schema. In the case of many RGB images typically these values are irrelevant. 7837240  changes the `Channel` constructor and `Image.add_channel` method to turn these metadata fields into optional key/value pairs rather than mandatory arguments and handling missing arguments/`None`

-  1ae8b58  refines the current `Image.validate()` logic to account for the optional nature of the `Channel` element and the `SamplesPerPixel` value by using the two following checks:
  1. the number of `Channel` elements is less or equal to `SizeC`
  2. the sum of the `SamplesPerPixels` for each `Channel` is less of equal to `SizeC`

## Testing

Without this PR the following examples should fail during the channel validation step. With this PR, it should create a valid OME-XML:

```
from ome_model.experimental import Image, create_companion
image = Image("test", 512, 512, 1, 3, 1)
image.add_tiff("test.tiff")
create_companion(images=[image])
```

```
from ome_model.experimental import Image, create_companion
image = Image("test", 512, 512, 1, 3, 1)
image.add_channel(samplesPerPixel=3)
image.add_tiff("test.tiff")
create_companion(images=[image])
```

In addition to manual testing, commits f22547e and following add Python unit tests covering the constructors of the `Image` and `Channel` classes as well as a `tox` infrastructure used byTravis to run these Python tests in a separate job.

Target: `6.2.0`