### PR TITLE
Ensure stdout works in Jupyter Notebooks

### DIFF
--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -6,11 +6,6 @@ import sys
 import uuid
 import xml.etree.ElementTree as ET
 
-if sys.version_info[0] > 2:
-    PYTHON = 3
-else:
-    PYTHON = 2
-
 OME_ATTRIBUTES = {
     'Creator': "ome_model/experimental.py",
     'UUID': "urn:uuid:%s" % uuid.uuid4(),
@@ -230,12 +225,9 @@ def create_companion(plates=[], images=[], out=None):
 
     # https://stackoverflow.com/a/48671499/56887
     kwargs = dict(encoding="UTF-8")
-    if PYTHON >= 3:
-        kwargs["xml_declaration"] = True
-        if not out:
-            out = sys.stdout.buffer
-    elif not out:
-        out = sys.stdout
+    kwargs["xml_declaration"] = True
+    if not out:
+        out = sys.stdout.buffer
     ET.ElementTree(root).write(out, **kwargs)
 
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -230,6 +230,8 @@ def create_companion(plates=[], images=[], out=None):
         try:
             out = sys.stdout.buffer
         except AttributeError:
+            # ipykernel.iostream.OutStream (used by Jupyter Notebook) does not
+            # have a .buffer attribute
             out = sys.stdout
     ET.ElementTree(root).write(out, **kwargs)
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -227,7 +227,10 @@ def create_companion(plates=[], images=[], out=None):
     kwargs = dict(encoding="UTF-8")
     kwargs["xml_declaration"] = True
     if not out:
-        out = sys.stdout.buffer
+        try:
+            out = sys.stdout.buffer
+        except AttributeError:
+            out = sys.stdout
     ET.ElementTree(root).write(out, **kwargs)
 
 


### PR DESCRIPTION
`sys.stdout` in Jupyter notebooks may not have a `buffer` attribute.

To test: run `create_companion(images=[companion])` (i.e. use the default `out` parameter) in a Jupyter Notebook.

See e.g. https://github.com/Yelp/mrjob/pull/1443