### PR TITLE
ome-model: add support for Plane population

### DIFF
--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -48,14 +48,21 @@ class Channel(object):
 
 class Plane(object):
 
+    ALLOWED_KEYS = (
+        'DeltaT', 'DeltaTUnit', 'ExposureTime', 'ExposureTimeUnit',
+        'PositionX', 'PositionXUnit', 'PositionY', 'PositionYUnit',
+        'PositionZ', 'PositionZUnit')
+
     def __init__(self, TheC=0, TheZ=0, TheT=0, options={}):
         self.data = {
             'TheC': str(TheC),
             'TheZ': str(TheZ),
             'TheT': str(TheT),
         }
-        if options:
-            for key, value in options.items():
+        if not options:
+            return
+        for key, value in options.items():
+            if key in self.ALLOWED_KEYS:
                 self.data[key] = value
 
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -46,6 +46,19 @@ class Channel(object):
         Channel.ID += 1
 
 
+class Plane(object):
+
+    def __init__(self, TheC=0, TheZ=0, TheT=0, options={}):
+        self.data = {
+            'TheC': str(TheC),
+            'TheZ': str(TheZ),
+            'TheT': str(TheT),
+        }
+        if options:
+            for key, value in options.items():
+                self.data[key] = value
+
+
 class UUID(object):
     def __init__(self,
                  filename=None
@@ -100,6 +113,7 @@ class Image(object):
             },
             'Channels': [],
             'TIFFs': [],
+            'Planes': [],
         }
         Image.ID += 1
         for tiff in tiffs:
@@ -124,6 +138,13 @@ class Image(object):
             ifd=ifd,
             planeCount=planeCount,
             uuid=UUID(filename)))
+
+    def add_plane(self, c=0, t=0, z=0, options={}):
+        assert c < int(self.data['Pixels']['SizeC'])
+        assert z < int(self.data['Pixels']['SizeZ'])
+        assert t < int(self.data['Pixels']['SizeT'])
+        self.data["Planes"].append(Plane(
+            TheC=c, TheT=t, TheZ=z, options=options))
 
     def validate(self):
         sizeC = int(self.data["Pixels"]["SizeC"])
@@ -227,6 +248,9 @@ def create_companion(plates=[], images=[], out=None):
             if tiff.uuid:
                 ET.SubElement(
                     tiffdata, "UUID", tiff.uuid.data).text = tiff.uuid.value
+
+        for plane in i["Planes"]:
+            ET.SubElement(pixels, "Plane", attrib=plane.data)
 
     # https://stackoverflow.com/a/48671499/56887
     kwargs = dict(encoding="UTF-8")

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -146,9 +146,9 @@ class Image(object):
             uuid=UUID(filename)))
 
     def add_plane(self, c=0, t=0, z=0, options={}):
-        assert c < int(self.data['Pixels']['SizeC'])
-        assert z < int(self.data['Pixels']['SizeZ'])
-        assert t < int(self.data['Pixels']['SizeT'])
+        assert c >= 0 and c < int(self.data['Pixels']['SizeC'])
+        assert z >= 0 and z < int(self.data['Pixels']['SizeZ'])
+        assert t >= 0 and t < int(self.data['Pixels']['SizeT'])
         self.data["Planes"].append(Plane(
             TheC=c, TheT=t, TheZ=z, options=options))
 

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -59,11 +59,10 @@ class Plane(object):
             'TheZ': str(TheZ),
             'TheT': str(TheT),
         }
-        if not options:
-            return
-        for key, value in options.items():
-            if key in self.ALLOWED_KEYS:
-                self.data[key] = value
+        if options:
+            for key, value in options.items():
+                if key in self.ALLOWED_KEYS:
+                    self.data[key] = value
 
 
 class UUID(object):

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -288,3 +288,35 @@ class TestPlane(object):
         i = Image("test", 512, 512, 1, 1, 1)
         with pytest.raises(AssertionError):
             i.add_plane(z=1, c=0, t=0)
+
+    def test_invalid_plane_option(self, tmpdir):
+        f = str(tmpdir.join('invalid_plane_options.companion.ome'))
+
+        i = Image("test", 512, 512, 1, 1, 1)
+        options = {
+            'EmissionWavelength': '512.0',
+            'EmissionWavelengthUnit': 'nm',
+        }
+        i.add_plane(z=0, c=0, t=0, options=options)
+        create_companion(images=[i], out=f)
+
+        root = ElementTree.parse(f).getroot()
+        images = root.findall('OME:Image', namespaces=NS)
+        assert len(images) == 1
+        assert images[0].attrib['Name'] == 'test'
+        pixels = images[0].findall('OME:Pixels', namespaces=NS)
+        assert len(pixels) == 1
+        assert pixels[0].attrib['SizeX'] == '512'
+        assert pixels[0].attrib['SizeY'] == '512'
+        assert pixels[0].attrib['SizeZ'] == '1'
+        assert pixels[0].attrib['SizeC'] == '1'
+        assert pixels[0].attrib['SizeT'] == '1'
+        assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
+        assert pixels[0].attrib['Type'] == 'uint16'
+        planes = pixels[0].findall('OME:Plane', namespaces=NS)
+        assert len(planes) == 1
+        assert planes[0].attrib['TheZ'] == '0'
+        assert planes[0].attrib['TheC'] == '0'
+        assert planes[0].attrib['TheT'] == '0'
+        assert 'EmissionWavelength' not in planes[0].attrib
+        assert 'EmissionWavelengthUnit' not in planes[0].attrib

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -283,11 +283,16 @@ class TestPlane(object):
         assert planes[0].attrib['PositionZ'] == '0.0'
         assert planes[0].attrib['PositionZUnit'] == 'reference frame'
 
-    def test_invalid_plane_index(self, tmpdir):
+    @pytest.mark.parametrize('invalidindex', [-1, 1])
+    def test_invalid_plane_index(self, tmpdir, invalidindex):
 
         i = Image("test", 512, 512, 1, 1, 1)
         with pytest.raises(AssertionError):
-            i.add_plane(z=1, c=0, t=0)
+            i.add_plane(z=invalidindex, c=0, t=0)
+        with pytest.raises(AssertionError):
+            i.add_plane(z=0, c=invalidindex, t=0)
+        with pytest.raises(AssertionError):
+            i.add_plane(z=0, c=0, t=invalidindex)
 
     def test_invalid_plane_option(self, tmpdir):
         f = str(tmpdir.join('invalid_plane_options.companion.ome'))

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -193,3 +193,50 @@ class TestChannel(object):
         i.add_channel(samplesPerPixel=3)
         with pytest.raises(AssertionError):
             create_companion(images=[i], out=f)
+
+
+class TestPlane(object):
+
+    def test_planes(self, tmpdir):
+        f = str(tmpdir.join('planes.companion.ome'))
+
+        i = Image("test", 256, 512, 1, 2, 2)
+        i.add_plane(c=0, z=0, t=0)
+        i.add_plane(c=0, z=0, t=1)
+        i.add_plane(c=1, z=0, t=0)
+        i.add_plane(c=1, z=0, t=1)
+        create_companion(images=[i], out=f)
+
+        root = ElementTree.parse(f).getroot()
+        images = root.findall('OME:Image', namespaces=NS)
+        assert len(images) == 1
+        assert images[0].attrib['Name'] == 'test'
+        pixels = images[0].findall('OME:Pixels', namespaces=NS)
+        assert len(pixels) == 1
+        assert pixels[0].attrib['SizeX'] == '256'
+        assert pixels[0].attrib['SizeY'] == '512'
+        assert pixels[0].attrib['SizeZ'] == '1'
+        assert pixels[0].attrib['SizeC'] == '2'
+        assert pixels[0].attrib['SizeT'] == '2'
+        assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
+        assert pixels[0].attrib['Type'] == 'uint16'
+        planes = pixels[0].findall('OME:Plane', namespaces=NS)
+        assert len(planes) == 4
+        assert planes[0].attrib['TheZ'] == '0'
+        assert planes[0].attrib['TheC'] == '0'
+        assert planes[0].attrib['TheT'] == '0'
+        assert planes[1].attrib['TheZ'] == '0'
+        assert planes[1].attrib['TheC'] == '0'
+        assert planes[1].attrib['TheT'] == '1'
+        assert planes[2].attrib['TheZ'] == '0'
+        assert planes[2].attrib['TheC'] == '1'
+        assert planes[2].attrib['TheT'] == '0'
+        assert planes[3].attrib['TheZ'] == '0'
+        assert planes[3].attrib['TheC'] == '1'
+        assert planes[3].attrib['TheT'] == '1'
+
+    def test_invalid_plane_index(self, tmpdir):
+
+        i = Image("test", 512, 512, 1, 1, 1)
+        with pytest.raises(AssertionError):
+            i.add_plane(z=1, c=0, t=0)

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -235,6 +235,54 @@ class TestPlane(object):
         assert planes[3].attrib['TheC'] == '1'
         assert planes[3].attrib['TheT'] == '1'
 
+    def test_plane_options(self, tmpdir):
+        f = str(tmpdir.join('plane_options.companion.ome'))
+
+        i = Image("test", 512, 512, 1, 1, 1)
+        options = {
+            'DeltaT': '0.0',
+            'DeltaTUnit': 's',
+            'ExposureTime': '100',
+            'ExposureTimeUnit': 'ms',
+            'PositionX': '0.0',
+            'PositionXUnit': 'reference frame',
+            'PositionY': '0.0',
+            'PositionYUnit': 'reference frame',
+            'PositionZ': '0.0',
+            'PositionZUnit': 'reference frame',
+        }
+        i.add_plane(z=0, c=0, t=0, options=options)
+        create_companion(images=[i], out=f)
+
+        root = ElementTree.parse(f).getroot()
+        images = root.findall('OME:Image', namespaces=NS)
+        assert len(images) == 1
+        assert images[0].attrib['Name'] == 'test'
+        pixels = images[0].findall('OME:Pixels', namespaces=NS)
+        assert len(pixels) == 1
+        assert pixels[0].attrib['SizeX'] == '512'
+        assert pixels[0].attrib['SizeY'] == '512'
+        assert pixels[0].attrib['SizeZ'] == '1'
+        assert pixels[0].attrib['SizeC'] == '1'
+        assert pixels[0].attrib['SizeT'] == '1'
+        assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
+        assert pixels[0].attrib['Type'] == 'uint16'
+        planes = pixels[0].findall('OME:Plane', namespaces=NS)
+        assert len(planes) == 1
+        assert planes[0].attrib['TheZ'] == '0'
+        assert planes[0].attrib['TheC'] == '0'
+        assert planes[0].attrib['TheT'] == '0'
+        assert planes[0].attrib['DeltaT'] == '0.0'
+        assert planes[0].attrib['DeltaTUnit'] == 's'
+        assert planes[0].attrib['ExposureTime'] == '100'
+        assert planes[0].attrib['ExposureTimeUnit'] == 'ms'
+        assert planes[0].attrib['PositionX'] == '0.0'
+        assert planes[0].attrib['PositionXUnit'] == 'reference frame'
+        assert planes[0].attrib['PositionY'] == '0.0'
+        assert planes[0].attrib['PositionYUnit'] == 'reference frame'
+        assert planes[0].attrib['PositionZ'] == '0.0'
+        assert planes[0].attrib['PositionZUnit'] == 'reference frame'
+
     def test_invalid_plane_index(self, tmpdir):
 
         i = Image("test", 512, 512, 1, 1, 1)


### PR DESCRIPTION
This API addition had  driven in the context of `idr0065` - see https://github.com/IDR/idr0065-camsund-crispri/blob/master/scripts/generate_companions.py#L146 to populate the `Plane` metadata using the submitted timestamp/exposure information - see https://idr.openmicroscopy.org/webclient/img_detail/9022301 for instance. As I was trying to re-use the API for `idr0092`, I realized I never backported the change.


In terms of style, the new `Plane` object explicitly defines the `z/c/t` arguments as well as an `options` dictionary which takes all the optional `Plane` attributes.   A minimal example of consumption of this API is illustrated below:

```
from ome_model.experimental import Image, create_companion

i = Image("test", 256, 512, 1, 2, 2)
i.add_plane(c=0, z=0, t=0, options={'DeltaT': '0.0'})
i.add_plane(c=0, z=0, t=1, options={'DeltaT': '1.0'})
i.add_plane(c=1, z=0, t=0, options={'DeltaT': '0.1'})
i.add_plane(c=1, z=0, t=1, options={'DeltaT': '1.1'})
create_companion(images=[i], out='planes.companion.ome')
```

The alternative is to define all these attributes explicitly in the constructor and the `Image.add_plane()` API. Feedback welcome.