### PR TITLE
ome-model: allow to introspect version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ target
 build
 dist
 ome_model.egg-info
-ome_model/version.py
+ome_model/__init__.py

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 build
 dist
 ome_model.egg-info
+ome_model/version.py

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -5,7 +5,7 @@ import re
 import sys
 import uuid
 import xml.etree.ElementTree as ET
-from .version import __version__
+from . import __version__
 
 OME_ATTRIBUTES = {
     'Creator': "ome_model %s" % __version__,

--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -5,9 +5,10 @@ import re
 import sys
 import uuid
 import xml.etree.ElementTree as ET
+from .version import __version__
 
 OME_ATTRIBUTES = {
-    'Creator': "ome_model/experimental.py",
+    'Creator': "ome_model %s" % __version__,
     'UUID': "urn:uuid:%s" % uuid.uuid4(),
     'xmlns': 'http://www.openmicroscopy.org/Schemas/OME/2016-06',
     'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def get_version():
 
 def write_version(version):
     with open('ome_model/version.py', 'w') as f:
-        f.write('__version__ = "%s"' % version)
+        f.write('__version__ = "%s"\n' % version)
 
 
 version = get_version()

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def get_version():
 
 
 def write_version(version):
-    with open('ome_model/version.py', 'w') as f:
+    with open('ome_model/__init__.py', 'w') as f:
         f.write('__version__ = "%s"\n' % version)
 
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
           'or later (GPLv2+)',
           'Natural Language :: English',
           'Operating System :: OS Independent',
-          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 3',
           'Topic :: Software Development :: Libraries :: Python Modules',
       ],  # Get strings from
           # http://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,13 @@ def get_version():
     return version.replace('-SNAPSHOT', '.dev0')
 
 
+def write_version(version):
+    with open('ome_model/version.py', 'w') as f:
+        f.write('__version__ = "%s"' % version)
+
+
 version = get_version()
+write_version(version)
 url = "https://github.com/ome/ome-model/"
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,7 @@ setup(
     classifiers=[
           'Development Status :: 2 - Pre-Alpha',
           'Intended Audience :: Developers',
-          'License :: OSI Approved :: GNU General Public License v2 '
-          'or later (GPLv2+)',
+          'License :: OSI Approved :: BSD License',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     description="Core OME model library (EXPERIMENTAL)",
     long_description="TBD",
     classifiers=[
-          'Development Status :: 2 - Pre-Alpha',
+          'Development Status :: 4 - Beta',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: BSD License',
           'Natural Language :: English',

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -25,7 +25,7 @@
 
 
 from ome_model.experimental import Image, create_companion
-from ome_model.version import __version__
+from ome_model import __version__
 import pytest
 import xml.etree.ElementTree as ElementTree
 

--- a/test/unit/test_image.py
+++ b/test/unit/test_image.py
@@ -25,11 +25,24 @@
 
 
 from ome_model.experimental import Image, create_companion
+from ome_model.version import __version__
 import pytest
 import xml.etree.ElementTree as ElementTree
 
 NS = {'OME': 'http://www.openmicroscopy.org/Schemas/OME/2016-06'}
 ElementTree.register_namespace('OME', NS['OME'])
+
+
+class TestOME(object):
+
+    def test_ome(self, tmpdir):
+        f = str(tmpdir.join('root.companion.ome'))
+
+        create_companion(out=f)
+
+        root = ElementTree.parse(f).getroot()
+        assert root.tag == '{%s}OME' % NS['OME']
+        assert root.attrib['Creator'] == 'ome_model %s' % __version__
 
 
 class TestImage(object):


### PR DESCRIPTION
Discussed with @manics and @joshmoore, this PR adds some logic to `setup.py` to write the current module version under `ome_model/version.py` using the `__version___` attribute - see https://www.python.org/dev/peps/pep-0396/. If `__init__.py` or another variable name is preferable, I have no strong opinion but I was not able to find a PEP authoritatively defining the recommended behavior.

The module is also updated to store `ome_model x.y.z[.dev0]` in the `OME.Creator` attribute similarly to the implementation in Bio-Formats - see https://github.com/ome/bioformats/pull/2207.