### PR TITLE
Convert Travis CI deployment into a build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ jobs:
       script:
         - ulimit -n 4096
         - tox -e py36
-
-deploy:
-  provider: pypi
-  user: $PYPI_USER
-  password: $PYPI_PASSWORD
-  distributions: sdist
-  on:
-    tags: true
-    python: "3.6"
+    - name: deploy
+      python: "3.6"
+      deploy:
+        provider: pypi
+        user: $PYPI_USER
+        password: $PYPI_PASSWORD
+        distributions: sdist
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ jobs:
       name: deploy
       python: "3.6"
       install: skip
+      script: skip
       deploy:
         provider: pypi
         user: $PYPI_USER

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,23 +17,27 @@ before_install: pip3 install --user -r requirements.txt
 jobs:
   fast_finish: true
   include:
-    - name: jdk8
+    - stage: test
+      name: jdk8
       language: java
       jdk: openjdk8
       install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dpython=python3
       script: mvn test -B -Dpython=python3
-    - name: JDK11
+    - stage: test
+      name: JDK11
       language: java
       jdk: openjdk11
       install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dpython=python3
       script: mvn test -B -Dpython=python3
-    - name: Python36
+    - stage: test
+      name: Python36
       python: "3.6"
       install: pip3 install --upgrade pip wheel pytest tox virtualenv
       script:
         - ulimit -n 4096
         - tox -e py36
-    - name: deploy
+    - stage: deploy
+      name: deploy
       python: "3.6"
       install: skip
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ jobs:
         - tox -e py36
     - name: deploy
       python: "3.6"
+      install: skip
       deploy:
         provider: pypi
         user: $PYPI_USER


### PR DESCRIPTION
The switch to build stages in #120 has broken the logic of the deployment stage so that `ome-model 6.2.0` was not automatically pushed to PyPI. This PR fixes the issue by moving the deployment to a dedicated build stage only executed on tags - see https://docs.travis-ci.com/user/build-stages/#build-stages-and-deployments

This re-uses most of the logic already implemented in https://github.com/ome/ome-zarr-py/blob/master/.travis.yml. https://travis-ci.org/github/sbesson/ome-model/jobs/727818756 also tests the conditional deployment logic (which failed due to the absence of credentials as expected)

Proposed tag `6.2.1`