### PR TITLE
OMEModelImpl: Do not permit the addition of null references

### DIFF
--- a/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
@@ -99,6 +99,9 @@ public class OMEModelImpl implements OMEModel {
    */
   @Override
   public boolean addReference(OMEModelObject a, Reference b) {
+    if (b == null) {
+      return false;
+    }
     List<Reference> bList = references.get(a);
     if (bList == null) {
       bList = new ArrayList<Reference>();


### PR DESCRIPTION
This is a small fix I was going to make for OME Files (see [MR !116](https://gitlab.com/codelibre/ome/ome-model/-/merge_requests/116/diffs?w=1)).  It prevents the addition of null references to the model which would cause problems later on when traversing the model data after the initial import.  Should not be seen in normal use, but it protects against unintentional incorrect use.  Returns a failure status as for other failure scenarios, so the caller will be notified the addition failed should they care to check.