### PR TITLE
ome-xml: java: Don't report unhandled links prematurely

### DIFF
--- a/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
+++ b/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
@@ -44,11 +44,18 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * @author callan
  *
  */
 public abstract class AbstractOMEModelObject implements OMEModelObject {
+
+  /** Logger for this class. */
+  protected static final Logger LOGGER =
+    LoggerFactory.getLogger(AbstractOMEModelObject.class);
 
   /* (non-Javadoc)
    * @see ome.xml.r201004.OMEModelObject#update(org.w3c.dom.Element, ome.xml.r201004.OMEModel)
@@ -82,6 +89,8 @@ public abstract class AbstractOMEModelObject implements OMEModelObject {
    */
   @Override
   public boolean link(Reference reference, OMEModelObject o) {
+    LOGGER.debug("{} unable to handle reference of type {} for {}",
+                 getClass(), reference.getClass(), o.getClass());
     return false;
   }
 

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -465,11 +465,6 @@ ${customUpdatePropertyContent[prop.name]}
 
   public boolean link(Reference reference, OMEModelObject o)
   {
-    boolean wasHandledBySuperClass = super.link(reference, o);
-    if (wasHandledBySuperClass)
-    {
-      return true;
-    }
 {% for prop in klass.properties.values() %}\
 {% if prop.isReference %}\
     if (reference instanceof ${prop.name})
@@ -493,8 +488,7 @@ ${customUpdatePropertyContent[prop.name]}
     }
 {% end %}\
 {% end %}\
-    LOGGER.debug("Unable to handle reference of type: {}", reference.getClass());
-    return false;
+    return super.link(reference, o);
   }
 {% if klass.langBaseType != 'Object' %}\
   // Element's text data getter


### PR DESCRIPTION
This PR is a second version of #81 but is Java-only and omits the C++ changes which are no longer applicable.  Please also see the discussion on that PR.

This PR corrects some long-standing issues in the Java reference processing implementation.

- `OMEModelObject::link` implementations always chained up to their parent before handling the linking themselves.  This works, but would result in the parent issuing a warning if it couldn't handle it, despite the child later handling the link.  We now chain up only if the child can't handle the link, and issue a warning right at the top if nothing handled it.  This solves a number of annoying Java model serialisation warnings which are completely bogus.

In effect, you will see that setting an `AnnotationRef` on `Detector` or any other element derived from `ManufacturerSpec` will no longer have `ManufacturerSpec::link` issue a bogus warning.  This applies to any model object which is derived from another model object, e.g. `LightSource`, where the reference is handled by the most derived type, or any derived type after the first, where the chaining up will trigger the spurious warning.

For OMERO import, this should remove a large number of the bogus import warnings related to OME-XML metadata which we have seen on e.g. the QA system and other channels over the last few years.  `LightSource` and `Shape` are notable culprits.

Testing:

- Run `tiffinfo` or `tiffcomment` on `test.ome.tiff`.  Check that you get three `AnnotationRef` elements linking to the three annotations, demonstrating that the reference processing and subsequent serialisation worked correctly.
- Check Java with a similar sample for C++ `metadata-formatwriter`, creating an `AnnotationRef` on `Detector` or similar.  You'll see the warnings go when built against this ome-model snapshot, but otherwise no other functional changes.