### PR TITLE
MetadataConverter: Fix dropping of WellAnnotationRefs during conversion

### DIFF
--- a/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
@@ -2301,7 +2301,7 @@ public final class MetadataConverter {
 
         int wellAnnotationRefCount = 0;
         try {
-          src.getWellAnnotationRefCount(i, q);
+          wellAnnotationRefCount = src.getWellAnnotationRefCount(i, q);
         }
         catch (NullPointerException e) { }
         for (int a=0; a<wellAnnotationRefCount; a++) {


### PR DESCRIPTION
Correctly initialise wellAnnotationRefCount.

This defect was found during static analysis of the source tree.  I will have several additional fixes to come, plus a number of performance and cosmetic improvements also picked up by the static analyser.

Testing: Try converting an OME-TIFF with `WellAnnotationRef`s.  You should see that they are stripped out during conversion.  Repeat with this PR.  You should find they are now correctly preserved.

Closes: #130 