### PR TITLE
OMEXMLModelEnum template: Correct exception handling

### DIFF
--- a/xsd-fu/templates/java/OMEXMLModelEnum.template
+++ b/xsd-fu/templates/java/OMEXMLModelEnum.template
@@ -136,10 +136,11 @@ public enum ${klass.langType} implements Enumeration
     {
       theQuantity = ${klass.langType}EnumHandler.getQuantity(newValue, newUnit);
     }
-    finally
+    catch (EnumerationException ignored)
     {
-      return theQuantity;
     }
+
+    return theQuantity;
   }
 
   public static <T extends Number> ${lang.typeToUnitsType(klass.langType)} create(T newValue, ${klass.langType} newUnit)
@@ -150,10 +151,11 @@ public enum ${klass.langType} implements Enumeration
     {
       theQuantity = ${klass.langType}EnumHandler.getQuantity(newValue, newUnit);
     }
-    finally
+    catch (EnumerationException ignored)
     {
-      return theQuantity;
     }
+
+    return theQuantity;
   }
 
 {% end %}\


### PR DESCRIPTION
Static analysis highlighted a bad use of `return` within a `finally` block.  This was indeed unnecessary and replaceable with an ignored `catch` block.

Testing: Nothing specific required; the effective code flow is unchanged with or without exceptions, but we no longer return from within a `finally` block.

Generated source changes: Download the diff from [here](https://gitlab.com/rleigh/ome-model/-/jobs/875962162) or generate the diff yourself.