### PR TITLE
Static analysis code remediation: xsd-fu Java templates

### DIFF
--- a/xsd-fu/python/ome/modeltools/property.py
+++ b/xsd-fu/python/ome/modeltools/property.py
@@ -483,9 +483,9 @@ class OMEModelProperty(OMEModelEntity):
 
         if isinstance(self.model.opts.lang, language.Java):
             if self.isReference and self.maxOccurs > 1:
-                idefault = "ReferenceList<%s>" % self.langType
+                idefault = "ReferenceList<>"
             elif self.isBackReference and self.maxOccurs > 1:
-                idefault = "ReferenceList<%s>" % self.langType
+                idefault = "ReferenceList<>"
             elif self.isBackReference:
                 idefault = None
             elif self.maxOccurs == 1 and (
@@ -494,7 +494,7 @@ class OMEModelProperty(OMEModelEntity):
                     not self.isChoice):
                 idefault = None
             elif self.maxOccurs > 1 and not self.parent.isAbstract:
-                idefault = "ArrayList<%s>" % self.langType
+                idefault = "ArrayList<>"
 
         return idefault
     instanceVariableDefault = property(

--- a/xsd-fu/templates/java/AggregateMetadata.template
+++ b/xsd-fu/templates/java/AggregateMetadata.template
@@ -256,7 +256,7 @@ public class AggregateMetadata implements IMetadata
   // -- Fields --
 
   /** The active metadata store delegates. */
-  private List<BaseMetadata> delegates;
+  private final List<BaseMetadata> delegates;
 
   // -- Constructor --
 

--- a/xsd-fu/templates/java/AggregateMetadata.template
+++ b/xsd-fu/templates/java/AggregateMetadata.template
@@ -14,9 +14,8 @@
 {% def counter(parent, obj, indexes) %}\
   public int get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}Count(${indexes_string(indexes[:-1])})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -33,9 +32,8 @@
 {% when len(indexes) > 0 and prop.maxOccurs > 1 %}\
   public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)}, ${index_string(prop.name)})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -49,9 +47,8 @@
 {% when len(indexes) > 0 %}\
   public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${indexes_string(indexes)})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -65,9 +62,8 @@
 {% otherwise %}\
   public ${prop.metadataStoreRetType} get{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}${prop.name}()
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -89,9 +85,8 @@
 {% end debug %}\
   public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         MetadataStore store = (MetadataStore) o;
@@ -106,9 +101,8 @@
 {% end debug %}\
   public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         MetadataStore store = (MetadataStore) o;
@@ -123,9 +117,8 @@
 {% end debug %}\
   public void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         MetadataStore store = (MetadataStore) o;
@@ -275,9 +268,8 @@ public class AggregateMetadata implements IMetadata
   /* @see MetadataStore#createRoot() */
   public void createRoot()
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         ((MetadataStore) o).createRoot();
@@ -309,8 +301,7 @@ public class AggregateMetadata implements IMetadata
   // -- Entity counting (manual definitions) --
 
   public int getBooleanAnnotationAnnotationCount(int booleanAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -322,8 +313,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getCommentAnnotationAnnotationCount(int commentAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -335,8 +325,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getDoubleAnnotationAnnotationCount(int doubleAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -348,8 +337,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getFileAnnotationAnnotationCount(int fileAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -361,8 +349,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getListAnnotationAnnotationCount(int listAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -374,8 +361,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getLongAnnotationAnnotationCount(int longAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -387,8 +373,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getMapAnnotationAnnotationCount(int mapAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -400,8 +385,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getTagAnnotationAnnotationCount(int tagAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -413,8 +397,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getTermAnnotationAnnotationCount(int termAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -427,8 +410,7 @@ public class AggregateMetadata implements IMetadata
 
   public int getTimestampAnnotationAnnotationCount(int timestampAnnotationIndex)
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result = retrieve.getTimestampAnnotationAnnotationCount(
@@ -440,8 +422,7 @@ public class AggregateMetadata implements IMetadata
   }
 
   public int getXMLAnnotationAnnotationCount(int xmlAnnotationIndex) {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -459,9 +440,8 @@ public class AggregateMetadata implements IMetadata
 {% for k, v in indexes[abstractClass].items() %}\
   public String get${abstractClass}Type(${indexes_string(v)})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -474,8 +454,7 @@ public class AggregateMetadata implements IMetadata
 
   public int get{% if is_multi_path[abstractClass] %}${k}{% end %}${abstractClass}Count(${indexes_string(v[:-1])})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();) {
-      Object o = iter.next();
+    for (Object o : delegates) {
       if (o instanceof MetadataRetrieve) {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
         int result =
@@ -498,9 +477,8 @@ public class AggregateMetadata implements IMetadata
 {% end debug %}\
   public void set${o.name}Value(${o.langBaseType} value, ${indexes_string(list(indexes[o.name].values())[0])})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         ((MetadataStore) o).set${o.name}Value(value, ${indexes_name_string(list(indexes[o.name].values())[0])});
@@ -510,9 +488,8 @@ public class AggregateMetadata implements IMetadata
 
   public ${o.langBaseType} get${o.name}Value(${indexes_string(list(indexes[o.name].values())[0])})
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         ${o.langBaseType} result = ((MetadataRetrieve) o).get${o.name}Value(${indexes_name_string(list(indexes[o.name].values())[0])});
@@ -542,9 +519,8 @@ ${counter(k, o, v)}\
   /** Gets the UUID associated with this collection of metadata. */
   public String getUUID()
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -574,9 +550,8 @@ ${counter(k, o, v)}\
   /** Gets the Map value associated with this annotation */
   public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -590,9 +565,8 @@ ${counter(k, o, v)}\
   /** Gets the Map value associated with this generic light source */
   public List<MapPair> getGenericExcitationSourceMap(int instrumentIndex, int lightSourceIndex)
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -606,9 +580,8 @@ ${counter(k, o, v)}\
   /** Gets the Map value associated with this imaging environment */
   public List<MapPair> getImagingEnvironmentMap(int imageIndex)
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataRetrieve)
       {
         MetadataRetrieve retrieve = (MetadataRetrieve) o;
@@ -711,9 +684,8 @@ ${getter(k, o, prop, v)}\
   /** Sets the UUID associated with this collection of metadata. */
   public void setUUID(String uuid)
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         ((MetadataStore) o).setUUID(uuid);
@@ -737,9 +709,8 @@ ${getter(k, o, prop, v)}\
   /** Sets the Map value associated with this annotation */
   public void setMapAnnotationValue(List<MapPair> value, int mapAnnotationIndex)
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         MetadataStore store = (MetadataStore) o;
@@ -751,9 +722,8 @@ ${getter(k, o, prop, v)}\
   /** Sets the Map value associated with this generic light source */
   public void setGenericExcitationSourceMap(List<MapPair> map, int instrumentIndex, int lightSourceIndex)
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         MetadataStore store = (MetadataStore) o;
@@ -765,9 +735,8 @@ ${getter(k, o, prop, v)}\
   /** Sets the Map value associated with this imaging environment */
   public void setImagingEnvironmentMap(List<MapPair> map, int imageIndex)
   {
-    for (Iterator iter = delegates.iterator(); iter.hasNext();)
+    for (Object o : delegates)
     {
-      Object o = iter.next();
       if (o instanceof MetadataStore)
       {
         MetadataStore store = (MetadataStore) o;

--- a/xsd-fu/templates/java/FilterMetadata.template
+++ b/xsd-fu/templates/java/FilterMetadata.template
@@ -170,9 +170,9 @@ public class FilterMetadata implements MetadataStore
   // -- Fields --
 
   /** The wrapped metadata store. */
-  private MetadataStore store;
+  private final MetadataStore store;
   /** Is filtering enabled? */
-  private boolean filter;
+  private final boolean filter;
 
   // -- Constructor --
 

--- a/xsd-fu/templates/java/MetadataRetrieve.template
+++ b/xsd-fu/templates/java/MetadataRetrieve.template
@@ -377,7 +377,6 @@ public interface MetadataRetrieve extends BaseMetadata {
    *
    * @return the UUID.
    */
-  /** Gets the UUID associated with this collection of metadata. */
   String getUUID();
 
   /**

--- a/xsd-fu/templates/java/OMEXMLMetadataImpl.template
+++ b/xsd-fu/templates/java/OMEXMLMetadataImpl.template
@@ -415,7 +415,7 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
 {% for k, v in indexes[abstractClass].items() %}\
   public String get${abstractClass}Type(${indexes_string(v)})
   {
-    ${abstractClass} o = (${abstractClass}) root.${".".join(basic_accessor(abstractClass))};
+    ${abstractClass} o = root.${".".join(basic_accessor(abstractClass))};
     String className = o.getClass().getName();
     return className.substring(
       className.lastIndexOf('.') + 1, className.length());

--- a/xsd-fu/templates/java/OMEXMLMetadataImpl.template
+++ b/xsd-fu/templates/java/OMEXMLMetadataImpl.template
@@ -418,7 +418,7 @@ public class OMEXMLMetadataImpl extends AbstractOMEXMLMetadata
     ${abstractClass} o = root.${".".join(basic_accessor(abstractClass))};
     String className = o.getClass().getName();
     return className.substring(
-      className.lastIndexOf('.') + 1, className.length());
+      className.lastIndexOf('.') + 1);
   }
 {% end %}\
 {% end %}\

--- a/xsd-fu/templates/java/OMEXMLModelEnum.template
+++ b/xsd-fu/templates/java/OMEXMLModelEnum.template
@@ -45,20 +45,15 @@
 
 package ${lang.omexml_model_enums_package};
 
-
-import ${lang.units_package}.quantity.Angle;
-import ${lang.units_package}.quantity.ElectricPotential;
-import ${lang.units_package}.quantity.Frequency;
-import ${lang.units_package}.quantity.Length;
-import ${lang.units_package}.quantity.Power;
-import ${lang.units_package}.quantity.Pressure;
-import ${lang.units_package}.quantity.Temperature;
-import ${lang.units_package}.quantity.${lang.typeToUnitsType("UnitsTime")};
-import ${lang.units_package}.unit.Unit;
-
+{% if klass.isUnitsEnumeration %}\
 import ${lang.omexml_model_omexml_model_enum_handlers_package}.${klass.langType}EnumHandler;
 import ome.xml.model.primitives.*;
+import ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)};
+import ome.units.unit.Unit;
+import ome.units.UNITS;
+{% end if klass.isUnitsEnumeration %}\
 
+@SuppressWarnings("SpellCheckingInspection")
 public enum ${klass.langType} implements Enumeration
 {
 {% for value in klass.possibleValues %}\

--- a/xsd-fu/templates/java/OMEXMLModelEnum.template
+++ b/xsd-fu/templates/java/OMEXMLModelEnum.template
@@ -82,11 +82,17 @@ public enum ${klass.langType} implements Enumeration
 {% end %}\
 {% end %}\
 
+{% if len(klass.possibleValues) == 1 %}\
+  @SuppressWarnings("SameParameterValue")
+{% end %}\
   ${klass.langType}(String value)
   {
     this.value = value;
   }
 
+{% if len(klass.possibleValues) == 1 %}\
+  @SuppressWarnings({"SameParameterValue", "SameReturnValue"})
+{% end %}\
   public static ${klass.langType} fromString(String value)
     throws EnumerationException
   {
@@ -110,6 +116,7 @@ public enum ${klass.langType} implements Enumeration
     throw new EnumerationException(s);
   }
 
+  @SuppressWarnings("unused")
   public String getValue()
   {
     return value;

--- a/xsd-fu/templates/java/OMEXMLModelEnum.template
+++ b/xsd-fu/templates/java/OMEXMLModelEnum.template
@@ -82,7 +82,7 @@ public enum ${klass.langType} implements Enumeration
 {% end %}\
 {% end %}\
 
-  private ${klass.langType}(String value)
+  ${klass.langType}(String value)
   {
     this.value = value;
   }

--- a/xsd-fu/templates/java/OMEXMLModelEnumHandler.template
+++ b/xsd-fu/templates/java/OMEXMLModelEnumHandler.template
@@ -85,7 +85,7 @@ public class ${klass.langType}EnumHandler implements IEnumerationHandler {
   private static final Hashtable<String, String> patterns = makePatterns();
 
   private static Hashtable<String, String> makePatterns() {
-    Hashtable<String, String> p = new Hashtable<String, String>();
+    Hashtable<String, String> p = new Hashtable<>();
     // BEGIN Schema enumeration mappings
 {% for value in klass.possibleValues %}\
     p.put("^\\\s*${value}\\\s*", "${value}");

--- a/xsd-fu/templates/java/OMEXMLModelEnumHandler.template
+++ b/xsd-fu/templates/java/OMEXMLModelEnumHandler.template
@@ -144,10 +144,15 @@ public class ${klass.langType}EnumHandler implements IEnumerationHandler {
     theResult = ${klass.model.opts.lang.typeToDefault(klass.langType)};
 {% for value in klass.possibleValues %}\
 {% if klass.enumProperties is not None and value in klass.enumProperties and klass.enumProperties[value].get('enum', None) is not None %}\
+{% if klass.model.opts.lang.typeToDefault(klass.langType) != "UNITS.{}".format(klass.enumProperties[value].enum) %}\
     if (${klass.langType}.${klass.enumProperties[value].enum}.equals(inModelUnit))
     {
       theResult = UNITS.${klass.enumProperties[value].enum};
     }
+{% end %}\
+{% if klass.model.opts.lang.typeToDefault(klass.langType) == "UNITS.{}".format(klass.enumProperties[value].enum) %}\
+    // Skip default unit ${klass.enumProperties[value].enum}
+{% end %}\
 {% end %}\
 {% if klass.enumProperties is None or not value in klass.enumProperties or klass.enumProperties[value].get('enum', None) is None %}\
     if (${klass.langType}.${enum_value_name(value, klass.isUnitsEnumeration).upper()}.equals(inModelUnit))

--- a/xsd-fu/templates/java/OMEXMLModelEnumHandler.template
+++ b/xsd-fu/templates/java/OMEXMLModelEnumHandler.template
@@ -131,6 +131,7 @@ public class ${klass.langType}EnumHandler implements IEnumerationHandler {
 
 {% if klass.isUnitsEnumeration %}\
 {% if lang.units_implementation_is == "ome" %}
+  @SuppressWarnings("unused")
   public Enumeration getEnumeration(${klass.model.opts.lang.typeToUnitsType(klass.langType)} inUnit)
     throws EnumerationException {
     return getEnumeration(inUnit.unit().getSymbol());

--- a/xsd-fu/templates/java/OMEXMLModelEnumHandler.template
+++ b/xsd-fu/templates/java/OMEXMLModelEnumHandler.template
@@ -54,19 +54,13 @@ import ${lang.omexml_model_enums_package}.Enumeration;
 import ${lang.omexml_model_enums_package}.EnumerationException;
 import ${lang.omexml_model_enums_package}.${klass.langType};
 
-import ${lang.units_package}.quantity.Angle;
-import ${lang.units_package}.quantity.ElectricPotential;
-import ${lang.units_package}.quantity.Frequency;
-import ${lang.units_package}.quantity.Length;
-import ${lang.units_package}.quantity.Power;
-import ${lang.units_package}.quantity.Pressure;
-import ${lang.units_package}.quantity.Temperature;
-import ${lang.units_package}.quantity.${lang.typeToUnitsType("UnitsTime")};
-import ${lang.units_package}.unit.Unit;
-
+{% if klass.isUnitsEnumeration %}\
 import ome.xml.model.primitives.*;
+import ome.units.quantity.${klass.model.opts.lang.typeToUnitsType(klass.langType)};
+import ome.units.unit.Unit;
+import ome.units.UNITS;
+{% end if klass.isUnitsEnumeration %}\
 
-${lang.units_implementation_imports}
 
 /**
  * Enumeration handler for ${klass.langType}.

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -526,6 +526,7 @@ ${customUpdatePropertyContent[prop.name]}
     return ${prop.instanceVariableName}.set(index, o);
   }
 
+  @SuppressWarnings("UnusedReturnValue")
   public boolean link${prop.methodName}(${prop.langType} o)
   {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\
@@ -540,6 +541,7 @@ ${customUpdatePropertyContent[prop.name]}
     return ${prop.instanceVariableName}.add(o);
   }
 
+  @SuppressWarnings("UnusedReturnValue")
   public boolean unlink${prop.methodName}(${prop.langType} o)
   {
 {% if not prop.isBackReference and not fu.link_overridden(prop.name, klass.name) %}\

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -227,7 +227,6 @@ ${customContent}\
 {% end if klass.langBaseType == 'String' %}\
     }
 {% end %}\
-    String tagName = element.getTagName();
 {% for prop in klass.properties.values() %}\
 {% choose %}\
 {% when prop.name in customUpdatePropertyContent %}\

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -592,6 +592,7 @@ ${customUpdatePropertyContent[prop.name]}
   // Attribute property which is Units enumeration ${prop.name}
 {% end debug %}\
   // Property ${prop.name} is a unit companion
+  @SuppressWarnings("SameReturnValue")
   public static String get${prop.methodName}XsdDefault()
   {
     return "${prop.defaultXsdValue}";

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -69,19 +69,11 @@ import org.w3c.dom.NodeList;
 import java.util.Base64;
 
 {% end %}\
-import ${lang.units_package}.quantity.Angle;
-import ${lang.units_package}.quantity.ElectricPotential;
-import ${lang.units_package}.quantity.Frequency;
-import ${lang.units_package}.quantity.Length;
-import ${lang.units_package}.quantity.Power;
-import ${lang.units_package}.quantity.Pressure;
-import ${lang.units_package}.quantity.Temperature;
-import ${lang.units_package}.quantity.${lang.typeToUnitsType("UnitsTime")};
-import ${lang.units_package}.unit.Unit;
-
 import ${lang.omexml_model_enums_package}.*;
 import ${lang.omexml_model_enums_package}.handlers.*;
 import ${lang.omexml_model_package}.primitives.*;
+import ${lang.units_package}.quantity.*;
+import ${lang.units_package}.unit.Unit;
 
 {% choose %}\
 {% when klass.isAbstract %}\

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -219,7 +219,12 @@ ${customContent}\
     // Element's text data
     String value_textContent = element.getTextContent();
     if (value_textContent.trim().length() > 0) {
+{% if klass.langBaseType != 'String' %}\
       value = ${klass.langBaseType}.valueOf(value_textContent);
+{% end if klass.langBaseType != 'String' %}\
+{% if klass.langBaseType == 'String' %}\
+      value = value_textContent;
+{% end if klass.langBaseType == 'String' %}\
     }
 {% end %}\
     String tagName = element.getTagName();

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -357,8 +357,7 @@ ${customUpdatePropertyContent[prop.name]}
       // Element property ${prop.name} which is complex (has
       // sub-elements)
 {% if prop.langTypeNS != 'List<MapPair>' %}\
-      set${prop.methodName}(new ${prop.langType}(
-        (Element) ${prop.name}_nodeList.get(0), model));
+      set${prop.methodName}(new ${prop.langType}(${prop.name}_nodeList.get(0), model));
 {% end %}\
 {% if prop.langTypeNS == 'List<MapPair>' %}\
       List<MapPair> p = new java.util.ArrayList<>();

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -368,7 +368,7 @@ ${customUpdatePropertyContent[prop.name]}
         (Element) ${prop.name}_nodeList.get(0), model));
 {% end %}\
 {% if prop.langTypeNS == 'List<MapPair>' %}\
-      List<MapPair> p = new java.util.ArrayList<MapPair>();
+      List<MapPair> p = new java.util.ArrayList<>();
       NodeList children = ${prop.name}_nodeList.get(0).getChildNodes();
 
       for (int i=0; i<children.getLength(); i++) {
@@ -521,7 +521,7 @@ ${customUpdatePropertyContent[prop.name]}
 
   public List<${prop.langType}> copyLinked${prop.methodName}List()
   {
-    return new ArrayList<${prop.langType}>(${prop.instanceVariableName});
+    return new ArrayList<>(${prop.instanceVariableName});
   }
 
   public ${prop.langType} getLinked${prop.methodName}(int index)
@@ -626,7 +626,7 @@ ${customUpdatePropertyContent[prop.name]}
 
   public List<${prop.langType}> copy${prop.methodName}List()
   {
-    return new ArrayList<${prop.langType}>(${prop.instanceVariableName});
+    return new ArrayList<>(${prop.instanceVariableName});
   }
 
   public ${prop.langType} get${prop.methodName}(int index)

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -683,7 +683,7 @@ ${customUpdatePropertyContent[prop.name]}
     super.asXMLElement(document, ${klass.name}_element);
 
 {% for prop in klass.properties.values() %}\
-{% if not prop.isUnitsEnumeration %}\
+{% if not prop.isUnitsEnumeration and not prop.isBackReference %}\
     if (${prop.instanceVariableName} != null)
     {
 {% choose %}\
@@ -738,9 +738,6 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% end if %}\
       o.asXMLElement(document, child);
       ${klass.name}_element.appendChild(child);
-{% end when %}\
-{% when prop.isBackReference %}\
-      // *** IGNORING *** Skipped back reference ${prop.name}
 {% end when %}\
 {% when prop.hasUnitsCompanion and prop.maxOccurs == 1 and prop.isAttribute %}\
 {% if debug %}\
@@ -846,7 +843,10 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% end otherwise %}\
 {% end choose %}\
     }
-{% end if %}\
+{% end if not prop.isUnitsEnumeration and not prop.isBackReference %}\
+{% if prop.isBackReference %}\
+    // *** IGNORING *** Skipped back reference ${prop.name}
+{% end if prop.isBackReference %}\
 {% end for %}\
 
     return ${klass.name}_element;

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -680,7 +680,12 @@ ${customUpdatePropertyContent[prop.name]}
 {% if klass.langBaseType != 'Object' %}\
     // Element's text data
     if (this.value != null) {
+{% if klass.langBaseType != 'String' %}\
       ${klass.name}_element.setTextContent(this.value.toString());
+{% end if %}\
+{% if klass.langBaseType == 'String' %}\
+      ${klass.name}_element.setTextContent(this.value);
+{% end if %}\
     }
 
 {% end if NOT Object %}\
@@ -704,7 +709,12 @@ ${customAsXMLElementPropertyContent[prop.name]}
 {% when prop.hasBaseAttribute %}\
       // Element's text data
 {% if not prop.type == 'base64Binary' %}\
+{% if prop.instanceVariableType != 'String' %}\
       ${klass.name}_element.setTextContent(${prop.instanceVariableName}.toString());
+{% end if %}\
+{% if prop.instanceVariableType == 'String' %}\
+      ${klass.name}_element.setTextContent(${prop.instanceVariableName});
+{% end if %}\
 {% end if not prop.type %}\
 {% if prop.type == 'base64Binary' %}\
       String encodedString = Base64.getEncoder().encodeToString(${prop.instanceVariableName});
@@ -775,7 +785,12 @@ ${customAsXMLElementPropertyContent[prop.name]}
       // MARKER [III]
 {% end debug %}\
       // Attribute property ${prop.name}
+{% if prop.instanceVariableType != 'String' %}\
       ${klass.name}_element.setAttribute("${prop.name}", ${prop.instanceVariableName}.toString());
+{% end if %}\
+{% if prop.instanceVariableType == 'String' %}\
+      ${klass.name}_element.setAttribute("${prop.name}", ${prop.instanceVariableName});
+{% end if %}\
 {% end when %}\
 {% when prop.maxOccurs == 1 and prop.isComplex() %}\
       // Element property ${prop.name} which is complex (has
@@ -810,7 +825,12 @@ ${customAsXMLElementPropertyContent[prop.name]}
     // sub-elements)
     Element ${prop.instanceVariableName}_element =
       document.createElementNS(NAMESPACE, "${prop.name}");
+{% if prop.instanceVariableType != 'String' %}\
       ${prop.instanceVariableName}_element.setTextContent(${prop.instanceVariableName}.toString());
+{% end if %}\
+{% if prop.instanceVariableType == 'String' %}\
+      ${prop.instanceVariableName}_element.setTextContent(${prop.instanceVariableName});
+{% end if %}\
       ${klass.name}_element.appendChild(${prop.instanceVariableName}_element);
 {% end when %}\
 {% when prop.maxOccurs > 1 and prop.isComplex() %}\

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -466,7 +466,9 @@ ${customUpdatePropertyContent[prop.name]}
 {% if prop.isReference %}\
     if (reference instanceof ${prop.name})
     {
+{% if prop.maxOccurs != 1 or not fu.link_overridden(prop.name, klass.name) %}\
       ${prop.langType} o_casted = (${prop.langType}) o;
+{% end %}\
 {% if not fu.link_overridden(prop.name, klass.name) %}\
 {% if not fu.backReference_overridden(prop.name, klass.name) %}\
       o_casted.link${klass.type}(this);
@@ -478,8 +480,11 @@ ${customUpdatePropertyContent[prop.name]}
 {% if prop.maxOccurs > 1 %}\
       ${prop.instanceVariableName}.add(o_casted);
 {% end %}\
-{% if prop.maxOccurs == 1 %}\
+{% if prop.maxOccurs == 1 and not fu.link_overridden(prop.name, klass.name) %}\
       ${prop.instanceVariableName} = o_casted;
+{% end %}\
+{% if prop.maxOccurs == 1 and fu.link_overridden(prop.name, klass.name) %}\
+      ${prop.instanceVariableName} = (${prop.langType}) o;
 {% end %}\
       return true;
     }

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -267,8 +267,8 @@ ${customUpdatePropertyContent[prop.name]}
     if (!element.hasAttribute("ID") && getID() == null)
     {
       // TODO: Should be its own exception
-      throw new RuntimeException(String.format(
-        "${klass.name} missing required ID property."));
+      throw new RuntimeException(
+        "${klass.name} missing required ID property.");
     }
     if (element.hasAttribute("ID"))
     {

--- a/xsd-fu/templates/java/OMEXMLModelObject.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject.template
@@ -315,10 +315,7 @@ ${customUpdatePropertyContent[prop.name]}
         ${prop.unitsCompanion.langType}.fromString(unitSymbol);
       ${prop.langType} baseValue = ${prop.langType}.valueOf(
         element.getAttribute("${prop.name}"));
-      if (baseValue != null)
-      {
-        set${prop.methodName}(${prop.unitsCompanion.langType}EnumHandler.getQuantity(baseValue, modelUnit));
-      }
+      set${prop.methodName}(${prop.unitsCompanion.langType}EnumHandler.getQuantity(baseValue, modelUnit));
     }
 {% end %}\
 {% when not prop.isEnumeration %}\

--- a/xsd-fu/templates/java/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
+++ b/xsd-fu/templates/java/OMEXMLModelObject_XMLAnnotation_asXMLElement_Value.template
@@ -1,4 +1,4 @@
-      Document Value_document = null;
+      Document Value_document;
       try
       {
         javax.xml.parsers.DocumentBuilderFactory factory =


### PR DESCRIPTION
Following static analysis of the ome-model source tree, the following remediation of the xsd-fu Java templates has been performed:

OME Model Object template:

* Removal of unnecessary casts
* Removal of unused variables
* Special-casing of `String` and numeric type member usage to remove unnecessary use of `toString` and `valueOf`
* Removal of special-cases which are never used
* Suppression of warnings for methods which are unused [within this source tree; many are used externally]

OME Model Enums and Handlers templates:

* Correction of double-assignment of units
* Suppression of unused method warnings [within this source tree; many are used externally]

OME Model Object and Enums templates:

* Use `<>` for generics where the type can be inferred
* Removal of unused imports

MetadataStore and MetadataRetrieve class templates:

* Addition of missing `final` qualifiers
* Javadoc comment fixes
* Use of new-style enhanced `for` loops
* Removal of unnecessary casts
* Correct usage of `lastIndexOf` to not use length

Total static analysis warnings fixed: **9042** (12303 before, 3261 after)

Testing:

The refactoring should not result in any behavioural changes.  All unit tests and integration tests should continue to pass.  There should be no compatibility changes for downstream consumers.

Generated source changes may be downloaded from [here](https://gitlab.com/rleigh/ome-model/-/jobs/879262844) or you can generate the diff yourself.

Review of the changes is [here](https://gitlab.com/codelibre/ome/ome-model/-/merge_requests/183#note_456663787).

If you would prefer to review these changes in a more fine-grained way, it can be split out into multiple PRs without any trouble.  None of the commits depend upon each other, so can be freely cherry-picked.