### PR TITLE
Static analysis code remediation: ome-xml and specification Java sources

### DIFF
--- a/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
+++ b/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
@@ -990,7 +990,7 @@ public class XMLMockObjects
     plate.setWellOriginY(new Length(1.0, UNITS.MICROMETER));
     plate.setStatus("Plate status");
     PlateAcquisition pa = null;
-    List<PlateAcquisition> pas = new ArrayList<PlateAcquisition>();
+    List<PlateAcquisition> pas = new ArrayList<>();
     int v;
     if (numberOfPlateAcquisition > 0) {
       for (int i = 0; i < numberOfPlateAcquisition; i++) {

--- a/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
+++ b/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
@@ -989,7 +989,7 @@ public class XMLMockObjects
     plate.setWellOriginX(new Length(0.0, UNITS.MICROMETER));
     plate.setWellOriginY(new Length(1.0, UNITS.MICROMETER));
     plate.setStatus("Plate status");
-    PlateAcquisition pa = null;
+    PlateAcquisition pa;
     List<PlateAcquisition> pas = new ArrayList<>();
     int v;
     if (numberOfPlateAcquisition > 0) {
@@ -1012,7 +1012,7 @@ public class XMLMockObjects
     Image image;
     int i = totalPlateIndex*rows*columns*fields*numberOfPlateAcquisition;
     Iterator<PlateAcquisition> k;
-    int kk = 0;
+    int kk;
     for (int row = 0; row < rows; row++) {
       for (int column = 0; column < columns; column++) {
         well = new Well();

--- a/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
+++ b/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
@@ -1474,31 +1474,27 @@ public class XMLMockObjects
     }
     List<Dichroic> dichroics = instrument.copyDichroicList();
     index = 0;
-    Iterator<Dichroic> j = dichroics.iterator();
-    while (j.hasNext()) {
-        j.next().setLinkedAnnotation(index, new LongAnnotation());
-        index++;
+    for (Dichroic dichroic : dichroics) {
+      dichroic.setLinkedAnnotation(index, new LongAnnotation());
+      index++;
     }
     List<Filter> filters = instrument.copyFilterList();
     index = 0;
-    Iterator<Filter> k = filters.iterator();
-    while (k.hasNext()) {
-        k.next().setLinkedAnnotation(index, new TermAnnotation());
-        index++;
+    for (Filter filter : filters) {
+      filter.setLinkedAnnotation(index, new TermAnnotation());
+      index++;
     }
     List<LightSource> lights = instrument.copyLightSourceList();
     index = 0;
-    Iterator<LightSource> l = lights.iterator();
-    while (l.hasNext()) {
-        l.next().setLinkedAnnotation(index, new DoubleAnnotation());
-        index++;
+    for (LightSource light : lights) {
+      light.setLinkedAnnotation(index, new DoubleAnnotation());
+      index++;
     }
     List<Objective> objectives = instrument.copyObjectiveList();
     index = 0;
-    Iterator<Objective> m = objectives.iterator();
-    while (m.hasNext()) {
-        m.next().setLinkedAnnotation(index,new MapAnnotation());
-        index++;
+    for (Objective objective : objectives) {
+      objective.setLinkedAnnotation(index, new MapAnnotation());
+      index++;
     }
     Image image = createImage(0, true);
     ObjectiveSettings settings = createObjectiveSettings(0);

--- a/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
+++ b/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
@@ -290,7 +290,7 @@ public class XMLMockObjects
   public static final Double CUT_OUT = 300.0;
 
   /** Root of the file. */
-  protected OME ome;
+  protected final OME ome;
 
   /** The instrument used for the metadata. */
   protected Instrument instrument;

--- a/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
+++ b/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
@@ -739,8 +739,8 @@ public class XMLMockObjects
       Mask m = new Mask();
       m.setX(0.0);
       m.setY(0.0);
-      m.setWidth(new Double(SIZE_X));
-      m.setHeight(new Double(SIZE_Y));
+      m.setWidth((double) SIZE_X);
+      m.setHeight((double) SIZE_Y);
       m.setBinData(createBinData(SIZE_X,SIZE_Y,BYTES_PER_PIXEL));
       shape = m;
     }

--- a/ome-xml/src/main/java/ome/specification/XMLWriter.java
+++ b/ome-xml/src/main/java/ome/specification/XMLWriter.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -221,7 +222,7 @@ public class XMLWriter
 				"{http://xml.apache.org/xslt}indent-amount", "4");
 		Source source = new DOMSource(document);
 		ByteArrayOutputStream os = new ByteArrayOutputStream();
-		Result result = new StreamResult(new OutputStreamWriter(os, "utf-8"));
+		Result result = new StreamResult(new OutputStreamWriter(os, StandardCharsets.UTF_8));
 		transformer.transform(source, result);
 		return os.toString();
 	}

--- a/ome-xml/src/main/java/ome/units/UNITS.java
+++ b/ome-xml/src/main/java/ome/units/UNITS.java
@@ -51,6 +51,7 @@ import java.math.BigInteger;
  */
 public final class UNITS
 {
+  @SuppressWarnings("SameReturnValue")
   public String getName()
   {
     return "OME-combined";

--- a/ome-xml/src/main/java/ome/units/UNITS.java
+++ b/ome-xml/src/main/java/ome/units/UNITS.java
@@ -57,15 +57,15 @@ public final class UNITS
   }
 
   // Definitions of units that others are calculated from
-  public static final ome.units.unit.Unit<Angle>             RADIAN  = ome.units.unit.Unit.<Angle>CreateBaseUnit("SI.RADIAN", "rad");
-  public static final ome.units.unit.Unit<ElectricPotential> VOLT    = ome.units.unit.Unit.<ElectricPotential>CreateBaseUnit("SI.VOLT", "V");
-  public static final ome.units.unit.Unit<Frequency>         HERTZ   = ome.units.unit.Unit.<Frequency>CreateBaseUnit("SI.HERTZ", "Hz");
-  public static final ome.units.unit.Unit<Length>            METRE   = ome.units.unit.Unit.<Length>CreateBaseUnit("SI.METRE", "m");
+  public static final ome.units.unit.Unit<Angle>             RADIAN  = ome.units.unit.Unit.CreateBaseUnit("SI.RADIAN", "rad");
+  public static final ome.units.unit.Unit<ElectricPotential> VOLT    = ome.units.unit.Unit.CreateBaseUnit("SI.VOLT", "V");
+  public static final ome.units.unit.Unit<Frequency>         HERTZ   = ome.units.unit.Unit.CreateBaseUnit("SI.HERTZ", "Hz");
+  public static final ome.units.unit.Unit<Length>            METRE   = ome.units.unit.Unit.CreateBaseUnit("SI.METRE", "m");
   public static final ome.units.unit.Unit<Length>            INCH    = METRE.multiply(0.0254).setSymbol("in");
-  public static final ome.units.unit.Unit<Power>             WATT    = ome.units.unit.Unit.<Power>CreateBaseUnit("SI.WATT", "W");
-  public static final ome.units.unit.Unit<Pressure>          PASCAL  = ome.units.unit.Unit.<Pressure>CreateBaseUnit("SI.PASCAL", "Pa");
-  public static final ome.units.unit.Unit<Temperature>       KELVIN  = ome.units.unit.Unit.<Temperature>CreateBaseUnit("SI.KELVIN", "K");
-  public static final ome.units.unit.Unit<Time>              SECOND  = ome.units.unit.Unit.<Time>CreateBaseUnit("SI.SECOND", "s");
+  public static final ome.units.unit.Unit<Power>             WATT    = ome.units.unit.Unit.CreateBaseUnit("SI.WATT", "W");
+  public static final ome.units.unit.Unit<Pressure>          PASCAL  = ome.units.unit.Unit.CreateBaseUnit("SI.PASCAL", "Pa");
+  public static final ome.units.unit.Unit<Temperature>       KELVIN  = ome.units.unit.Unit.CreateBaseUnit("SI.KELVIN", "K");
+  public static final ome.units.unit.Unit<Time>              SECOND  = ome.units.unit.Unit.CreateBaseUnit("SI.SECOND", "s");
 
   // functions to provide standard SI scaling
   public static <T extends Quantity> ome.units.unit.Unit<T> YOTTA(ome.units.unit.Unit<T> inUnit){return inUnit.prefixSymbol( "Y").multiply(BigInteger.TEN.pow(24).doubleValue());}
@@ -276,8 +276,8 @@ public final class UNITS
   public static final ome.units.unit.Unit<Length> LIGHTYEAR =        PETA(METRE.multiply(9.4607304725808)).setSymbol("ly");
   public static final ome.units.unit.Unit<Length> PARSEC =           GIGA(METRE.multiply(30856776)).setSymbol("pc"); // APPROXIMATE 3.0856776×10^16 m, exact would be UA.divide(tan(DEGREE.divide(3600)))
   public static final ome.units.unit.Unit<Length> POINT =            INCH.divide(72).setSymbol("pt");
-  public static final ome.units.unit.Unit<Length> PIXEL =            ome.units.unit.Unit.<Length>CreateBaseUnit("Pixel", "pixel");
-  public static final ome.units.unit.Unit<Length> REFERENCEFRAME =   ome.units.unit.Unit.<Length>CreateBaseUnit("ReferenceFrame", "reference frame");
+  public static final ome.units.unit.Unit<Length> PIXEL =            ome.units.unit.Unit.CreateBaseUnit("Pixel", "pixel");
+  public static final ome.units.unit.Unit<Length> REFERENCEFRAME =   ome.units.unit.Unit.CreateBaseUnit("ReferenceFrame", "reference frame");
 
   // Deprecated old names
   /**

--- a/ome-xml/src/main/java/ome/units/quantity/Angle.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Angle.java
@@ -158,16 +158,15 @@ public class Angle extends Quantity implements Comparable<Angle>
   @Override
   public String toString()
   {
-    StringBuilder result = new StringBuilder();
-    result.append(this.getClass().getName());
-    result.append(": ");
-    result.append("value[");
-    result.append(value);
-    result.append("], unit[");
-    result.append(unit.getSymbol());
-    result.append("] stored as ");
-    result.append(value.getClass().getName());
-    return result.toString();
+    String result = this.getClass().getName() +
+            ": " +
+            "value[" +
+            value +
+            "], unit[" +
+            unit.getSymbol() +
+            "] stored as " +
+            value.getClass().getName();
+    return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Angle.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Angle.java
@@ -158,7 +158,7 @@ public class Angle extends Quantity implements Comparable<Angle>
   @Override
   public String toString()
   {
-    String result = this.getClass().getName() +
+    return this.getClass().getName() +
             ": " +
             "value[" +
             value +
@@ -166,7 +166,6 @@ public class Angle extends Quantity implements Comparable<Angle>
             unit.getSymbol() +
             "] stored as " +
             value.getClass().getName();
-    return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/ElectricPotential.java
+++ b/ome-xml/src/main/java/ome/units/quantity/ElectricPotential.java
@@ -158,16 +158,15 @@ public class ElectricPotential extends Quantity implements Comparable<ElectricPo
   @Override
   public String toString()
   {
-    StringBuilder result = new StringBuilder();
-    result.append(this.getClass().getName());
-    result.append(": ");
-    result.append("value[");
-    result.append(value);
-    result.append("], unit[");
-    result.append(unit.getSymbol());
-    result.append("] stored as ");
-    result.append(value.getClass().getName());
-    return result.toString();
+    String result = this.getClass().getName() +
+            ": " +
+            "value[" +
+            value +
+            "], unit[" +
+            unit.getSymbol() +
+            "] stored as " +
+            value.getClass().getName();
+    return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/ElectricPotential.java
+++ b/ome-xml/src/main/java/ome/units/quantity/ElectricPotential.java
@@ -158,7 +158,7 @@ public class ElectricPotential extends Quantity implements Comparable<ElectricPo
   @Override
   public String toString()
   {
-    String result = this.getClass().getName() +
+    return this.getClass().getName() +
             ": " +
             "value[" +
             value +
@@ -166,7 +166,6 @@ public class ElectricPotential extends Quantity implements Comparable<ElectricPo
             unit.getSymbol() +
             "] stored as " +
             value.getClass().getName();
-    return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Frequency.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Frequency.java
@@ -158,16 +158,15 @@ public class Frequency extends Quantity implements Comparable<Frequency>
   @Override
   public String toString()
   {
-    StringBuilder result = new StringBuilder();
-    result.append(this.getClass().getName());
-    result.append(": ");
-    result.append("value[");
-    result.append(value);
-    result.append("], unit[");
-    result.append(unit.getSymbol());
-    result.append("] stored as ");
-    result.append(value.getClass().getName());
-    return result.toString();
+    String result = this.getClass().getName() +
+            ": " +
+            "value[" +
+            value +
+            "], unit[" +
+            unit.getSymbol() +
+            "] stored as " +
+            value.getClass().getName();
+    return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Frequency.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Frequency.java
@@ -158,7 +158,7 @@ public class Frequency extends Quantity implements Comparable<Frequency>
   @Override
   public String toString()
   {
-    String result = this.getClass().getName() +
+    return this.getClass().getName() +
             ": " +
             "value[" +
             value +
@@ -166,7 +166,6 @@ public class Frequency extends Quantity implements Comparable<Frequency>
             unit.getSymbol() +
             "] stored as " +
             value.getClass().getName();
-    return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Length.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Length.java
@@ -158,7 +158,7 @@ public class Length extends Quantity implements Comparable<Length>
   @Override
   public String toString()
   {
-    String result = this.getClass().getName() +
+    return this.getClass().getName() +
             ": " +
             "value[" +
             value +
@@ -166,7 +166,6 @@ public class Length extends Quantity implements Comparable<Length>
             unit.getSymbol() +
             "] stored as " +
             value.getClass().getName();
-    return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Length.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Length.java
@@ -158,16 +158,15 @@ public class Length extends Quantity implements Comparable<Length>
   @Override
   public String toString()
   {
-    StringBuilder result = new StringBuilder();
-    result.append(this.getClass().getName());
-    result.append(": ");
-    result.append("value[");
-    result.append(value);
-    result.append("], unit[");
-    result.append(unit.getSymbol());
-    result.append("] stored as ");
-    result.append(value.getClass().getName());
-    return result.toString();
+    String result = this.getClass().getName() +
+            ": " +
+            "value[" +
+            value +
+            "], unit[" +
+            unit.getSymbol() +
+            "] stored as " +
+            value.getClass().getName();
+    return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Power.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Power.java
@@ -158,7 +158,7 @@ public class Power extends Quantity implements Comparable<Power>
   @Override
   public String toString()
   {
-      String result = this.getClass().getName() +
+      return this.getClass().getName() +
               ": " +
               "value[" +
               value +
@@ -166,7 +166,6 @@ public class Power extends Quantity implements Comparable<Power>
               unit.getSymbol() +
               "] stored as " +
               value.getClass().getName();
-      return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Power.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Power.java
@@ -158,16 +158,15 @@ public class Power extends Quantity implements Comparable<Power>
   @Override
   public String toString()
   {
-    StringBuilder result = new StringBuilder();
-    result.append(this.getClass().getName());
-    result.append(": ");
-    result.append("value[");
-    result.append(value);
-    result.append("], unit[");
-    result.append(unit.getSymbol());
-    result.append("] stored as ");
-    result.append(value.getClass().getName());
-    return result.toString();
+      String result = this.getClass().getName() +
+              ": " +
+              "value[" +
+              value +
+              "], unit[" +
+              unit.getSymbol() +
+              "] stored as " +
+              value.getClass().getName();
+      return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Pressure.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Pressure.java
@@ -158,16 +158,15 @@ public class Pressure extends Quantity implements Comparable<Pressure>
   @Override
   public String toString()
   {
-    StringBuilder result = new StringBuilder();
-    result.append(this.getClass().getName());
-    result.append(": ");
-    result.append("value[");
-    result.append(value);
-    result.append("], unit[");
-    result.append(unit.getSymbol());
-    result.append("] stored as ");
-    result.append(value.getClass().getName());
-    return result.toString();
+      String result = this.getClass().getName() +
+              ": " +
+              "value[" +
+              value +
+              "], unit[" +
+              unit.getSymbol() +
+              "] stored as " +
+              value.getClass().getName();
+      return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Pressure.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Pressure.java
@@ -158,7 +158,7 @@ public class Pressure extends Quantity implements Comparable<Pressure>
   @Override
   public String toString()
   {
-      String result = this.getClass().getName() +
+      return this.getClass().getName() +
               ": " +
               "value[" +
               value +
@@ -166,7 +166,6 @@ public class Pressure extends Quantity implements Comparable<Pressure>
               unit.getSymbol() +
               "] stored as " +
               value.getClass().getName();
-      return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Temperature.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Temperature.java
@@ -158,7 +158,7 @@ public class Temperature extends Quantity implements Comparable<Temperature>
   @Override
   public String toString()
   {
-      String result = this.getClass().getName() +
+      return this.getClass().getName() +
               ": " +
               "value[" +
               value +
@@ -166,7 +166,6 @@ public class Temperature extends Quantity implements Comparable<Temperature>
               unit.getSymbol() +
               "] stored as " +
               value.getClass().getName();
-      return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Temperature.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Temperature.java
@@ -158,16 +158,15 @@ public class Temperature extends Quantity implements Comparable<Temperature>
   @Override
   public String toString()
   {
-    StringBuilder result = new StringBuilder();
-    result.append(this.getClass().getName());
-    result.append(": ");
-    result.append("value[");
-    result.append(value);
-    result.append("], unit[");
-    result.append(unit.getSymbol());
-    result.append("] stored as ");
-    result.append(value.getClass().getName());
-    return result.toString();
+      String result = this.getClass().getName() +
+              ": " +
+              "value[" +
+              value +
+              "], unit[" +
+              unit.getSymbol() +
+              "] stored as " +
+              value.getClass().getName();
+      return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Time.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Time.java
@@ -158,7 +158,7 @@ public class Time extends Quantity implements Comparable<Time>
   @Override
   public String toString()
   {
-      String result = this.getClass().getName() +
+      return this.getClass().getName() +
               ": " +
               "value[" +
               value +
@@ -166,7 +166,6 @@ public class Time extends Quantity implements Comparable<Time>
               unit.getSymbol() +
               "] stored as " +
               value.getClass().getName();
-      return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/quantity/Time.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Time.java
@@ -158,16 +158,15 @@ public class Time extends Quantity implements Comparable<Time>
   @Override
   public String toString()
   {
-    StringBuilder result = new StringBuilder();
-    result.append(this.getClass().getName());
-    result.append(": ");
-    result.append("value[");
-    result.append(value);
-    result.append("], unit[");
-    result.append(unit.getSymbol());
-    result.append("] stored as ");
-    result.append(value.getClass().getName());
-    return result.toString();
+      String result = this.getClass().getName() +
+              ": " +
+              "value[" +
+              value +
+              "], unit[" +
+              unit.getSymbol() +
+              "] stored as " +
+              value.getClass().getName();
+      return result;
   }
 
   @Override

--- a/ome-xml/src/main/java/ome/units/unit/Unit.java
+++ b/ome-xml/src/main/java/ome/units/unit/Unit.java
@@ -134,8 +134,7 @@ public class Unit<Q extends Quantity>
         inUnit.measurementSystem +
         "]");
     }
-    Double theResult = (((inValue.doubleValue()*scaleFactor)+offset)-inUnit.offset)/inUnit.scaleFactor;
-    return theResult;
+    return (((inValue.doubleValue()*scaleFactor)+offset)-inUnit.offset)/inUnit.scaleFactor;
   }
 
   // Begin "protected" functions

--- a/ome-xml/src/main/java/ome/units/unit/Unit.java
+++ b/ome-xml/src/main/java/ome/units/unit/Unit.java
@@ -153,7 +153,7 @@ public class Unit<Q extends Quantity>
   {
     Double newScaleFactor = scaleFactor * scalar;
     Double newOffset = offset * scalar;
-    return new Unit<Q>(measurementSystem, symbol, newScaleFactor, newOffset);
+    return new Unit<>(measurementSystem, symbol, newScaleFactor, newOffset);
   }
   /**
    * Multiply the scaling conversion factor in this unit by a scalar.
@@ -165,7 +165,7 @@ public class Unit<Q extends Quantity>
   {
     Double newScaleFactor = scaleFactor * scalar;
     Double newOffset = offset * scalar;
-    return new Unit<Q>(measurementSystem, symbol, newScaleFactor, newOffset);
+    return new Unit<>(measurementSystem, symbol, newScaleFactor, newOffset);
   }
   /**
    * Divide the scaling conversion factor in this unit by a scalar.
@@ -177,7 +177,7 @@ public class Unit<Q extends Quantity>
   {
     Double newScaleFactor = scaleFactor / scalar;
     Double newOffset = offset / scalar;
-    return new Unit<Q>(measurementSystem, symbol, newScaleFactor, newOffset);
+    return new Unit<>(measurementSystem, symbol, newScaleFactor, newOffset);
   }
   /**
    * Divide the scaling conversion factor in this unit by a scalar.
@@ -189,7 +189,7 @@ public class Unit<Q extends Quantity>
   {
     Double newScaleFactor = scaleFactor / scalar;
     Double newOffset = offset / scalar;
-    return new Unit<Q>(measurementSystem, symbol, newScaleFactor, newOffset);
+    return new Unit<>(measurementSystem, symbol, newScaleFactor, newOffset);
   }
   /**
    * Increase the scaling offset in this unit by a scalar.
@@ -200,7 +200,7 @@ public class Unit<Q extends Quantity>
   public Unit<Q> add(Integer scalar)
   {
     Double newOffset = offset + scalar;
-    return new Unit<Q>(measurementSystem, symbol, scaleFactor, newOffset);
+    return new Unit<>(measurementSystem, symbol, scaleFactor, newOffset);
   }
   /**
    * Increase the scaling offset in this unit by a scalar.
@@ -211,7 +211,7 @@ public class Unit<Q extends Quantity>
   public Unit<Q> add(Double scalar)
   {
     Double newOffset = offset + scalar;
-    return new Unit<Q>(measurementSystem, symbol, scaleFactor, newOffset);
+    return new Unit<>(measurementSystem, symbol, scaleFactor, newOffset);
   }
   /**
    * Change the unit symbol in this unit.
@@ -221,7 +221,7 @@ public class Unit<Q extends Quantity>
    */
   public Unit<Q> setSymbol(String inSymbol)
   {
-    return new Unit<Q>(measurementSystem, inSymbol, scaleFactor, offset);
+    return new Unit<>(measurementSystem, inSymbol, scaleFactor, offset);
   }
 
   /**
@@ -233,7 +233,7 @@ public class Unit<Q extends Quantity>
   public Unit<Q> prefixSymbol(String prefix)
   {
     String newSymbol = prefix + symbol;
-    return new Unit<Q>(measurementSystem, newSymbol, scaleFactor, offset);
+    return new Unit<>(measurementSystem, newSymbol, scaleFactor, offset);
   }
 
   /**
@@ -249,7 +249,7 @@ public class Unit<Q extends Quantity>
    */
   public static <Q extends Quantity> Unit<Q> CreateBaseUnit(String inMeasurementSystem, String inSymbol)
   {
-    return new Unit<Q>(inMeasurementSystem, inSymbol, 1.0, 0.0);
+    return new Unit<>(inMeasurementSystem, inSymbol, 1.0, 0.0);
   }
   // End "protected" functions
 

--- a/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
@@ -153,7 +153,7 @@ public final class MetadataConverter {
         String channelID = src.getChannelID(srcImage, srcChannel);
         dest.setChannelID(channelID, destImage, destChannel);
       }
-      catch (NullPointerException e) {
+      catch (NullPointerException ignored) {
         return;
       }
     }
@@ -162,79 +162,79 @@ public final class MetadataConverter {
       AcquisitionMode mode = src.getChannelAcquisitionMode(srcImage, srcChannel);
       dest.setChannelAcquisitionMode(mode, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       Color color = src.getChannelColor(srcImage, srcChannel);
       dest.setChannelColor(color, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       ContrastMethod method = src.getChannelContrastMethod(srcImage, srcChannel);
       dest.setChannelContrastMethod(method, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       Length emWave = src.getChannelEmissionWavelength(srcImage, srcChannel);
       dest.setChannelEmissionWavelength(emWave, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       Length exWave = src.getChannelExcitationWavelength(srcImage, srcChannel);
       dest.setChannelExcitationWavelength(exWave, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String filterSetRef = src.getChannelFilterSetRef(srcImage, srcChannel);
       dest.setChannelFilterSetRef(filterSetRef, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String fluor = src.getChannelFluor(srcImage, srcChannel);
       dest.setChannelFluor(fluor, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       IlluminationType illumType = src.getChannelIlluminationType(srcImage, srcChannel);
       dest.setChannelIlluminationType(illumType, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       Double ndFilter = src.getChannelNDFilter(srcImage, srcChannel);
       dest.setChannelNDFilter(ndFilter, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String channelName = src.getChannelName(srcImage, srcChannel);
       dest.setChannelName(channelName, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       Length pinholeSize = src.getChannelPinholeSize(srcImage, srcChannel);
       dest.setChannelPinholeSize(pinholeSize, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       Integer pockelCell = src.getChannelPockelCellSetting(srcImage, srcChannel);
       dest.setChannelPockelCellSetting(pockelCell, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       PositiveInteger samplesPerPixel = src.getChannelSamplesPerPixel(srcImage, srcChannel);
       dest.setChannelSamplesPerPixel(samplesPerPixel, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String detectorSettingsID = src.getDetectorSettingsID(srcImage, srcChannel);
@@ -245,53 +245,53 @@ public final class MetadataConverter {
           Binning binning = src.getDetectorSettingsBinning(srcImage, srcChannel);
           dest.setDetectorSettingsBinning(binning, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Double gain = src.getDetectorSettingsGain(srcImage, srcChannel);
           dest.setDetectorSettingsGain(gain, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger integration =
             src.getDetectorSettingsIntegration(srcImage, srcChannel);
           dest.setDetectorSettingsIntegration(integration, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Double offset = src.getDetectorSettingsOffset(srcImage, srcChannel);
           dest.setDetectorSettingsOffset(offset, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Frequency readOutRate = src.getDetectorSettingsReadOutRate(srcImage, srcChannel);
           dest.setDetectorSettingsReadOutRate(readOutRate, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           ElectricPotential voltage = src.getDetectorSettingsVoltage(srcImage, srcChannel);
           dest.setDetectorSettingsVoltage(voltage, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Double zoom = src.getDetectorSettingsZoom(srcImage, srcChannel);
           dest.setDetectorSettingsZoom(zoom, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String dichroicRef = src.getLightPathDichroicRef(srcImage, srcChannel);
       dest.setLightPathDichroicRef(dichroicRef, destImage, destChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String lightSourceID = src.getChannelLightSourceSettingsID(srcImage, srcChannel);
@@ -303,67 +303,67 @@ public final class MetadataConverter {
             src.getChannelLightSourceSettingsAttenuation(srcImage, srcChannel);
           dest.setChannelLightSourceSettingsAttenuation(attenuation, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length wavelength = src.getChannelLightSourceSettingsWavelength(srcImage, srcChannel);
           dest.setChannelLightSourceSettingsWavelength(wavelength, destImage, destChannel);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     int channelAnnotationRefCount = 0;
     try {
       channelAnnotationRefCount = src.getChannelAnnotationRefCount(srcImage, srcChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int q=0; q<channelAnnotationRefCount; q++) {
       try {
         String channelAnnotationRef = src.getChannelAnnotationRef(srcImage, srcChannel, q);
         dest.setChannelAnnotationRef(channelAnnotationRef, destImage, destChannel, q);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
     }
 
     int emFilterRefCount = 0;
     try {
       emFilterRefCount = src.getLightPathEmissionFilterRefCount(srcImage, srcChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int q=0; q<emFilterRefCount; q++) {
       try {
         String emFilterRef = src.getLightPathEmissionFilterRef(srcImage, srcChannel, q);
         dest.setLightPathEmissionFilterRef(emFilterRef, destImage, destChannel, q);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
     }
 
     int exFilterRefCount = 0;
     try {
       exFilterRefCount = src.getLightPathExcitationFilterRefCount(srcImage, srcChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int q=0; q<exFilterRefCount; q++) {
       try {
         String exFilterRef = src.getLightPathExcitationFilterRef(srcImage, srcChannel, q);
         dest.setLightPathExcitationFilterRef(exFilterRef, destImage, destChannel, q);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
     }
 
     int lightPathAnnotationRefCount = 0;
     try {
       lightPathAnnotationRefCount = src.getLightPathAnnotationRefCount(srcImage, srcChannel);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int q=0; q<lightPathAnnotationRefCount; q++) {
       try {
         String lightPathAnnotationRef = src.getLightPathAnnotationRef(srcImage, srcChannel, q);
         dest.setLightPathAnnotationRef(lightPathAnnotationRef, destImage, destChannel, q);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
     }
   }
 
@@ -381,7 +381,7 @@ public final class MetadataConverter {
     try {
       booleanAnnotationCount = src.getBooleanAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<booleanAnnotationCount; i++) {
       try {
         String id = src.getBooleanAnnotationID(i);
@@ -395,37 +395,37 @@ public final class MetadataConverter {
         String description = src.getBooleanAnnotationDescription(i);
         dest.setBooleanAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getBooleanAnnotationNamespace(i);
         dest.setBooleanAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Boolean value = src.getBooleanAnnotationValue(i);
         dest.setBooleanAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getBooleanAnnotationAnnotator(i);
         dest.setBooleanAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getBooleanAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getBooleanAnnotationAnnotationRef(i, a);
           dest.setBooleanAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -442,7 +442,7 @@ public final class MetadataConverter {
     try {
       commentAnnotationCount = src.getCommentAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<commentAnnotationCount; i++) {
       try {
         String id = src.getCommentAnnotationID(i);
@@ -456,37 +456,37 @@ public final class MetadataConverter {
         String description = src.getCommentAnnotationDescription(i);
         dest.setCommentAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getCommentAnnotationNamespace(i);
         dest.setCommentAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String value = src.getCommentAnnotationValue(i);
         dest.setCommentAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getCommentAnnotationAnnotator(i);
         dest.setCommentAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getCommentAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getCommentAnnotationAnnotationRef(i, a);
           dest.setCommentAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -502,7 +502,7 @@ public final class MetadataConverter {
     try {
       datasets = src.getDatasetCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<datasets; i++) {
       try {
         String id = src.getDatasetID(i);
@@ -516,25 +516,25 @@ public final class MetadataConverter {
         String description = src.getDatasetDescription(i);
         dest.setDatasetDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String experimenterGroupRef = src.getDatasetExperimenterGroupRef(i);
         dest.setDatasetExperimenterGroupRef(experimenterGroupRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String experimenterRef = src.getDatasetExperimenterRef(i);
         dest.setDatasetExperimenterRef(experimenterRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String name = src.getDatasetName(i);
         dest.setDatasetName(name, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         int imageRefCount = src.getDatasetImageRefCount(i);
@@ -543,10 +543,10 @@ public final class MetadataConverter {
             String imageRef = src.getDatasetImageRef(i, q);
             dest.setDatasetImageRef(imageRef, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         int annotationRefCount = src.getDatasetAnnotationRefCount(i);
@@ -555,10 +555,10 @@ public final class MetadataConverter {
             String annotationRef = src.getDatasetAnnotationRef(i, q);
             dest.setDatasetAnnotationRef(annotationRef, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
     }
   }
 
@@ -574,7 +574,7 @@ public final class MetadataConverter {
     try {
       doubleAnnotationCount = src.getDoubleAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<doubleAnnotationCount; i++) {
       try {
         String id = src.getDoubleAnnotationID(i);
@@ -588,37 +588,37 @@ public final class MetadataConverter {
         String description = src.getDoubleAnnotationDescription(i);
         dest.setDoubleAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getDoubleAnnotationNamespace(i);
         dest.setDoubleAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Double value = src.getDoubleAnnotationValue(i);
         dest.setDoubleAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getDoubleAnnotationAnnotator(i);
         dest.setDoubleAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getDoubleAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getDoubleAnnotationAnnotationRef(i, a);
           dest.setDoubleAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -635,7 +635,7 @@ public final class MetadataConverter {
     try {
       experimentCount = src.getExperimentCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<experimentCount; i++) {
       try {
         String id = src.getExperimentID(i);
@@ -649,25 +649,25 @@ public final class MetadataConverter {
         String description = src.getExperimentDescription(i);
         dest.setExperimentDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String experimenterRef = src.getExperimentExperimenterRef(i);
         dest.setExperimentExperimenterRef(experimenterRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         ExperimentType type = src.getExperimentType(i);
         dest.setExperimentType(type, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int microbeamCount = 0;
       try {
         microbeamCount = src.getMicrobeamManipulationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<microbeamCount; q++) {
         try {
           String microbeamID = src.getMicrobeamManipulationID(i, q);
@@ -681,25 +681,25 @@ public final class MetadataConverter {
           String microbeamDescription = src.getMicrobeamManipulationDescription(i, q);
           dest.setMicrobeamManipulationDescription(microbeamDescription, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String microbeamExperimenterRef = src.getMicrobeamManipulationExperimenterRef(i, q);
           dest.setMicrobeamManipulationExperimenterRef(microbeamExperimenterRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           MicrobeamManipulationType microbeamType = src.getMicrobeamManipulationType(i, q);
           dest.setMicrobeamManipulationType(microbeamType, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int lightSourceCount = 0;
         try {
           lightSourceCount = src.getMicrobeamManipulationLightSourceSettingsCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int p=0; p<lightSourceCount; p++) {
           String lightSourceID = src.getMicrobeamManipulationLightSourceSettingsID(i, q, p);
           if (lightSourceID != null) {
@@ -709,13 +709,13 @@ public final class MetadataConverter {
               PercentFraction attenuation = src.getMicrobeamManipulationLightSourceSettingsAttenuation(i, q, p);
               dest.setMicrobeamManipulationLightSourceSettingsAttenuation(attenuation, i, q, p);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
 
             try {
               Length wavelength = src.getMicrobeamManipulationLightSourceSettingsWavelength(i, q, p);
               dest.setMicrobeamManipulationLightSourceSettingsWavelength(wavelength, i, q, p);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
 
@@ -723,13 +723,13 @@ public final class MetadataConverter {
         try {
           roiRefCount = src.getMicrobeamManipulationROIRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int p=0; p<roiRefCount; p++) {
           try {
             String roiRef = src.getMicrobeamManipulationROIRef(i, q, p);
             dest.setMicrobeamManipulationROIRef(roiRef, i, q, p);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
     }
@@ -747,7 +747,7 @@ public final class MetadataConverter {
     try {
       experimenterCount = src.getExperimenterCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<experimenterCount; i++) {
       try {
         String id = src.getExperimenterID(i);
@@ -761,49 +761,49 @@ public final class MetadataConverter {
         String email = src.getExperimenterEmail(i);
         dest.setExperimenterEmail(email, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String firstName = src.getExperimenterFirstName(i);
         dest.setExperimenterFirstName(firstName, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String institution = src.getExperimenterInstitution(i);
         dest.setExperimenterInstitution(institution, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String lastName = src.getExperimenterLastName(i);
         dest.setExperimenterLastName(lastName, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String middleName = src.getExperimenterMiddleName(i);
         dest.setExperimenterMiddleName(middleName, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String userName = src.getExperimenterUserName(i);
         dest.setExperimenterUserName(userName, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getExperimenterAnnotationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<annotationRefCount; q++) {
         try {
           String annotationRef = src.getExperimenterAnnotationRef(i, q);
           dest.setExperimenterAnnotationRef(annotationRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -820,7 +820,7 @@ public final class MetadataConverter {
     try {
       experimenterGroupCount = src.getExperimenterGroupCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<experimenterGroupCount; i++) {
       try {
         String id = src.getExperimenterGroupID(i);
@@ -834,51 +834,51 @@ public final class MetadataConverter {
         String description = src.getExperimenterGroupDescription(i);
         dest.setExperimenterGroupDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String name = src.getExperimenterGroupName(i);
         dest.setExperimenterGroupName(name, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getExperimenterGroupAnnotationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<annotationRefCount; q++) {
         try {
           String annotationRef = src.getExperimenterGroupAnnotationRef(i, q);
           dest.setExperimenterGroupAnnotationRef(annotationRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
 
       int experimenterRefCount = 0;
       try {
         experimenterRefCount = src.getExperimenterGroupExperimenterRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<experimenterRefCount; q++) {
         try {
           String experimenterRef = src.getExperimenterGroupExperimenterRef(i, q);
           dest.setExperimenterGroupExperimenterRef(experimenterRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
 
       int leaderCount = 0;
       try {
         leaderCount = src.getLeaderCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<leaderCount; q++) {
         try {
           String leader = src.getExperimenterGroupLeader(i, q);
           dest.setExperimenterGroupLeader(leader, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -895,7 +895,7 @@ public final class MetadataConverter {
     try {
       fileAnnotationCount = src.getFileAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<fileAnnotationCount; i++) {
       try {
         String id = src.getFileAnnotationID(i);
@@ -909,73 +909,73 @@ public final class MetadataConverter {
         String description = src.getFileAnnotationDescription(i);
         dest.setFileAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getFileAnnotationNamespace(i);
         dest.setFileAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getFileAnnotationAnnotator(i);
         dest.setFileAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String fileName = src.getBinaryFileFileName(i);
         dest.setBinaryFileFileName(fileName, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String mimeType = src.getBinaryFileMIMEType(i);
         dest.setBinaryFileMIMEType(mimeType, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         NonNegativeLong fileSize = src.getBinaryFileSize(i);
         dest.setBinaryFileSize(fileSize, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         byte[] binData = src.getBinaryFileBinData(i);
         dest.setBinaryFileBinData(binData, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         boolean bigEndian = src.getBinaryFileBinDataBigEndian(i);
         dest.setBinaryFileBinDataBigEndian(bigEndian, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         NonNegativeLong length = src.getBinaryFileBinDataLength(i);
         dest.setBinaryFileBinDataLength(length, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Compression compression = src.getBinaryFileBinDataCompression(i);
         dest.setBinaryFileBinDataCompression(compression, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getFileAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getFileAnnotationAnnotationRef(i, a);
           dest.setFileAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -991,7 +991,7 @@ public final class MetadataConverter {
     try {
       folders = src.getFolderCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     for (int i=0; i<folders; i++) {
       try {
@@ -1006,13 +1006,13 @@ public final class MetadataConverter {
         String description = src.getFolderDescription(i);
         dest.setFolderDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String name = src.getFolderName(i);
         dest.setFolderName(name, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         int folderRefCount = src.getFolderRefCount(i);
@@ -1021,10 +1021,10 @@ public final class MetadataConverter {
             String folderRef = src.getFolderFolderRef(i, q);
             dest.setFolderFolderRef(folderRef, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         int imageRefCount = src.getFolderImageRefCount(i);
@@ -1033,10 +1033,10 @@ public final class MetadataConverter {
             String imageRef = src.getFolderImageRef(i, q);
             dest.setFolderImageRef(imageRef, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         int roiRefCount = src.getFolderROIRefCount(i);
@@ -1045,10 +1045,10 @@ public final class MetadataConverter {
             String roiRef = src.getFolderROIRef(i, q);
             dest.setFolderROIRef(roiRef, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         int annotationRefCount = src.getFolderAnnotationRefCount(i);
@@ -1057,10 +1057,10 @@ public final class MetadataConverter {
             String annotationRef = src.getFolderAnnotationRef(i, q);
             dest.setFolderAnnotationRef(annotationRef, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
     }
   }
 
@@ -1076,7 +1076,7 @@ public final class MetadataConverter {
     try {
       imageCount = src.getImageCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<imageCount; i++) {
       try {
         String id = src.getImageID(i);
@@ -1090,73 +1090,73 @@ public final class MetadataConverter {
         Timestamp date = src.getImageAcquisitionDate(i);
         dest.setImageAcquisitionDate(date, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String description = src.getImageDescription(i);
         dest.setImageDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String experimentRef = src.getImageExperimentRef(i);
         dest.setImageExperimentRef(experimentRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String experimenterGroupRef = src.getImageExperimenterGroupRef(i);
         dest.setImageExperimenterGroupRef(experimenterGroupRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String experimenterRef = src.getImageExperimenterRef(i);
         dest.setImageExperimenterRef(experimenterRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String instrumentRef = src.getImageInstrumentRef(i);
         dest.setImageInstrumentRef(instrumentRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String name = src.getImageName(i);
         dest.setImageName(name, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Pressure airPressure = src.getImagingEnvironmentAirPressure(i);
         dest.setImagingEnvironmentAirPressure(airPressure, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         PercentFraction co2 = src.getImagingEnvironmentCO2Percent(i);
         dest.setImagingEnvironmentCO2Percent(co2, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         PercentFraction humidity = src.getImagingEnvironmentHumidity(i);
         dest.setImagingEnvironmentHumidity(humidity, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         List<MapPair> map = src.getImagingEnvironmentMap(i);
         dest.setImagingEnvironmentMap(map, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Temperature temperature = src.getImagingEnvironmentTemperature(i);
         dest.setImagingEnvironmentTemperature(temperature, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String objectiveID = src.getObjectiveSettingsID(i);
@@ -1167,23 +1167,23 @@ public final class MetadataConverter {
             Double correction = src.getObjectiveSettingsCorrectionCollar(i);
             dest.setObjectiveSettingsCorrectionCollar(correction, i);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Medium medium = src.getObjectiveSettingsMedium(i);
             dest.setObjectiveSettingsMedium(medium, i);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double refractiveIndex = src.getObjectiveSettingsRefractiveIndex(i);
             dest.setObjectiveSettingsRefractiveIndex(refractiveIndex, i);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String stageLabelName = src.getStageLabelName(i);
@@ -1194,22 +1194,22 @@ public final class MetadataConverter {
             final Length stageLabelX = src.getStageLabelX(i);
             dest.setStageLabelX(stageLabelX, i);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             final Length stageLabelY = src.getStageLabelY(i);
             dest.setStageLabelY(stageLabelY, i);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             final Length stageLabelZ = src.getStageLabelZ(i);
             dest.setStageLabelZ(stageLabelZ, i);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String pixelsID = src.getPixelsID(i);
@@ -1219,127 +1219,127 @@ public final class MetadataConverter {
           DimensionOrder order = src.getPixelsDimensionOrder(i);
           dest.setPixelsDimensionOrder(order, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length physicalSizeX = src.getPixelsPhysicalSizeX(i);
           dest.setPixelsPhysicalSizeX(physicalSizeX, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length physicalSizeY = src.getPixelsPhysicalSizeY(i);
           dest.setPixelsPhysicalSizeY(physicalSizeY, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length physicalSizeZ = src.getPixelsPhysicalSizeZ(i);
           dest.setPixelsPhysicalSizeZ(physicalSizeZ, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger sizeC = src.getPixelsSizeC(i);
           dest.setPixelsSizeC(sizeC, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger sizeT = src.getPixelsSizeT(i);
           dest.setPixelsSizeT(sizeT, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger sizeX = src.getPixelsSizeX(i);
           dest.setPixelsSizeX(sizeX, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger sizeY = src.getPixelsSizeY(i);
           dest.setPixelsSizeY(sizeY, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger sizeZ = src.getPixelsSizeZ(i);
           dest.setPixelsSizeZ(sizeZ, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Time timeIncrement = src.getPixelsTimeIncrement(i);
           dest.setPixelsTimeIncrement(timeIncrement, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PixelType type = src.getPixelsType(i);
           dest.setPixelsType(type, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Boolean bigEndian = src.getPixelsBigEndian(i);
           dest.setPixelsBigEndian(bigEndian, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Boolean interleaved = src.getPixelsInterleaved(i);
           dest.setPixelsInterleaved(interleaved, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger significantBits = src.getPixelsSignificantBits(i);
           dest.setPixelsSignificantBits(significantBits, i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int binDataCount = 0;
         try {
           binDataCount = src.getPixelsBinDataCount(i);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int q=0; q<binDataCount; q++) {
           try {
             Boolean bigEndian = src.getPixelsBinDataBigEndian(i, q);
             dest.setPixelsBinDataBigEndian(bigEndian, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           try {
             NonNegativeLong length = src.getPixelsBinDataLength(i, q);
             dest.setPixelsBinDataLength(length, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           try {
             Compression compression = src.getPixelsBinDataCompression(i, q);
             dest.setPixelsBinDataCompression(compression, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           try {
             byte[] data = src.getPixelsBinData(i, q);
             dest.setPixelsBinData(data, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getImageAnnotationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<annotationRefCount; q++) {
         try {
           String annotationRef = src.getImageAnnotationRef(i, q);
           dest.setImageAnnotationRef(annotationRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
 
 
@@ -1347,7 +1347,7 @@ public final class MetadataConverter {
       try {
         channelCount = src.getChannelCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int c=0; c<channelCount; c++) {
         convertChannels(src, i, c, dest, i, c, true, lightSourceIds);
       }
@@ -1356,73 +1356,73 @@ public final class MetadataConverter {
       try {
         planeCount = src.getPlaneCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int p=0; p<planeCount; p++) {
         try {
           Time deltaT = src.getPlaneDeltaT(i, p);
           dest.setPlaneDeltaT(deltaT, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Time exposureTime = src.getPlaneExposureTime(i, p);
           dest.setPlaneExposureTime(exposureTime, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String sha1 = src.getPlaneHashSHA1(i, p);
           dest.setPlaneHashSHA1(sha1, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           final Length positionX = src.getPlanePositionX(i, p);
           dest.setPlanePositionX(positionX, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           final Length positionY = src.getPlanePositionY(i, p);
           dest.setPlanePositionY(positionY, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           final Length positionZ = src.getPlanePositionZ(i, p);
           dest.setPlanePositionZ(positionZ, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger theC = src.getPlaneTheC(i, p);
           dest.setPlaneTheC(theC, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger theT = src.getPlaneTheT(i, p);
           dest.setPlaneTheT(theT, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger theZ = src.getPlaneTheZ(i, p);
           dest.setPlaneTheZ(theZ, i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int planeAnnotationRefCount = 0;
         try {
           planeAnnotationRefCount = src.getPlaneAnnotationRefCount(i, p);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int q=0; q<planeAnnotationRefCount; q++) {
           try {
             String planeAnnotationRef = src.getPlaneAnnotationRef(i, p, q);
             dest.setPlaneAnnotationRef(planeAnnotationRef, i, p, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
 
@@ -1430,75 +1430,75 @@ public final class MetadataConverter {
       try {
         microbeamCount = src.getMicrobeamManipulationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<microbeamCount; q++) {
         try {
           String microbeamRef = src.getImageMicrobeamManipulationRef(i, q);
           dest.setImageMicrobeamManipulationRef(microbeamRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
 
       int roiRefCount = 0;
       try {
         roiRefCount = src.getImageROIRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<roiRefCount; q++) {
         try {
           String roiRef = src.getImageROIRef(i, q);
           dest.setImageROIRef(roiRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
 
       int tiffDataCount = 0;
       try {
         tiffDataCount = src.getTiffDataCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<tiffDataCount; q++) {
         try {
           String uuid = src.getUUIDValue(i, q);
           dest.setUUIDValue(uuid, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String filename = src.getUUIDFileName(i, q);
           dest.setUUIDFileName(filename, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger firstC = src.getTiffDataFirstC(i, q);
           dest.setTiffDataFirstC(firstC, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger firstT = src.getTiffDataFirstT(i, q);
           dest.setTiffDataFirstT(firstT, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger firstZ = src.getTiffDataFirstZ(i, q);
           dest.setTiffDataFirstZ(firstZ, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger ifd = src.getTiffDataIFD(i, q);
           dest.setTiffDataIFD(ifd, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger tiffDataPlaneCount = src.getTiffDataPlaneCount(i, q);
           dest.setTiffDataPlaneCount(tiffDataPlaneCount, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -1517,7 +1517,7 @@ public final class MetadataConverter {
     try {
       instrumentCount = src.getInstrumentCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<instrumentCount; i++) {
       try {
         String id = src.getInstrumentID(i);
@@ -1531,37 +1531,37 @@ public final class MetadataConverter {
         String microscopeLotNumber = src.getMicroscopeLotNumber(i);
         dest.setMicroscopeLotNumber(microscopeLotNumber, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String microscopeManufacturer = src.getMicroscopeManufacturer(i);
         dest.setMicroscopeManufacturer(microscopeManufacturer, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String microscopeModel = src.getMicroscopeModel(i);
         dest.setMicroscopeModel(microscopeModel, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String microscopeSerialNumber = src.getMicroscopeSerialNumber(i);
         dest.setMicroscopeSerialNumber(microscopeSerialNumber, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         MicroscopeType microscopeType = src.getMicroscopeType(i);
         dest.setMicroscopeType(microscopeType, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int detectorCount = 0;
       try {
         detectorCount = src.getDetectorCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<detectorCount; q++) {
         try {
           String detectorID = src.getDetectorID(i, q);
@@ -1575,73 +1575,73 @@ public final class MetadataConverter {
           Double amplificationGain = src.getDetectorAmplificationGain(i, q);
           dest.setDetectorAmplificationGain(amplificationGain, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Double gain = src.getDetectorGain(i, q);
           dest.setDetectorGain(gain, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String lotNumber = src.getDetectorLotNumber(i, q);
           dest.setDetectorLotNumber(lotNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer = src.getDetectorManufacturer(i, q);
           dest.setDetectorManufacturer(manufacturer, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model = src.getDetectorModel(i, q);
           dest.setDetectorModel(model, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Double offset = src.getDetectorOffset(i, q);
           dest.setDetectorOffset(offset, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber = src.getDetectorSerialNumber(i, q);
           dest.setDetectorSerialNumber(serialNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           DetectorType detectorType = src.getDetectorType(i, q);
           dest.setDetectorType(detectorType, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           ElectricPotential voltage = src.getDetectorVoltage(i, q);
           dest.setDetectorVoltage(voltage, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Double zoom = src.getDetectorZoom(i, q);
           dest.setDetectorZoom(zoom, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int detectorAnnotationRefCount = 0;
         try {
           detectorAnnotationRefCount = src.getDetectorAnnotationRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<detectorAnnotationRefCount; r++) {
           try {
             String detectorAnnotationRef = src.getDetectorAnnotationRef(i, q, r);
             dest.setDetectorAnnotationRef(detectorAnnotationRef, i, q, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
 
@@ -1649,7 +1649,7 @@ public final class MetadataConverter {
       try {
         dichroicCount = src.getDichroicCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<dichroicCount; q++) {
         try {
           String dichroicID = src.getDichroicID(i, q);
@@ -1663,37 +1663,37 @@ public final class MetadataConverter {
           String lotNumber = src.getDichroicLotNumber(i, q);
           dest.setDichroicLotNumber(lotNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer = src.getDichroicManufacturer(i, q);
           dest.setDichroicManufacturer(manufacturer, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model = src.getDichroicModel(i, q);
           dest.setDichroicModel(model, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber = src.getDichroicSerialNumber(i, q);
           dest.setDichroicSerialNumber(serialNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int dichroicAnnotationRefCount = 0;
         try {
           dichroicAnnotationRefCount = src.getDichroicAnnotationRefCount(i,q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<dichroicAnnotationRefCount; r++) {
           try {
             String dichroicAnnotationRef = src.getDichroicAnnotationRef(i, q, r);
             dest.setDichroicAnnotationRef(dichroicAnnotationRef, i, q, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
 
@@ -1701,7 +1701,7 @@ public final class MetadataConverter {
       try {
         filterCount = src.getFilterCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<filterCount; q++) {
         try {
           String filterID = src.getFilterID(i, q);
@@ -1715,79 +1715,79 @@ public final class MetadataConverter {
           String filterWheel = src.getFilterFilterWheel(i, q);
           dest.setFilterFilterWheel(filterWheel, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String lotNumber = src.getFilterLotNumber(i, q);
           dest.setFilterLotNumber(lotNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer = src.getFilterManufacturer(i, q);
           dest.setFilterManufacturer(manufacturer, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model = src.getFilterModel(i, q);
           dest.setFilterModel(model, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber = src.getFilterSerialNumber(i, q);
           dest.setFilterSerialNumber(serialNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           FilterType filterType = src.getFilterType(i, q);
           dest.setFilterType(filterType, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length cutIn = src.getTransmittanceRangeCutIn(i, q);
           dest.setTransmittanceRangeCutIn(cutIn, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length cutInTolerance = src.getTransmittanceRangeCutInTolerance(i, q);
           dest.setTransmittanceRangeCutInTolerance(cutInTolerance, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length cutOut = src.getTransmittanceRangeCutOut(i, q);
           dest.setTransmittanceRangeCutOut(cutOut, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length cutOutTolerance = src.getTransmittanceRangeCutOutTolerance(i, q);
           dest.setTransmittanceRangeCutOutTolerance(cutOutTolerance, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PercentFraction transmittance = src.getTransmittanceRangeTransmittance(i, q);
           dest.setTransmittanceRangeTransmittance(transmittance, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int filterAnnotationRefCount = 0;
         try {
           filterAnnotationRefCount = src.getFilterAnnotationRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<filterAnnotationRefCount; r++) {
           try {
             String filterAnnotationRef = src.getFilterAnnotationRef(i, q, r);
             dest.setFilterAnnotationRef(filterAnnotationRef, i, q, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
 
@@ -1795,7 +1795,7 @@ public final class MetadataConverter {
       try {
         objectiveCount = src.getObjectiveCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<objectiveCount; q++) {
         try {
           String objectiveID = src.getObjectiveID(i, q);
@@ -1809,80 +1809,80 @@ public final class MetadataConverter {
           Double calibratedMag = src.getObjectiveCalibratedMagnification(i, q);
           dest.setObjectiveCalibratedMagnification(calibratedMag, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Correction correction = src.getObjectiveCorrection(i, q);
           dest.setObjectiveCorrection(correction, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Immersion immersion = src.getObjectiveImmersion(i, q);
           dest.setObjectiveImmersion(immersion, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Boolean iris = src.getObjectiveIris(i, q);
           dest.setObjectiveIris(iris, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Double lensNA = src.getObjectiveLensNA(i, q);
           dest.setObjectiveLensNA(lensNA, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String lotNumber = src.getObjectiveLotNumber(i, q);
           dest.setObjectiveLotNumber(lotNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer = src.getObjectiveManufacturer(i, q);
           dest.setObjectiveManufacturer(manufacturer, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model = src.getObjectiveModel(i, q);
           dest.setObjectiveModel(model, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Double nominalMag = src.getObjectiveNominalMagnification(i, q);
           dest.setObjectiveNominalMagnification(nominalMag, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber = src.getObjectiveSerialNumber(i, q);
           dest.setObjectiveSerialNumber(serialNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length workingDistance = src.getObjectiveWorkingDistance(i, q);
           dest.setObjectiveWorkingDistance(workingDistance, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int objectiveAnnotationRefCount = 0;
         try {
           objectiveAnnotationRefCount = src.getObjectiveAnnotationRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         for (int r=0; r<objectiveAnnotationRefCount; r++) {
           try {
             String objectiveAnnotationRef = src.getObjectiveAnnotationRef(i, q, r);
             dest.setObjectiveAnnotationRef(objectiveAnnotationRef, i, q, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
 
@@ -1890,7 +1890,7 @@ public final class MetadataConverter {
       try {
         filterSetCount = src.getFilterSetCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<filterSetCount; q++) {
         try {
           String filterSetID = src.getFilterSetID(i, q);
@@ -1904,56 +1904,56 @@ public final class MetadataConverter {
           String dichroicRef = src.getFilterSetDichroicRef(i, q);
           dest.setFilterSetDichroicRef(dichroicRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String lotNumber = src.getFilterSetLotNumber(i, q);
           dest.setFilterSetLotNumber(lotNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer = src.getFilterSetManufacturer(i, q);
           dest.setFilterSetManufacturer(manufacturer, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model = src.getFilterSetModel(i, q);
           dest.setFilterSetModel(model, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber = src.getFilterSetSerialNumber(i, q);
           dest.setFilterSetSerialNumber(serialNumber, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int emFilterCount = 0;
         try {
           emFilterCount = src.getFilterSetEmissionFilterRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int f=0; f<emFilterCount; f++) {
           try {
             String emFilterRef = src.getFilterSetEmissionFilterRef(i, q, f);
             dest.setFilterSetEmissionFilterRef(emFilterRef, i, q, f);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
 
         int exFilterCount = 0;
         try {
           exFilterCount = src.getFilterSetExcitationFilterRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int f=0; f<exFilterCount; f++) {
           try {
             String exFilterRef = src.getFilterSetExcitationFilterRef(i, q, f);
             dest.setFilterSetExcitationFilterRef(exFilterRef, i, q, f);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
 
@@ -1963,13 +1963,13 @@ public final class MetadataConverter {
       try {
         instrumentRefCount = src.getInstrumentAnnotationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int r=0; r<instrumentRefCount; r++) {
         try {
           String id = src.getInstrumentAnnotationRef(i, r);
           dest.setInstrumentAnnotationRef(id, i, r);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
     return lightSourceIds;
@@ -1987,7 +1987,7 @@ public final class MetadataConverter {
     try {
       listAnnotationCount = src.getListAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<listAnnotationCount; i++) {
       try {
         String id = src.getListAnnotationID(i);
@@ -2001,31 +2001,31 @@ public final class MetadataConverter {
         String description = src.getListAnnotationDescription(i);
         dest.setListAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getListAnnotationNamespace(i);
         dest.setListAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getListAnnotationAnnotator(i);
         dest.setListAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getListAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getListAnnotationAnnotationRef(i, a);
           dest.setListAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -2042,7 +2042,7 @@ public final class MetadataConverter {
     try {
       longAnnotationCount = src.getLongAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<longAnnotationCount; i++) {
       try {
         String id = src.getLongAnnotationID(i);
@@ -2056,37 +2056,37 @@ public final class MetadataConverter {
         String description = src.getLongAnnotationDescription(i);
         dest.setLongAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getLongAnnotationNamespace(i);
         dest.setLongAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Long value = src.getLongAnnotationValue(i);
         dest.setLongAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getLongAnnotationAnnotator(i);
         dest.setLongAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getLongAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getLongAnnotationAnnotationRef(i, a);
           dest.setLongAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -2102,7 +2102,7 @@ public final class MetadataConverter {
     try {
       mapAnnotationCount = src.getMapAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<mapAnnotationCount; i++) {
       try {
         String id = src.getMapAnnotationID(i);
@@ -2116,37 +2116,37 @@ public final class MetadataConverter {
         String description = src.getMapAnnotationDescription(i);
         dest.setMapAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getMapAnnotationNamespace(i);
         dest.setMapAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         List<MapPair> value = src.getMapAnnotationValue(i);
         dest.setMapAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getMapAnnotationAnnotator(i);
         dest.setMapAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getMapAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getMapAnnotationAnnotationRef(i, a);
           dest.setMapAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -2161,7 +2161,7 @@ public final class MetadataConverter {
     try {
       plateCount = src.getPlateCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<plateCount; i++) {
       try {
         String id = src.getPlateID(i);
@@ -2175,31 +2175,31 @@ public final class MetadataConverter {
         NamingConvention columnConvention = src.getPlateColumnNamingConvention(i);
         dest.setPlateColumnNamingConvention(columnConvention, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         PositiveInteger columns = src.getPlateColumns(i);
         dest.setPlateColumns(columns, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String description = src.getPlateDescription(i);
         dest.setPlateDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String externalID = src.getPlateExternalIdentifier(i);
         dest.setPlateExternalIdentifier(externalID, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         NonNegativeInteger fieldIndex = src.getPlateFieldIndex(i);
         dest.setPlateFieldIndex(fieldIndex, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       // NB: plate name is required in OMERO
       try {
@@ -2209,7 +2209,7 @@ public final class MetadataConverter {
         }
         dest.setPlateName(name, i);
       }
-      catch (NullPointerException e) {
+      catch (NullPointerException ignored) {
         dest.setPlateName("", i);
       }
 
@@ -2217,37 +2217,37 @@ public final class MetadataConverter {
         NamingConvention rowConvention = src.getPlateRowNamingConvention(i);
         dest.setPlateRowNamingConvention(rowConvention, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         PositiveInteger rows = src.getPlateRows(i);
         dest.setPlateRows(rows, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String status = src.getPlateStatus(i);
         dest.setPlateStatus(status, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Length wellOriginX = src.getPlateWellOriginX(i);
         dest.setPlateWellOriginX(wellOriginX, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Length wellOriginY = src.getPlateWellOriginY(i);
         dest.setPlateWellOriginY(wellOriginY, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int wellCount = 0;
       try {
         wellCount = src.getWellCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<wellCount; q++) {
         try {
           String wellID = src.getWellID(i, q);
@@ -2261,62 +2261,62 @@ public final class MetadataConverter {
           Color color = src.getWellColor(i, q);
           dest.setWellColor(color, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger column = src.getWellColumn(i, q);
           dest.setWellColumn(column, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String externalDescription = src.getWellExternalDescription(i, q);
           dest.setWellExternalDescription(externalDescription, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String wellExternalID = src.getWellExternalIdentifier(i, q);
           dest.setWellExternalIdentifier(wellExternalID, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String reagentRef = src.getWellReagentRef(i, q);
           dest.setWellReagentRef(reagentRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           NonNegativeInteger row = src.getWellRow(i, q);
           dest.setWellRow(row, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String type = src.getWellType(i, q);
           dest.setWellType(type, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int wellAnnotationRefCount = 0;
         try {
           src.getWellAnnotationRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int a=0; a<wellAnnotationRefCount; a++) {
           try {
             String wellAnnotationRef = src.getWellAnnotationRef(i, q, a);
             dest.setWellAnnotationRef(wellAnnotationRef, i, q, a);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
 
         int wellSampleCount = 0;
         try {
           wellSampleCount = src.getWellSampleCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int w=0; w<wellSampleCount; w++) {
           try {
             String wellSampleID = src.getWellSampleID(i, q, w);
@@ -2330,31 +2330,31 @@ public final class MetadataConverter {
             NonNegativeInteger index = src.getWellSampleIndex(i, q, w);
             dest.setWellSampleIndex(index, i, q, w);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String imageRef = src.getWellSampleImageRef(i, q, w);
             dest.setWellSampleImageRef(imageRef, i, q, w);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length positionX = src.getWellSamplePositionX(i, q, w);
             dest.setWellSamplePositionX(positionX, i, q, w);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length positionY = src.getWellSamplePositionY(i, q, w);
             dest.setWellSamplePositionY(positionY, i, q, w);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Timestamp timepoint = src.getWellSampleTimepoint(i, q, w);
             dest.setWellSampleTimepoint(timepoint, i, q, w);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
 
@@ -2362,7 +2362,7 @@ public final class MetadataConverter {
       try {
         plateAcquisitionCount = src.getPlateAcquisitionCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<plateAcquisitionCount; q++) {
         try {
           String plateAcquisitionID = src.getPlateAcquisitionID(i, q);
@@ -2376,56 +2376,56 @@ public final class MetadataConverter {
           String acquisitionDescription = src.getPlateAcquisitionDescription(i, q);
           dest.setPlateAcquisitionDescription(acquisitionDescription, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Timestamp endTime = src.getPlateAcquisitionEndTime(i, q);
           dest.setPlateAcquisitionEndTime(endTime, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger maximumFields = src.getPlateAcquisitionMaximumFieldCount(i, q);
           dest.setPlateAcquisitionMaximumFieldCount(maximumFields, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String acquisitionName = src.getPlateAcquisitionName(i, q);
           dest.setPlateAcquisitionName(acquisitionName, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Timestamp startTime = src.getPlateAcquisitionStartTime(i, q);
           dest.setPlateAcquisitionStartTime(startTime, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int plateAcquisitionAnnotationRefCount = 0;
         try {
           plateAcquisitionAnnotationRefCount = src.getPlateAcquisitionAnnotationRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int a=0; a<plateAcquisitionAnnotationRefCount; a++) {
           try {
             String plateAcquisitionAnnotationRef = src.getPlateAcquisitionAnnotationRef(i, q, a);
             dest.setPlateAcquisitionAnnotationRef(plateAcquisitionAnnotationRef, i, q, a);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
 
         int wellSampleRefCount = 0;
         try {
           wellSampleRefCount = src.getWellSampleRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int w=0; w<wellSampleRefCount; w++) {
           try {
             String wellSampleRef = src.getPlateAcquisitionWellSampleRef(i, q, w);
             dest.setPlateAcquisitionWellSampleRef(wellSampleRef, i, q, w);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
 
@@ -2433,13 +2433,13 @@ public final class MetadataConverter {
       try {
         plateAnnotationRefCount = src.getPlateAnnotationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<plateAnnotationRefCount; q++) {
         try {
           String annotationRef = src.getPlateAnnotationRef(i, q);
           dest.setPlateAnnotationRef(annotationRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -2455,7 +2455,7 @@ public final class MetadataConverter {
     try {
       projectCount = src.getProjectCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<projectCount; i++) {
       try {
         String projectID = src.getProjectID(i);
@@ -2469,50 +2469,50 @@ public final class MetadataConverter {
         String description = src.getProjectDescription(i);
         dest.setProjectDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String experimenterGroupRef = src.getProjectExperimenterGroupRef(i);
         dest.setProjectExperimenterGroupRef(experimenterGroupRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String experimenterRef = src.getProjectExperimenterRef(i);
         dest.setProjectExperimenterRef(experimenterRef, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String name = src.getProjectName(i);
         dest.setProjectName(name, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getProjectAnnotationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<annotationRefCount; q++) {
         try {
           String annotationRef = src.getProjectAnnotationRef(i, q);
           dest.setProjectAnnotationRef(annotationRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
 
       int datasetRefCount = 0;
       try {
         datasetRefCount = src.getDatasetRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<datasetRefCount; q++) {
         try {
           String datasetRef = src.getProjectDatasetRef(i, q);
           dest.setProjectDatasetRef(datasetRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -2527,7 +2527,7 @@ public final class MetadataConverter {
     try {
       roiCount = src.getROICount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<roiCount; i++) {
       try {
         String id = src.getROIID(i);
@@ -2541,19 +2541,19 @@ public final class MetadataConverter {
         String name = src.getROIName(i);
         dest.setROIName(name, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String description = src.getROIDescription(i);
         dest.setROIDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int shapeCount = 0;
       try {
         shapeCount = src.getShapeCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<shapeCount; q++) {
         String type = src.getShapeType(i, q);
 
@@ -2570,121 +2570,121 @@ public final class MetadataConverter {
             Color fillColor = src.getEllipseFillColor(i, q);
             dest.setEllipseFillColor(fillColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FillRule fillRule = src.getEllipseFillRule(i, q);
             dest.setEllipseFillRule(fillRule, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontFamily fontFamily = src.getEllipseFontFamily(i, q);
             dest.setEllipseFontFamily(fontFamily, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length fontSize = src.getEllipseFontSize(i, q);
             dest.setEllipseFontSize(fontSize, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontStyle fontStyle = src.getEllipseFontStyle(i, q);
             dest.setEllipseFontStyle(fontStyle, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Boolean locked = src.getEllipseLocked(i, q);
             dest.setEllipseLocked(locked, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Color strokeColor = src.getEllipseStrokeColor(i, q);
             dest.setEllipseStrokeColor(strokeColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String dashArray = src.getEllipseStrokeDashArray(i, q);
             dest.setEllipseStrokeDashArray(dashArray, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length strokeWidth = src.getEllipseStrokeWidth(i, q);
             dest.setEllipseStrokeWidth(strokeWidth, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String text = src.getEllipseText(i, q);
             dest.setEllipseText(text, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theC = src.getEllipseTheC(i, q);
             dest.setEllipseTheC(theC, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theT = src.getEllipseTheT(i, q);
             dest.setEllipseTheT(theT, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theZ = src.getEllipseTheZ(i, q);
             dest.setEllipseTheZ(theZ, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             AffineTransform transform = src.getEllipseTransform(i, q);
             dest.setEllipseTransform(transform, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
           Double radiusX = src.getEllipseRadiusX(i, q);
           dest.setEllipseRadiusX(radiusX, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double radiusY = src.getEllipseRadiusY(i, q);
             dest.setEllipseRadiusY(radiusY, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double x = src.getEllipseX(i, q);
             dest.setEllipseX(x, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double y = src.getEllipseY(i, q);
             dest.setEllipseY(y, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           int shapeAnnotationRefCount = 0;
           try {
             shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
               String shapeAnnotationRef = src.getEllipseAnnotationRef(i, q, r);
               dest.setEllipseAnnotationRef(shapeAnnotationRef, i, q, r);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
         else if (type.equals("Label")) {
@@ -2700,109 +2700,109 @@ public final class MetadataConverter {
             Color fillColor = src.getLabelFillColor(i, q);
             dest.setLabelFillColor(fillColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FillRule fillRule = src.getLabelFillRule(i, q);
             dest.setLabelFillRule(fillRule, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontFamily fontFamily = src.getLabelFontFamily(i, q);
             dest.setLabelFontFamily(fontFamily, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length fontSize = src.getLabelFontSize(i, q);
             dest.setLabelFontSize(fontSize, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontStyle fontStyle = src.getLabelFontStyle(i, q);
             dest.setLabelFontStyle(fontStyle, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Boolean locked = src.getLabelLocked(i, q);
             dest.setLabelLocked(locked, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Color strokeColor = src.getLabelStrokeColor(i, q);
             dest.setLabelStrokeColor(strokeColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String dashArray = src.getLabelStrokeDashArray(i, q);
             dest.setLabelStrokeDashArray(dashArray, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length strokeWidth = src.getLabelStrokeWidth(i, q);
             dest.setLabelStrokeWidth(strokeWidth, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String text = src.getLabelText(i, q);
             dest.setLabelText(text, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theC = src.getLabelTheC(i, q);
             dest.setLabelTheC(theC, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theT = src.getLabelTheT(i, q);
             dest.setLabelTheT(theT, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theZ = src.getLabelTheZ(i, q);
             dest.setLabelTheZ(theZ, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             AffineTransform transform = src.getLabelTransform(i, q);
             dest.setLabelTransform(transform, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double x = src.getLabelX(i, q);
             dest.setLabelX(x, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double y = src.getLabelY(i, q);
             dest.setLabelY(y, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           int shapeAnnotationRefCount = 0;
           try {
             shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
               String shapeAnnotationRef = src.getLabelAnnotationRef(i, q, r);
               dest.setLabelAnnotationRef(shapeAnnotationRef, i, q, r);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
         else if (type.equals("Line")) {
@@ -2818,133 +2818,133 @@ public final class MetadataConverter {
             Color fillColor = src.getLineFillColor(i, q);
             dest.setLineFillColor(fillColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FillRule fillRule = src.getLineFillRule(i, q);
             dest.setLineFillRule(fillRule, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontFamily fontFamily = src.getLineFontFamily(i, q);
             dest.setLineFontFamily(fontFamily, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length fontSize = src.getLineFontSize(i, q);
             dest.setLineFontSize(fontSize, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontStyle fontStyle = src.getLineFontStyle(i, q);
             dest.setLineFontStyle(fontStyle, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Boolean locked = src.getLineLocked(i, q);
             dest.setLineLocked(locked, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Color strokeColor = src.getLineStrokeColor(i, q);
             dest.setLineStrokeColor(strokeColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String dashArray = src.getLineStrokeDashArray(i, q);
             dest.setLineStrokeDashArray(dashArray, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length strokeWidth = src.getLineStrokeWidth(i, q);
             dest.setLineStrokeWidth(strokeWidth, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String text = src.getLineText(i, q);
             dest.setLineText(text, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theC = src.getLineTheC(i, q);
             dest.setLineTheC(theC, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theT = src.getLineTheT(i, q);
             dest.setLineTheT(theT, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theZ = src.getLineTheZ(i, q);
             dest.setLineTheZ(theZ, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             AffineTransform transform = src.getLineTransform(i, q);
             dest.setLineTransform(transform, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Marker end = src.getLineMarkerEnd(i, q);
             dest.setLineMarkerEnd(end, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Marker start = src.getLineMarkerStart(i, q);
             dest.setLineMarkerStart(start, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double x1 = src.getLineX1(i, q);
             dest.setLineX1(x1, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double x2 = src.getLineX2(i, q);
             dest.setLineX2(x2, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double y1 = src.getLineY1(i, q);
             dest.setLineY1(y1, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double y2 = src.getLineY2(i, q);
             dest.setLineY2(y2, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           int shapeAnnotationRefCount = 0;
           try {
             shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
               String shapeAnnotationRef = src.getLineAnnotationRef(i, q, r);
               dest.setLineAnnotationRef(shapeAnnotationRef, i, q, r);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
         else if (type.equals("Mask")) {
@@ -2960,145 +2960,145 @@ public final class MetadataConverter {
             Color fillColor = src.getMaskFillColor(i, q);
             dest.setMaskFillColor(fillColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FillRule fillRule = src.getMaskFillRule(i, q);
             dest.setMaskFillRule(fillRule, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontFamily fontFamily = src.getMaskFontFamily(i, q);
             dest.setMaskFontFamily(fontFamily, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length fontSize = src.getMaskFontSize(i, q);
             dest.setMaskFontSize(fontSize, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontStyle fontStyle = src.getMaskFontStyle(i, q);
             dest.setMaskFontStyle(fontStyle, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Boolean locked = src.getMaskLocked(i, q);
             dest.setMaskLocked(locked, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Color strokeColor = src.getMaskStrokeColor(i, q);
             dest.setMaskStrokeColor(strokeColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String dashArray = src.getMaskStrokeDashArray(i, q);
             dest.setMaskStrokeDashArray(dashArray, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length strokeWidth = src.getMaskStrokeWidth(i, q);
             dest.setMaskStrokeWidth(strokeWidth, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String text = src.getMaskText(i, q);
             dest.setMaskText(text, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theC = src.getMaskTheC(i, q);
             dest.setMaskTheC(theC, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theT = src.getMaskTheT(i, q);
             dest.setMaskTheT(theT, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theZ = src.getMaskTheZ(i, q);
             dest.setMaskTheZ(theZ, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             AffineTransform transform = src.getMaskTransform(i, q);
             dest.setMaskTransform(transform, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double height = src.getMaskHeight(i, q);
             dest.setMaskHeight(height, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double width = src.getMaskWidth(i, q);
             dest.setMaskWidth(width, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double x = src.getMaskX(i, q);
             dest.setMaskX(x, i, q);
           }
-          catch (NullPointerException e) { }
-          
+          catch (NullPointerException ignored) { }
+
           try {
             byte[] binData = src.getMaskBinData(i, q);
             dest.setMaskBinData(binData, i, q);
           }
-          catch (NullPointerException e) { }
-          
+          catch (NullPointerException ignored) { }
+
           try {
             boolean bigEndian = src.getMaskBinDataBigEndian(i, q);
             dest.setMaskBinDataBigEndian(bigEndian, i, q);
           }
-          catch (NullPointerException e) { }
-          
+          catch (NullPointerException ignored) { }
+
           try {
             NonNegativeLong length = src.getMaskBinDataLength(i, q);
             dest.setMaskBinDataLength(length, i, q);
           }
-          catch (NullPointerException e) { }
-          
+          catch (NullPointerException ignored) { }
+
           try {
             Compression compression = src.getMaskBinDataCompression(i, q);
             dest.setMaskBinDataCompression(compression, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double y = src.getMaskY(i, q);
             dest.setMaskY(y, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           int shapeAnnotationRefCount = 0;
           try {
             shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
               String shapeAnnotationRef = src.getMaskAnnotationRef(i, q, r);
               dest.setMaskAnnotationRef(shapeAnnotationRef, i, q, r);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
         else if (type.equals("Point")) {
@@ -3114,109 +3114,109 @@ public final class MetadataConverter {
             Color fillColor = src.getPointFillColor(i, q);
             dest.setPointFillColor(fillColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FillRule fillRule = src.getPointFillRule(i, q);
             dest.setPointFillRule(fillRule, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontFamily fontFamily = src.getPointFontFamily(i, q);
             dest.setPointFontFamily(fontFamily, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length fontSize = src.getPointFontSize(i, q);
             dest.setPointFontSize(fontSize, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontStyle fontStyle = src.getPointFontStyle(i, q);
             dest.setPointFontStyle(fontStyle, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Boolean locked = src.getPointLocked(i, q);
             dest.setPointLocked(locked, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Color strokeColor = src.getPointStrokeColor(i, q);
             dest.setPointStrokeColor(strokeColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String dashArray = src.getPointStrokeDashArray(i, q);
             dest.setPointStrokeDashArray(dashArray, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length strokeWidth = src.getPointStrokeWidth(i, q);
             dest.setPointStrokeWidth(strokeWidth, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String text = src.getPointText(i, q);
             dest.setPointText(text, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theC = src.getPointTheC(i, q);
             dest.setPointTheC(theC, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theT = src.getPointTheT(i, q);
             dest.setPointTheT(theT, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theZ = src.getPointTheZ(i, q);
             dest.setPointTheZ(theZ, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             AffineTransform transform = src.getPointTransform(i, q);
             dest.setPointTransform(transform, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double x = src.getPointX(i, q);
             dest.setPointX(x, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double y = src.getPointY(i, q);
             dest.setPointY(y, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           int shapeAnnotationRefCount = 0;
           try {
             shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
               String shapeAnnotationRef = src.getPointAnnotationRef(i, q, r);
               dest.setPointAnnotationRef(shapeAnnotationRef, i, q, r);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
         else if (type.equals("Polygon")) {
@@ -3232,103 +3232,103 @@ public final class MetadataConverter {
             Color fillColor = src.getPolygonFillColor(i, q);
             dest.setPolygonFillColor(fillColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FillRule fillRule = src.getPolygonFillRule(i, q);
             dest.setPolygonFillRule(fillRule, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontFamily fontFamily = src.getPolygonFontFamily(i, q);
             dest.setPolygonFontFamily(fontFamily, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length fontSize = src.getPolygonFontSize(i, q);
             dest.setPolygonFontSize(fontSize, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontStyle fontStyle = src.getPolygonFontStyle(i, q);
             dest.setPolygonFontStyle(fontStyle, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Boolean locked = src.getPolygonLocked(i, q);
             dest.setPolygonLocked(locked, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Color strokeColor = src.getPolygonStrokeColor(i, q);
             dest.setPolygonStrokeColor(strokeColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String dashArray = src.getPolygonStrokeDashArray(i, q);
             dest.setPolygonStrokeDashArray(dashArray, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length strokeWidth = src.getPolygonStrokeWidth(i, q);
             dest.setPolygonStrokeWidth(strokeWidth, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String text = src.getPolygonText(i, q);
             dest.setPolygonText(text, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theC = src.getPolygonTheC(i, q);
             dest.setPolygonTheC(theC, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theT = src.getPolygonTheT(i, q);
             dest.setPolygonTheT(theT, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theZ = src.getPolygonTheZ(i, q);
             dest.setPolygonTheZ(theZ, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             AffineTransform transform = src.getPolygonTransform(i, q);
             dest.setPolygonTransform(transform, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String points = src.getPolygonPoints(i, q);
             dest.setPolygonPoints(points, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           int shapeAnnotationRefCount = 0;
           try {
             shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
               String shapeAnnotationRef = src.getPolygonAnnotationRef(i, q, r);
               dest.setPolygonAnnotationRef(shapeAnnotationRef, i, q, r);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
         else if (type.equals("Polyline")) {
@@ -3344,115 +3344,115 @@ public final class MetadataConverter {
             Color fillColor = src.getPolylineFillColor(i, q);
             dest.setPolylineFillColor(fillColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FillRule fillRule = src.getPolylineFillRule(i, q);
             dest.setPolylineFillRule(fillRule, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontFamily fontFamily = src.getPolylineFontFamily(i, q);
             dest.setPolylineFontFamily(fontFamily, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length fontSize = src.getPolylineFontSize(i, q);
             dest.setPolylineFontSize(fontSize, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontStyle fontStyle = src.getPolylineFontStyle(i, q);
             dest.setPolylineFontStyle(fontStyle, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Boolean locked = src.getPolylineLocked(i, q);
             dest.setPolylineLocked(locked, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Color strokeColor = src.getPolylineStrokeColor(i, q);
             dest.setPolylineStrokeColor(strokeColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String dashArray = src.getPolylineStrokeDashArray(i, q);
             dest.setPolylineStrokeDashArray(dashArray, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length strokeWidth = src.getPolylineStrokeWidth(i, q);
             dest.setPolylineStrokeWidth(strokeWidth, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String text = src.getPolylineText(i, q);
             dest.setPolylineText(text, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theC = src.getPolylineTheC(i, q);
             dest.setPolylineTheC(theC, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theT = src.getPolylineTheT(i, q);
             dest.setPolylineTheT(theT, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theZ = src.getPolylineTheZ(i, q);
             dest.setPolylineTheZ(theZ, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             AffineTransform transform = src.getPolylineTransform(i, q);
             dest.setPolylineTransform(transform, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Marker end = src.getPolylineMarkerEnd(i, q);
             dest.setPolylineMarkerEnd(end, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Marker start = src.getPolylineMarkerStart(i, q);
             dest.setPolylineMarkerStart(start, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String points = src.getPolylinePoints(i, q);
             dest.setPolylinePoints(points, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           int shapeAnnotationRefCount = 0;
           try {
             shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
               String shapeAnnotationRef = src.getPolylineAnnotationRef(i, q, r);
               dest.setPolylineAnnotationRef(shapeAnnotationRef, i, q, r);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
         else if (type.equals("Rectangle")) {
@@ -3468,121 +3468,121 @@ public final class MetadataConverter {
             Color fillColor = src.getRectangleFillColor(i, q);
             dest.setRectangleFillColor(fillColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FillRule fillRule = src.getRectangleFillRule(i, q);
             dest.setRectangleFillRule(fillRule, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontFamily fontFamily = src.getRectangleFontFamily(i, q);
             dest.setRectangleFontFamily(fontFamily, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length fontSize = src.getRectangleFontSize(i, q);
             dest.setRectangleFontSize(fontSize, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             FontStyle fontStyle = src.getRectangleFontStyle(i, q);
             dest.setRectangleFontStyle(fontStyle, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Boolean locked = src.getRectangleLocked(i, q);
             dest.setRectangleLocked(locked, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Color strokeColor = src.getRectangleStrokeColor(i, q);
             dest.setRectangleStrokeColor(strokeColor, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String dashArray = src.getRectangleStrokeDashArray(i, q);
             dest.setRectangleStrokeDashArray(dashArray, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Length strokeWidth = src.getRectangleStrokeWidth(i, q);
             dest.setRectangleStrokeWidth(strokeWidth, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             String text = src.getRectangleText(i, q);
             dest.setRectangleText(text, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theC = src.getRectangleTheC(i, q);
             dest.setRectangleTheC(theC, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theT = src.getRectangleTheT(i, q);
             dest.setRectangleTheT(theT, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             NonNegativeInteger theZ = src.getRectangleTheZ(i, q);
             dest.setRectangleTheZ(theZ, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             AffineTransform transform = src.getRectangleTransform(i, q);
             dest.setRectangleTransform(transform, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double height = src.getRectangleHeight(i, q);
             dest.setRectangleHeight(height, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double width = src.getRectangleWidth(i, q);
             dest.setRectangleWidth(width, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double x = src.getRectangleX(i, q);
             dest.setRectangleX(x, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           try {
             Double y = src.getRectangleY(i, q);
             dest.setRectangleY(y, i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
 
           int shapeAnnotationRefCount = 0;
           try {
             shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
           for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
               String shapeAnnotationRef = src.getRectangleAnnotationRef(i, q, r);
               dest.setRectangleAnnotationRef(shapeAnnotationRef, i, q, r);
             }
-            catch (NullPointerException e) { }
+            catch (NullPointerException ignored) { }
           }
         }
       }
@@ -3591,13 +3591,13 @@ public final class MetadataConverter {
       try {
         annotationRefCount = src.getROIAnnotationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<annotationRefCount; q++) {
         try {
           String annotationRef = src.getROIAnnotationRef(i, q);
           dest.setROIAnnotationRef(annotationRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -3612,7 +3612,7 @@ public final class MetadataConverter {
     try {
       screenCount = src.getScreenCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<screenCount; i++) {
       try {
         String id = src.getScreenID(i);
@@ -3626,7 +3626,7 @@ public final class MetadataConverter {
         String description = src.getScreenDescription(i);
         dest.setScreenDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       // NB: screen name is required in OMERO
       try {
@@ -3636,7 +3636,7 @@ public final class MetadataConverter {
         }
         dest.setScreenName(name, i);
       }
-      catch (NullPointerException e) {
+      catch (NullPointerException ignored) {
         dest.setScreenName("", i);
       }
 
@@ -3644,63 +3644,63 @@ public final class MetadataConverter {
         String protocolDescription = src.getScreenProtocolDescription(i);
         dest.setScreenProtocolDescription(protocolDescription, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String protocolIdentifier = src.getScreenProtocolIdentifier(i);
         dest.setScreenProtocolIdentifier(protocolIdentifier, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String reagentSetDescription = src.getScreenReagentSetDescription(i);
         dest.setScreenReagentSetDescription(reagentSetDescription, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String reagentSetIdentifier = src.getScreenReagentSetIdentifier(i);
         dest.setScreenReagentSetIdentifier(reagentSetIdentifier, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String type = src.getScreenType(i);
         dest.setScreenType(type, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int plateRefCount = 0;
       try {
         plateRefCount = src.getPlateRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<plateRefCount; q++) {
         try {
           String plateRef = src.getScreenPlateRef(i, q);
           dest.setScreenPlateRef(plateRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getScreenAnnotationRefCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<annotationRefCount; q++) {
         try {
           String annotationRef = src.getScreenAnnotationRef(i, q);
           dest.setScreenAnnotationRef(annotationRef, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
 
       int reagentCount = 0;
       try {
         reagentCount = src.getReagentCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int q=0; q<reagentCount; q++) {
         try {
           String reagentID = src.getReagentID(i, q);
@@ -3714,31 +3714,31 @@ public final class MetadataConverter {
           String reagentDescription = src.getReagentDescription(i, q);
           dest.setReagentDescription(reagentDescription, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String reagentName = src.getReagentName(i, q);
           dest.setReagentName(reagentName, i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String reagentIdentifier = src.getReagentReagentIdentifier(i, q);
           dest.setReagentReagentIdentifier(reagentIdentifier, i ,q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int reagentAnnotationRefCount = 0;
         try {
           reagentAnnotationRefCount = src.getReagentAnnotationRefCount(i, q);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<reagentAnnotationRefCount; r++) {
           try {
             String reagentAnnotationRef = src.getReagentAnnotationRef(i, q, r);
             dest.setReagentAnnotationRef(reagentAnnotationRef, i, q, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
     }
@@ -3756,7 +3756,7 @@ public final class MetadataConverter {
     try {
       tagAnnotationCount = src.getTagAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<tagAnnotationCount; i++) {
       try {
         String id = src.getTagAnnotationID(i);
@@ -3770,37 +3770,37 @@ public final class MetadataConverter {
         String description = src.getTagAnnotationDescription(i);
         dest.setTagAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getTagAnnotationNamespace(i);
         dest.setTagAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String value = src.getTagAnnotationValue(i);
         dest.setTagAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getTagAnnotationAnnotator(i);
         dest.setTagAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getTagAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getTagAnnotationAnnotationRef(i, a);
           dest.setTagAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -3817,7 +3817,7 @@ public final class MetadataConverter {
     try {
       termAnnotationCount = src.getTermAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<termAnnotationCount; i++) {
       try {
         String id = src.getTermAnnotationID(i);
@@ -3831,37 +3831,37 @@ public final class MetadataConverter {
         String description = src.getTermAnnotationDescription(i);
         dest.setTermAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getTermAnnotationNamespace(i);
         dest.setTermAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String value = src.getTermAnnotationValue(i);
         dest.setTermAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getTermAnnotationAnnotator(i);
         dest.setTermAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getTermAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getTermAnnotationAnnotationRef(i, a);
           dest.setTermAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -3878,7 +3878,7 @@ public final class MetadataConverter {
     try {
       timestampAnnotationCount = src.getTimestampAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<timestampAnnotationCount; i++) {
       try {
         String id = src.getTimestampAnnotationID(i);
@@ -3892,37 +3892,37 @@ public final class MetadataConverter {
         String description = src.getTimestampAnnotationDescription(i);
         dest.setTimestampAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getTimestampAnnotationNamespace(i);
         dest.setTimestampAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         Timestamp value = src.getTimestampAnnotationValue(i);
         dest.setTimestampAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getTimestampAnnotationAnnotator(i);
         dest.setTimestampAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getTimestampAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getTimestampAnnotationAnnotationRef(i, a);
           dest.setTimestampAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -3939,7 +3939,7 @@ public final class MetadataConverter {
     try {
       xmlAnnotationCount = src.getXMLAnnotationCount();
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
     for (int i=0; i<xmlAnnotationCount; i++) {
       try {
         String id = src.getXMLAnnotationID(i);
@@ -3953,37 +3953,37 @@ public final class MetadataConverter {
         String description = src.getXMLAnnotationDescription(i);
         dest.setXMLAnnotationDescription(description, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String namespace = src.getXMLAnnotationNamespace(i);
         dest.setXMLAnnotationNamespace(namespace, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String value = src.getXMLAnnotationValue(i);
         dest.setXMLAnnotationValue(value, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       try {
         String annotator = src.getXMLAnnotationAnnotator(i);
         dest.setXMLAnnotationAnnotator(annotator, i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
 
       int annotationRefCount = 0;
       try {
         annotationRefCount = src.getXMLAnnotationAnnotationCount(i);
       }
-      catch (NullPointerException e) { }
+      catch (NullPointerException ignored) { }
       for (int a=0; a<annotationRefCount; a++) {
         try {
           String id = src.getXMLAnnotationAnnotationRef(i, a);
           dest.setXMLAnnotationAnnotationRef(id, i, a);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
       }
     }
   }
@@ -4002,7 +4002,7 @@ public final class MetadataConverter {
     try {
       lightSourceCount = src.getLightSourceCount(instrumentIndex);
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     for (int lightSource=0; lightSource<lightSourceCount; lightSource++) {
       String type = src.getLightSourceType(instrumentIndex, lightSource);
@@ -4024,7 +4024,7 @@ public final class MetadataConverter {
             dest.setArcLotNumber(lotNumber, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer =
@@ -4033,7 +4033,7 @@ public final class MetadataConverter {
             dest.setArcManufacturer(manufacturer, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model = src.getArcModel(instrumentIndex, lightSource);
@@ -4041,7 +4041,7 @@ public final class MetadataConverter {
             dest.setArcModel(model, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Power power = src.getArcPower(instrumentIndex, lightSource);
@@ -4049,7 +4049,7 @@ public final class MetadataConverter {
             dest.setArcPower(power, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber =
@@ -4058,7 +4058,7 @@ public final class MetadataConverter {
             dest.setArcSerialNumber(serialNumber, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           ArcType arcType = src.getArcType(instrumentIndex, lightSource);
@@ -4066,19 +4066,19 @@ public final class MetadataConverter {
             dest.setArcType(arcType, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int lightSourceAnnotationRefCount = 0;
         try {
           lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
             String lightSourceAnnotationRef = src.getArcAnnotationRef(instrumentIndex, lightSource, r);
             dest.setArcAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
       else if (type.equals("Filament")) {
@@ -4100,7 +4100,7 @@ public final class MetadataConverter {
             dest.setFilamentLotNumber(lotNumber, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer =
@@ -4110,7 +4110,7 @@ public final class MetadataConverter {
               manufacturer, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model = src.getFilamentModel(instrumentIndex, lightSource);
@@ -4118,7 +4118,7 @@ public final class MetadataConverter {
             dest.setFilamentModel(model, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Power power = src.getFilamentPower(instrumentIndex, lightSource);
@@ -4126,7 +4126,7 @@ public final class MetadataConverter {
             dest.setFilamentPower(power, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber =
@@ -4136,7 +4136,7 @@ public final class MetadataConverter {
               serialNumber, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           FilamentType filamentType =
@@ -4145,19 +4145,19 @@ public final class MetadataConverter {
             dest.setFilamentType(filamentType, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int lightSourceAnnotationRefCount = 0;
         try {
           lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
             String lightSourceAnnotationRef = src.getFilamentAnnotationRef(instrumentIndex, lightSource, r);
             dest.setFilamentAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
       else if (type.equals("GenericExcitationSource")) {
@@ -4178,7 +4178,7 @@ public final class MetadataConverter {
             src.getGenericExcitationSourceMap(instrumentIndex, lightSource);
           dest.setGenericExcitationSourceMap(map, instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String lotNumber = src.getGenericExcitationSourceLotNumber(
@@ -4186,7 +4186,7 @@ public final class MetadataConverter {
           dest.setGenericExcitationSourceLotNumber(lotNumber,
             instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer = src.getGenericExcitationSourceManufacturer(
@@ -4194,7 +4194,7 @@ public final class MetadataConverter {
           dest.setGenericExcitationSourceManufacturer(manufacturer,
             instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model =
@@ -4202,7 +4202,7 @@ public final class MetadataConverter {
           dest.setGenericExcitationSourceModel(model,
             instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Power power =
@@ -4210,7 +4210,7 @@ public final class MetadataConverter {
           dest.setGenericExcitationSourcePower(power,
             instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber = src.getGenericExcitationSourceSerialNumber(
@@ -4218,19 +4218,19 @@ public final class MetadataConverter {
           dest.setGenericExcitationSourceSerialNumber(serialNumber,
             instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int lightSourceAnnotationRefCount = 0;
         try {
           lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
             String lightSourceAnnotationRef = src.getGenericExcitationSourceAnnotationRef(instrumentIndex, lightSource, r);
             dest.setGenericExcitationSourceAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
       else if (type.equals("Laser")) {
@@ -4252,7 +4252,7 @@ public final class MetadataConverter {
             dest.setLaserLotNumber(lotNumber, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer =
@@ -4262,7 +4262,7 @@ public final class MetadataConverter {
               manufacturer, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model = src.getLaserModel(instrumentIndex, lightSource);
@@ -4270,7 +4270,7 @@ public final class MetadataConverter {
             dest.setLaserModel(model, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Power power = src.getLaserPower(instrumentIndex, lightSource);
@@ -4278,7 +4278,7 @@ public final class MetadataConverter {
             dest.setLaserPower(power, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber =
@@ -4288,7 +4288,7 @@ public final class MetadataConverter {
               serialNumber, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           LaserType laserType = src.getLaserType(instrumentIndex, lightSource);
@@ -4296,7 +4296,7 @@ public final class MetadataConverter {
             dest.setLaserType(laserType, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           PositiveInteger frequencyMultiplication =
@@ -4306,7 +4306,7 @@ public final class MetadataConverter {
               frequencyMultiplication, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           LaserMedium medium =
@@ -4315,7 +4315,7 @@ public final class MetadataConverter {
             dest.setLaserLaserMedium(medium, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Boolean pockelCell =
@@ -4324,7 +4324,7 @@ public final class MetadataConverter {
             dest.setLaserPockelCell(pockelCell, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Pulse pulse = src.getLaserPulse(instrumentIndex, lightSource);
@@ -4332,7 +4332,7 @@ public final class MetadataConverter {
             dest.setLaserPulse(pulse, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String pump = src.getLaserPump(instrumentIndex, lightSource);
@@ -4340,7 +4340,7 @@ public final class MetadataConverter {
             dest.setLaserPump(pump, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Frequency repetitionRate =
@@ -4350,7 +4350,7 @@ public final class MetadataConverter {
               repetitionRate, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Boolean tuneable = src.getLaserTuneable(instrumentIndex, lightSource);
@@ -4358,7 +4358,7 @@ public final class MetadataConverter {
             dest.setLaserTuneable(tuneable, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Length wavelength =
@@ -4367,19 +4367,19 @@ public final class MetadataConverter {
             dest.setLaserWavelength(wavelength, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int lightSourceAnnotationRefCount = 0;
         try {
           lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
             String lightSourceAnnotationRef = src.getLaserAnnotationRef(instrumentIndex, lightSource, r);
             dest.setLaserAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
       else if (type.equals("LightEmittingDiode")) {
@@ -4402,7 +4402,7 @@ public final class MetadataConverter {
               lotNumber, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String manufacturer =
@@ -4412,7 +4412,7 @@ public final class MetadataConverter {
               manufacturer, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String model =
@@ -4422,7 +4422,7 @@ public final class MetadataConverter {
               model, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           Power power =
@@ -4432,7 +4432,7 @@ public final class MetadataConverter {
               power, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         try {
           String serialNumber =
@@ -4442,19 +4442,19 @@ public final class MetadataConverter {
               serialNumber, instrumentIndex, lightSource);
           }
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
 
         int lightSourceAnnotationRefCount = 0;
         try {
           lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
         }
-        catch (NullPointerException e) { }
+        catch (NullPointerException ignored) { }
         for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
             String lightSourceAnnotationRef = src.getLightEmittingDiodeAnnotationRef(instrumentIndex, lightSource, r);
             dest.setLightEmittingDiodeAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
           }
-          catch (NullPointerException e) { }
+          catch (NullPointerException ignored) { }
         }
       }
     }
@@ -4473,7 +4473,7 @@ public final class MetadataConverter {
         dest.setUUID(uuid);
       }
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String creator = src.getCreator();
@@ -4481,7 +4481,7 @@ public final class MetadataConverter {
         dest.setCreator(creator);
       }
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String rightsHeld = src.getRightsRightsHeld();
@@ -4489,7 +4489,7 @@ public final class MetadataConverter {
         dest.setRightsRightsHeld(rightsHeld);
       }
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String rightsHolder = src.getRightsRightsHolder();
@@ -4497,7 +4497,7 @@ public final class MetadataConverter {
         dest.setRightsRightsHolder(rightsHolder);
       }
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String metadataFile = src.getBinaryOnlyMetadataFile();
@@ -4505,7 +4505,7 @@ public final class MetadataConverter {
         dest.setBinaryOnlyMetadataFile(metadataFile);
       }
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
 
     try {
       String uuid = src.getBinaryOnlyUUID();
@@ -4513,7 +4513,7 @@ public final class MetadataConverter {
         dest.setBinaryOnlyUUID(uuid);
       }
     }
-    catch (NullPointerException e) { }
+    catch (NullPointerException ignored) { }
   }
 
 }

--- a/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
@@ -1512,7 +1512,7 @@ public final class MetadataConverter {
   private static List<String> convertInstruments(MetadataRetrieve src,
     MetadataStore dest)
   {
-    List<String> lightSourceIds = new ArrayList<String>();
+    List<String> lightSourceIds = new ArrayList<>();
     int instrumentCount = 0;
     try {
       instrumentCount = src.getInstrumentCount();

--- a/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
@@ -2557,1032 +2557,1042 @@ public final class MetadataConverter {
       for (int q=0; q<shapeCount; q++) {
         String type = src.getShapeType(i, q);
 
-        if (type.equals("Ellipse")) {
-          try {
-            String shapeID = src.getEllipseID(i, q);
-            dest.setEllipseID(shapeID, i, q);
-          }
-          catch (NullPointerException e) {
-            continue;
-          }
-
-          try {
-            Color fillColor = src.getEllipseFillColor(i, q);
-            dest.setEllipseFillColor(fillColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FillRule fillRule = src.getEllipseFillRule(i, q);
-            dest.setEllipseFillRule(fillRule, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontFamily fontFamily = src.getEllipseFontFamily(i, q);
-            dest.setEllipseFontFamily(fontFamily, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length fontSize = src.getEllipseFontSize(i, q);
-            dest.setEllipseFontSize(fontSize, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontStyle fontStyle = src.getEllipseFontStyle(i, q);
-            dest.setEllipseFontStyle(fontStyle, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Boolean locked = src.getEllipseLocked(i, q);
-            dest.setEllipseLocked(locked, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Color strokeColor = src.getEllipseStrokeColor(i, q);
-            dest.setEllipseStrokeColor(strokeColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String dashArray = src.getEllipseStrokeDashArray(i, q);
-            dest.setEllipseStrokeDashArray(dashArray, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length strokeWidth = src.getEllipseStrokeWidth(i, q);
-            dest.setEllipseStrokeWidth(strokeWidth, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String text = src.getEllipseText(i, q);
-            dest.setEllipseText(text, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theC = src.getEllipseTheC(i, q);
-            dest.setEllipseTheC(theC, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theT = src.getEllipseTheT(i, q);
-            dest.setEllipseTheT(theT, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theZ = src.getEllipseTheZ(i, q);
-            dest.setEllipseTheZ(theZ, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            AffineTransform transform = src.getEllipseTransform(i, q);
-            dest.setEllipseTransform(transform, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-          Double radiusX = src.getEllipseRadiusX(i, q);
-          dest.setEllipseRadiusX(radiusX, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double radiusY = src.getEllipseRadiusY(i, q);
-            dest.setEllipseRadiusY(radiusY, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double x = src.getEllipseX(i, q);
-            dest.setEllipseX(x, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double y = src.getEllipseY(i, q);
-            dest.setEllipseY(y, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          int shapeAnnotationRefCount = 0;
-          try {
-            shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
-          }
-          catch (NullPointerException ignored) { }
-          for (int r=0; r<shapeAnnotationRefCount; r++) {
+        switch (type) {
+          case "Ellipse": {
             try {
-              String shapeAnnotationRef = src.getEllipseAnnotationRef(i, q, r);
-              dest.setEllipseAnnotationRef(shapeAnnotationRef, i, q, r);
+              String shapeID = src.getEllipseID(i, q);
+              dest.setEllipseID(shapeID, i, q);
+            }
+            catch (NullPointerException e) {
+              continue;
+            }
+
+            try {
+              Color fillColor = src.getEllipseFillColor(i, q);
+              dest.setEllipseFillColor(fillColor, i, q);
             }
             catch (NullPointerException ignored) { }
-          }
-        }
-        else if (type.equals("Label")) {
-          try {
-            String shapeID = src.getLabelID(i, q);
-            dest.setLabelID(shapeID, i, q);
-          }
-          catch (NullPointerException e) {
-            continue;
-          }
 
-          try {
-            Color fillColor = src.getLabelFillColor(i, q);
-            dest.setLabelFillColor(fillColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FillRule fillRule = src.getLabelFillRule(i, q);
-            dest.setLabelFillRule(fillRule, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontFamily fontFamily = src.getLabelFontFamily(i, q);
-            dest.setLabelFontFamily(fontFamily, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length fontSize = src.getLabelFontSize(i, q);
-            dest.setLabelFontSize(fontSize, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontStyle fontStyle = src.getLabelFontStyle(i, q);
-            dest.setLabelFontStyle(fontStyle, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Boolean locked = src.getLabelLocked(i, q);
-            dest.setLabelLocked(locked, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Color strokeColor = src.getLabelStrokeColor(i, q);
-            dest.setLabelStrokeColor(strokeColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String dashArray = src.getLabelStrokeDashArray(i, q);
-            dest.setLabelStrokeDashArray(dashArray, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length strokeWidth = src.getLabelStrokeWidth(i, q);
-            dest.setLabelStrokeWidth(strokeWidth, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String text = src.getLabelText(i, q);
-            dest.setLabelText(text, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theC = src.getLabelTheC(i, q);
-            dest.setLabelTheC(theC, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theT = src.getLabelTheT(i, q);
-            dest.setLabelTheT(theT, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theZ = src.getLabelTheZ(i, q);
-            dest.setLabelTheZ(theZ, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            AffineTransform transform = src.getLabelTransform(i, q);
-            dest.setLabelTransform(transform, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double x = src.getLabelX(i, q);
-            dest.setLabelX(x, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double y = src.getLabelY(i, q);
-            dest.setLabelY(y, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          int shapeAnnotationRefCount = 0;
-          try {
-            shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
-          }
-          catch (NullPointerException ignored) { }
-          for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
-              String shapeAnnotationRef = src.getLabelAnnotationRef(i, q, r);
-              dest.setLabelAnnotationRef(shapeAnnotationRef, i, q, r);
+              FillRule fillRule = src.getEllipseFillRule(i, q);
+              dest.setEllipseFillRule(fillRule, i, q);
             }
             catch (NullPointerException ignored) { }
-          }
-        }
-        else if (type.equals("Line")) {
-          try {
-            String shapeID = src.getLineID(i, q);
-            dest.setLineID(shapeID, i, q);
-          }
-          catch (NullPointerException e) {
-            continue;
-          }
 
-          try {
-            Color fillColor = src.getLineFillColor(i, q);
-            dest.setLineFillColor(fillColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FillRule fillRule = src.getLineFillRule(i, q);
-            dest.setLineFillRule(fillRule, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontFamily fontFamily = src.getLineFontFamily(i, q);
-            dest.setLineFontFamily(fontFamily, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length fontSize = src.getLineFontSize(i, q);
-            dest.setLineFontSize(fontSize, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontStyle fontStyle = src.getLineFontStyle(i, q);
-            dest.setLineFontStyle(fontStyle, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Boolean locked = src.getLineLocked(i, q);
-            dest.setLineLocked(locked, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Color strokeColor = src.getLineStrokeColor(i, q);
-            dest.setLineStrokeColor(strokeColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String dashArray = src.getLineStrokeDashArray(i, q);
-            dest.setLineStrokeDashArray(dashArray, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length strokeWidth = src.getLineStrokeWidth(i, q);
-            dest.setLineStrokeWidth(strokeWidth, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String text = src.getLineText(i, q);
-            dest.setLineText(text, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theC = src.getLineTheC(i, q);
-            dest.setLineTheC(theC, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theT = src.getLineTheT(i, q);
-            dest.setLineTheT(theT, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theZ = src.getLineTheZ(i, q);
-            dest.setLineTheZ(theZ, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            AffineTransform transform = src.getLineTransform(i, q);
-            dest.setLineTransform(transform, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Marker end = src.getLineMarkerEnd(i, q);
-            dest.setLineMarkerEnd(end, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Marker start = src.getLineMarkerStart(i, q);
-            dest.setLineMarkerStart(start, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double x1 = src.getLineX1(i, q);
-            dest.setLineX1(x1, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double x2 = src.getLineX2(i, q);
-            dest.setLineX2(x2, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double y1 = src.getLineY1(i, q);
-            dest.setLineY1(y1, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double y2 = src.getLineY2(i, q);
-            dest.setLineY2(y2, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          int shapeAnnotationRefCount = 0;
-          try {
-            shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
-          }
-          catch (NullPointerException ignored) { }
-          for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
-              String shapeAnnotationRef = src.getLineAnnotationRef(i, q, r);
-              dest.setLineAnnotationRef(shapeAnnotationRef, i, q, r);
+              FontFamily fontFamily = src.getEllipseFontFamily(i, q);
+              dest.setEllipseFontFamily(fontFamily, i, q);
             }
             catch (NullPointerException ignored) { }
-          }
-        }
-        else if (type.equals("Mask")) {
-          try {
-            String shapeID = src.getMaskID(i, q);
-            dest.setMaskID(shapeID, i, q);
-          }
-          catch (NullPointerException e) {
-            continue;
-          }
 
-          try {
-            Color fillColor = src.getMaskFillColor(i, q);
-            dest.setMaskFillColor(fillColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FillRule fillRule = src.getMaskFillRule(i, q);
-            dest.setMaskFillRule(fillRule, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontFamily fontFamily = src.getMaskFontFamily(i, q);
-            dest.setMaskFontFamily(fontFamily, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length fontSize = src.getMaskFontSize(i, q);
-            dest.setMaskFontSize(fontSize, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontStyle fontStyle = src.getMaskFontStyle(i, q);
-            dest.setMaskFontStyle(fontStyle, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Boolean locked = src.getMaskLocked(i, q);
-            dest.setMaskLocked(locked, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Color strokeColor = src.getMaskStrokeColor(i, q);
-            dest.setMaskStrokeColor(strokeColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String dashArray = src.getMaskStrokeDashArray(i, q);
-            dest.setMaskStrokeDashArray(dashArray, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length strokeWidth = src.getMaskStrokeWidth(i, q);
-            dest.setMaskStrokeWidth(strokeWidth, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String text = src.getMaskText(i, q);
-            dest.setMaskText(text, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theC = src.getMaskTheC(i, q);
-            dest.setMaskTheC(theC, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theT = src.getMaskTheT(i, q);
-            dest.setMaskTheT(theT, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theZ = src.getMaskTheZ(i, q);
-            dest.setMaskTheZ(theZ, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            AffineTransform transform = src.getMaskTransform(i, q);
-            dest.setMaskTransform(transform, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double height = src.getMaskHeight(i, q);
-            dest.setMaskHeight(height, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double width = src.getMaskWidth(i, q);
-            dest.setMaskWidth(width, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double x = src.getMaskX(i, q);
-            dest.setMaskX(x, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            byte[] binData = src.getMaskBinData(i, q);
-            dest.setMaskBinData(binData, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            boolean bigEndian = src.getMaskBinDataBigEndian(i, q);
-            dest.setMaskBinDataBigEndian(bigEndian, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeLong length = src.getMaskBinDataLength(i, q);
-            dest.setMaskBinDataLength(length, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Compression compression = src.getMaskBinDataCompression(i, q);
-            dest.setMaskBinDataCompression(compression, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double y = src.getMaskY(i, q);
-            dest.setMaskY(y, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          int shapeAnnotationRefCount = 0;
-          try {
-            shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
-          }
-          catch (NullPointerException ignored) { }
-          for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
-              String shapeAnnotationRef = src.getMaskAnnotationRef(i, q, r);
-              dest.setMaskAnnotationRef(shapeAnnotationRef, i, q, r);
+              Length fontSize = src.getEllipseFontSize(i, q);
+              dest.setEllipseFontSize(fontSize, i, q);
             }
             catch (NullPointerException ignored) { }
-          }
-        }
-        else if (type.equals("Point")) {
-          try {
-            String shapeID = src.getPointID(i, q);
-            dest.setPointID(shapeID, i, q);
-          }
-          catch (NullPointerException e) {
-            continue;
-          }
 
-          try {
-            Color fillColor = src.getPointFillColor(i, q);
-            dest.setPointFillColor(fillColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FillRule fillRule = src.getPointFillRule(i, q);
-            dest.setPointFillRule(fillRule, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontFamily fontFamily = src.getPointFontFamily(i, q);
-            dest.setPointFontFamily(fontFamily, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length fontSize = src.getPointFontSize(i, q);
-            dest.setPointFontSize(fontSize, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontStyle fontStyle = src.getPointFontStyle(i, q);
-            dest.setPointFontStyle(fontStyle, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Boolean locked = src.getPointLocked(i, q);
-            dest.setPointLocked(locked, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Color strokeColor = src.getPointStrokeColor(i, q);
-            dest.setPointStrokeColor(strokeColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String dashArray = src.getPointStrokeDashArray(i, q);
-            dest.setPointStrokeDashArray(dashArray, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length strokeWidth = src.getPointStrokeWidth(i, q);
-            dest.setPointStrokeWidth(strokeWidth, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String text = src.getPointText(i, q);
-            dest.setPointText(text, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theC = src.getPointTheC(i, q);
-            dest.setPointTheC(theC, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theT = src.getPointTheT(i, q);
-            dest.setPointTheT(theT, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theZ = src.getPointTheZ(i, q);
-            dest.setPointTheZ(theZ, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            AffineTransform transform = src.getPointTransform(i, q);
-            dest.setPointTransform(transform, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double x = src.getPointX(i, q);
-            dest.setPointX(x, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double y = src.getPointY(i, q);
-            dest.setPointY(y, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          int shapeAnnotationRefCount = 0;
-          try {
-            shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
-          }
-          catch (NullPointerException ignored) { }
-          for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
-              String shapeAnnotationRef = src.getPointAnnotationRef(i, q, r);
-              dest.setPointAnnotationRef(shapeAnnotationRef, i, q, r);
+              FontStyle fontStyle = src.getEllipseFontStyle(i, q);
+              dest.setEllipseFontStyle(fontStyle, i, q);
             }
             catch (NullPointerException ignored) { }
-          }
-        }
-        else if (type.equals("Polygon")) {
-          try {
-            String shapeID = src.getPolygonID(i, q);
-            dest.setPolygonID(shapeID, i, q);
-          }
-          catch (NullPointerException e) {
-            continue;
-          }
 
-          try {
-            Color fillColor = src.getPolygonFillColor(i, q);
-            dest.setPolygonFillColor(fillColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FillRule fillRule = src.getPolygonFillRule(i, q);
-            dest.setPolygonFillRule(fillRule, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontFamily fontFamily = src.getPolygonFontFamily(i, q);
-            dest.setPolygonFontFamily(fontFamily, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length fontSize = src.getPolygonFontSize(i, q);
-            dest.setPolygonFontSize(fontSize, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontStyle fontStyle = src.getPolygonFontStyle(i, q);
-            dest.setPolygonFontStyle(fontStyle, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Boolean locked = src.getPolygonLocked(i, q);
-            dest.setPolygonLocked(locked, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Color strokeColor = src.getPolygonStrokeColor(i, q);
-            dest.setPolygonStrokeColor(strokeColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String dashArray = src.getPolygonStrokeDashArray(i, q);
-            dest.setPolygonStrokeDashArray(dashArray, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length strokeWidth = src.getPolygonStrokeWidth(i, q);
-            dest.setPolygonStrokeWidth(strokeWidth, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String text = src.getPolygonText(i, q);
-            dest.setPolygonText(text, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theC = src.getPolygonTheC(i, q);
-            dest.setPolygonTheC(theC, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theT = src.getPolygonTheT(i, q);
-            dest.setPolygonTheT(theT, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theZ = src.getPolygonTheZ(i, q);
-            dest.setPolygonTheZ(theZ, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            AffineTransform transform = src.getPolygonTransform(i, q);
-            dest.setPolygonTransform(transform, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String points = src.getPolygonPoints(i, q);
-            dest.setPolygonPoints(points, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          int shapeAnnotationRefCount = 0;
-          try {
-            shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
-          }
-          catch (NullPointerException ignored) { }
-          for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
-              String shapeAnnotationRef = src.getPolygonAnnotationRef(i, q, r);
-              dest.setPolygonAnnotationRef(shapeAnnotationRef, i, q, r);
+              Boolean locked = src.getEllipseLocked(i, q);
+              dest.setEllipseLocked(locked, i, q);
             }
             catch (NullPointerException ignored) { }
-          }
-        }
-        else if (type.equals("Polyline")) {
-          try {
-            String shapeID = src.getPolylineID(i, q);
-            dest.setPolylineID(shapeID, i, q);
-          }
-          catch (NullPointerException e) {
-            continue;
-          }
 
-          try {
-            Color fillColor = src.getPolylineFillColor(i, q);
-            dest.setPolylineFillColor(fillColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FillRule fillRule = src.getPolylineFillRule(i, q);
-            dest.setPolylineFillRule(fillRule, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontFamily fontFamily = src.getPolylineFontFamily(i, q);
-            dest.setPolylineFontFamily(fontFamily, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length fontSize = src.getPolylineFontSize(i, q);
-            dest.setPolylineFontSize(fontSize, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontStyle fontStyle = src.getPolylineFontStyle(i, q);
-            dest.setPolylineFontStyle(fontStyle, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Boolean locked = src.getPolylineLocked(i, q);
-            dest.setPolylineLocked(locked, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Color strokeColor = src.getPolylineStrokeColor(i, q);
-            dest.setPolylineStrokeColor(strokeColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String dashArray = src.getPolylineStrokeDashArray(i, q);
-            dest.setPolylineStrokeDashArray(dashArray, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length strokeWidth = src.getPolylineStrokeWidth(i, q);
-            dest.setPolylineStrokeWidth(strokeWidth, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String text = src.getPolylineText(i, q);
-            dest.setPolylineText(text, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theC = src.getPolylineTheC(i, q);
-            dest.setPolylineTheC(theC, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theT = src.getPolylineTheT(i, q);
-            dest.setPolylineTheT(theT, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theZ = src.getPolylineTheZ(i, q);
-            dest.setPolylineTheZ(theZ, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            AffineTransform transform = src.getPolylineTransform(i, q);
-            dest.setPolylineTransform(transform, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Marker end = src.getPolylineMarkerEnd(i, q);
-            dest.setPolylineMarkerEnd(end, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Marker start = src.getPolylineMarkerStart(i, q);
-            dest.setPolylineMarkerStart(start, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String points = src.getPolylinePoints(i, q);
-            dest.setPolylinePoints(points, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          int shapeAnnotationRefCount = 0;
-          try {
-            shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
-          }
-          catch (NullPointerException ignored) { }
-          for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
-              String shapeAnnotationRef = src.getPolylineAnnotationRef(i, q, r);
-              dest.setPolylineAnnotationRef(shapeAnnotationRef, i, q, r);
+              Color strokeColor = src.getEllipseStrokeColor(i, q);
+              dest.setEllipseStrokeColor(strokeColor, i, q);
             }
             catch (NullPointerException ignored) { }
-          }
-        }
-        else if (type.equals("Rectangle")) {
-          try {
-            String shapeID = src.getRectangleID(i, q);
-            dest.setRectangleID(shapeID, i, q);
-          }
-          catch (NullPointerException e) {
-            continue;
-          }
 
-          try {
-            Color fillColor = src.getRectangleFillColor(i, q);
-            dest.setRectangleFillColor(fillColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FillRule fillRule = src.getRectangleFillRule(i, q);
-            dest.setRectangleFillRule(fillRule, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontFamily fontFamily = src.getRectangleFontFamily(i, q);
-            dest.setRectangleFontFamily(fontFamily, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length fontSize = src.getRectangleFontSize(i, q);
-            dest.setRectangleFontSize(fontSize, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            FontStyle fontStyle = src.getRectangleFontStyle(i, q);
-            dest.setRectangleFontStyle(fontStyle, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Boolean locked = src.getRectangleLocked(i, q);
-            dest.setRectangleLocked(locked, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Color strokeColor = src.getRectangleStrokeColor(i, q);
-            dest.setRectangleStrokeColor(strokeColor, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String dashArray = src.getRectangleStrokeDashArray(i, q);
-            dest.setRectangleStrokeDashArray(dashArray, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Length strokeWidth = src.getRectangleStrokeWidth(i, q);
-            dest.setRectangleStrokeWidth(strokeWidth, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            String text = src.getRectangleText(i, q);
-            dest.setRectangleText(text, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theC = src.getRectangleTheC(i, q);
-            dest.setRectangleTheC(theC, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theT = src.getRectangleTheT(i, q);
-            dest.setRectangleTheT(theT, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            NonNegativeInteger theZ = src.getRectangleTheZ(i, q);
-            dest.setRectangleTheZ(theZ, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            AffineTransform transform = src.getRectangleTransform(i, q);
-            dest.setRectangleTransform(transform, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double height = src.getRectangleHeight(i, q);
-            dest.setRectangleHeight(height, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double width = src.getRectangleWidth(i, q);
-            dest.setRectangleWidth(width, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double x = src.getRectangleX(i, q);
-            dest.setRectangleX(x, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          try {
-            Double y = src.getRectangleY(i, q);
-            dest.setRectangleY(y, i, q);
-          }
-          catch (NullPointerException ignored) { }
-
-          int shapeAnnotationRefCount = 0;
-          try {
-            shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
-          }
-          catch (NullPointerException ignored) { }
-          for (int r=0; r<shapeAnnotationRefCount; r++) {
             try {
-              String shapeAnnotationRef = src.getRectangleAnnotationRef(i, q, r);
-              dest.setRectangleAnnotationRef(shapeAnnotationRef, i, q, r);
+              String dashArray = src.getEllipseStrokeDashArray(i, q);
+              dest.setEllipseStrokeDashArray(dashArray, i, q);
             }
             catch (NullPointerException ignored) { }
+
+            try {
+              Length strokeWidth = src.getEllipseStrokeWidth(i, q);
+              dest.setEllipseStrokeWidth(strokeWidth, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String text = src.getEllipseText(i, q);
+              dest.setEllipseText(text, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theC = src.getEllipseTheC(i, q);
+              dest.setEllipseTheC(theC, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theT = src.getEllipseTheT(i, q);
+              dest.setEllipseTheT(theT, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theZ = src.getEllipseTheZ(i, q);
+              dest.setEllipseTheZ(theZ, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              AffineTransform transform = src.getEllipseTransform(i, q);
+              dest.setEllipseTransform(transform, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double radiusX = src.getEllipseRadiusX(i, q);
+              dest.setEllipseRadiusX(radiusX, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double radiusY = src.getEllipseRadiusY(i, q);
+              dest.setEllipseRadiusY(radiusY, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double x = src.getEllipseX(i, q);
+              dest.setEllipseX(x, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double y = src.getEllipseY(i, q);
+              dest.setEllipseY(y, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            int shapeAnnotationRefCount = 0;
+            try {
+              shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
+            }
+            catch (NullPointerException ignored) { }
+            for (int r = 0; r < shapeAnnotationRefCount; r++) {
+              try {
+                String shapeAnnotationRef = src.getEllipseAnnotationRef(i, q, r);
+                dest.setEllipseAnnotationRef(shapeAnnotationRef, i, q, r);
+              }
+            catch (NullPointerException ignored) { }
+            }
+            break;
+          }
+          case "Label": {
+            try {
+              String shapeID = src.getLabelID(i, q);
+              dest.setLabelID(shapeID, i, q);
+            }
+            catch (NullPointerException e) {
+              continue;
+            }
+
+            try {
+              Color fillColor = src.getLabelFillColor(i, q);
+              dest.setLabelFillColor(fillColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FillRule fillRule = src.getLabelFillRule(i, q);
+              dest.setLabelFillRule(fillRule, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontFamily fontFamily = src.getLabelFontFamily(i, q);
+              dest.setLabelFontFamily(fontFamily, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length fontSize = src.getLabelFontSize(i, q);
+              dest.setLabelFontSize(fontSize, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontStyle fontStyle = src.getLabelFontStyle(i, q);
+              dest.setLabelFontStyle(fontStyle, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Boolean locked = src.getLabelLocked(i, q);
+              dest.setLabelLocked(locked, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Color strokeColor = src.getLabelStrokeColor(i, q);
+              dest.setLabelStrokeColor(strokeColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String dashArray = src.getLabelStrokeDashArray(i, q);
+              dest.setLabelStrokeDashArray(dashArray, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length strokeWidth = src.getLabelStrokeWidth(i, q);
+              dest.setLabelStrokeWidth(strokeWidth, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String text = src.getLabelText(i, q);
+              dest.setLabelText(text, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theC = src.getLabelTheC(i, q);
+              dest.setLabelTheC(theC, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theT = src.getLabelTheT(i, q);
+              dest.setLabelTheT(theT, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theZ = src.getLabelTheZ(i, q);
+              dest.setLabelTheZ(theZ, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              AffineTransform transform = src.getLabelTransform(i, q);
+              dest.setLabelTransform(transform, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double x = src.getLabelX(i, q);
+              dest.setLabelX(x, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double y = src.getLabelY(i, q);
+              dest.setLabelY(y, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            int shapeAnnotationRefCount = 0;
+            try {
+              shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
+            }
+            catch (NullPointerException ignored) { }
+            for (int r = 0; r < shapeAnnotationRefCount; r++) {
+              try {
+                String shapeAnnotationRef = src.getLabelAnnotationRef(i, q, r);
+                dest.setLabelAnnotationRef(shapeAnnotationRef, i, q, r);
+              }
+            catch (NullPointerException ignored) { }
+            }
+            break;
+          }
+          case "Line": {
+            try {
+              String shapeID = src.getLineID(i, q);
+              dest.setLineID(shapeID, i, q);
+            }
+            catch (NullPointerException e) {
+              continue;
+            }
+
+            try {
+              Color fillColor = src.getLineFillColor(i, q);
+              dest.setLineFillColor(fillColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FillRule fillRule = src.getLineFillRule(i, q);
+              dest.setLineFillRule(fillRule, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontFamily fontFamily = src.getLineFontFamily(i, q);
+              dest.setLineFontFamily(fontFamily, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length fontSize = src.getLineFontSize(i, q);
+              dest.setLineFontSize(fontSize, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontStyle fontStyle = src.getLineFontStyle(i, q);
+              dest.setLineFontStyle(fontStyle, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Boolean locked = src.getLineLocked(i, q);
+              dest.setLineLocked(locked, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Color strokeColor = src.getLineStrokeColor(i, q);
+              dest.setLineStrokeColor(strokeColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String dashArray = src.getLineStrokeDashArray(i, q);
+              dest.setLineStrokeDashArray(dashArray, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length strokeWidth = src.getLineStrokeWidth(i, q);
+              dest.setLineStrokeWidth(strokeWidth, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String text = src.getLineText(i, q);
+              dest.setLineText(text, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theC = src.getLineTheC(i, q);
+              dest.setLineTheC(theC, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theT = src.getLineTheT(i, q);
+              dest.setLineTheT(theT, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theZ = src.getLineTheZ(i, q);
+              dest.setLineTheZ(theZ, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              AffineTransform transform = src.getLineTransform(i, q);
+              dest.setLineTransform(transform, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Marker end = src.getLineMarkerEnd(i, q);
+              dest.setLineMarkerEnd(end, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Marker start = src.getLineMarkerStart(i, q);
+              dest.setLineMarkerStart(start, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double x1 = src.getLineX1(i, q);
+              dest.setLineX1(x1, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double x2 = src.getLineX2(i, q);
+              dest.setLineX2(x2, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double y1 = src.getLineY1(i, q);
+              dest.setLineY1(y1, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double y2 = src.getLineY2(i, q);
+              dest.setLineY2(y2, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            int shapeAnnotationRefCount = 0;
+            try {
+              shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
+            }
+            catch (NullPointerException ignored) { }
+            for (int r = 0; r < shapeAnnotationRefCount; r++) {
+              try {
+                String shapeAnnotationRef = src.getLineAnnotationRef(i, q, r);
+                dest.setLineAnnotationRef(shapeAnnotationRef, i, q, r);
+              }
+            catch (NullPointerException ignored) { }
+            }
+            break;
+          }
+          case "Mask": {
+            try {
+              String shapeID = src.getMaskID(i, q);
+              dest.setMaskID(shapeID, i, q);
+            }
+            catch (NullPointerException e) {
+              continue;
+            }
+
+            try {
+              Color fillColor = src.getMaskFillColor(i, q);
+              dest.setMaskFillColor(fillColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FillRule fillRule = src.getMaskFillRule(i, q);
+              dest.setMaskFillRule(fillRule, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontFamily fontFamily = src.getMaskFontFamily(i, q);
+              dest.setMaskFontFamily(fontFamily, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length fontSize = src.getMaskFontSize(i, q);
+              dest.setMaskFontSize(fontSize, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontStyle fontStyle = src.getMaskFontStyle(i, q);
+              dest.setMaskFontStyle(fontStyle, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Boolean locked = src.getMaskLocked(i, q);
+              dest.setMaskLocked(locked, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Color strokeColor = src.getMaskStrokeColor(i, q);
+              dest.setMaskStrokeColor(strokeColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String dashArray = src.getMaskStrokeDashArray(i, q);
+              dest.setMaskStrokeDashArray(dashArray, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length strokeWidth = src.getMaskStrokeWidth(i, q);
+              dest.setMaskStrokeWidth(strokeWidth, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String text = src.getMaskText(i, q);
+              dest.setMaskText(text, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theC = src.getMaskTheC(i, q);
+              dest.setMaskTheC(theC, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theT = src.getMaskTheT(i, q);
+              dest.setMaskTheT(theT, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theZ = src.getMaskTheZ(i, q);
+              dest.setMaskTheZ(theZ, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              AffineTransform transform = src.getMaskTransform(i, q);
+              dest.setMaskTransform(transform, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double height = src.getMaskHeight(i, q);
+              dest.setMaskHeight(height, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double width = src.getMaskWidth(i, q);
+              dest.setMaskWidth(width, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double x = src.getMaskX(i, q);
+              dest.setMaskX(x, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              byte[] binData = src.getMaskBinData(i, q);
+              dest.setMaskBinData(binData, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              boolean bigEndian = src.getMaskBinDataBigEndian(i, q);
+              dest.setMaskBinDataBigEndian(bigEndian, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeLong length = src.getMaskBinDataLength(i, q);
+              dest.setMaskBinDataLength(length, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Compression compression = src.getMaskBinDataCompression(i, q);
+              dest.setMaskBinDataCompression(compression, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double y = src.getMaskY(i, q);
+              dest.setMaskY(y, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            int shapeAnnotationRefCount = 0;
+            try {
+              shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
+            }
+            catch (NullPointerException ignored) { }
+            for (int r = 0; r < shapeAnnotationRefCount; r++) {
+              try {
+                String shapeAnnotationRef = src.getMaskAnnotationRef(i, q, r);
+                dest.setMaskAnnotationRef(shapeAnnotationRef, i, q, r);
+              }
+            catch (NullPointerException ignored) { }
+            }
+            break;
+          }
+          case "Point": {
+            try {
+              String shapeID = src.getPointID(i, q);
+              dest.setPointID(shapeID, i, q);
+            }
+            catch (NullPointerException e) {
+              continue;
+            }
+
+            try {
+              Color fillColor = src.getPointFillColor(i, q);
+              dest.setPointFillColor(fillColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FillRule fillRule = src.getPointFillRule(i, q);
+              dest.setPointFillRule(fillRule, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontFamily fontFamily = src.getPointFontFamily(i, q);
+              dest.setPointFontFamily(fontFamily, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length fontSize = src.getPointFontSize(i, q);
+              dest.setPointFontSize(fontSize, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontStyle fontStyle = src.getPointFontStyle(i, q);
+              dest.setPointFontStyle(fontStyle, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Boolean locked = src.getPointLocked(i, q);
+              dest.setPointLocked(locked, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Color strokeColor = src.getPointStrokeColor(i, q);
+              dest.setPointStrokeColor(strokeColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String dashArray = src.getPointStrokeDashArray(i, q);
+              dest.setPointStrokeDashArray(dashArray, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length strokeWidth = src.getPointStrokeWidth(i, q);
+              dest.setPointStrokeWidth(strokeWidth, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String text = src.getPointText(i, q);
+              dest.setPointText(text, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theC = src.getPointTheC(i, q);
+              dest.setPointTheC(theC, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theT = src.getPointTheT(i, q);
+              dest.setPointTheT(theT, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theZ = src.getPointTheZ(i, q);
+              dest.setPointTheZ(theZ, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              AffineTransform transform = src.getPointTransform(i, q);
+              dest.setPointTransform(transform, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double x = src.getPointX(i, q);
+              dest.setPointX(x, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double y = src.getPointY(i, q);
+              dest.setPointY(y, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            int shapeAnnotationRefCount = 0;
+            try {
+              shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
+            }
+            catch (NullPointerException ignored) { }
+            for (int r = 0; r < shapeAnnotationRefCount; r++) {
+              try {
+                String shapeAnnotationRef = src.getPointAnnotationRef(i, q, r);
+                dest.setPointAnnotationRef(shapeAnnotationRef, i, q, r);
+              }
+            catch (NullPointerException ignored) { }
+            }
+            break;
+          }
+          case "Polygon": {
+            try {
+              String shapeID = src.getPolygonID(i, q);
+              dest.setPolygonID(shapeID, i, q);
+            }
+            catch (NullPointerException e) {
+              continue;
+            }
+
+            try {
+              Color fillColor = src.getPolygonFillColor(i, q);
+              dest.setPolygonFillColor(fillColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FillRule fillRule = src.getPolygonFillRule(i, q);
+              dest.setPolygonFillRule(fillRule, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontFamily fontFamily = src.getPolygonFontFamily(i, q);
+              dest.setPolygonFontFamily(fontFamily, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length fontSize = src.getPolygonFontSize(i, q);
+              dest.setPolygonFontSize(fontSize, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontStyle fontStyle = src.getPolygonFontStyle(i, q);
+              dest.setPolygonFontStyle(fontStyle, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Boolean locked = src.getPolygonLocked(i, q);
+              dest.setPolygonLocked(locked, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Color strokeColor = src.getPolygonStrokeColor(i, q);
+              dest.setPolygonStrokeColor(strokeColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String dashArray = src.getPolygonStrokeDashArray(i, q);
+              dest.setPolygonStrokeDashArray(dashArray, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length strokeWidth = src.getPolygonStrokeWidth(i, q);
+              dest.setPolygonStrokeWidth(strokeWidth, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String text = src.getPolygonText(i, q);
+              dest.setPolygonText(text, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theC = src.getPolygonTheC(i, q);
+              dest.setPolygonTheC(theC, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theT = src.getPolygonTheT(i, q);
+              dest.setPolygonTheT(theT, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theZ = src.getPolygonTheZ(i, q);
+              dest.setPolygonTheZ(theZ, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              AffineTransform transform = src.getPolygonTransform(i, q);
+              dest.setPolygonTransform(transform, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String points = src.getPolygonPoints(i, q);
+              dest.setPolygonPoints(points, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            int shapeAnnotationRefCount = 0;
+            try {
+              shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
+            }
+            catch (NullPointerException ignored) { }
+            for (int r = 0; r < shapeAnnotationRefCount; r++) {
+              try {
+                String shapeAnnotationRef = src.getPolygonAnnotationRef(i, q, r);
+                dest.setPolygonAnnotationRef(shapeAnnotationRef, i, q, r);
+              }
+            catch (NullPointerException ignored) { }
+            }
+            break;
+          }
+          case "Polyline": {
+            try {
+              String shapeID = src.getPolylineID(i, q);
+              dest.setPolylineID(shapeID, i, q);
+            }
+            catch (NullPointerException e) {
+              continue;
+            }
+
+            try {
+              Color fillColor = src.getPolylineFillColor(i, q);
+              dest.setPolylineFillColor(fillColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FillRule fillRule = src.getPolylineFillRule(i, q);
+              dest.setPolylineFillRule(fillRule, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontFamily fontFamily = src.getPolylineFontFamily(i, q);
+              dest.setPolylineFontFamily(fontFamily, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length fontSize = src.getPolylineFontSize(i, q);
+              dest.setPolylineFontSize(fontSize, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontStyle fontStyle = src.getPolylineFontStyle(i, q);
+              dest.setPolylineFontStyle(fontStyle, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Boolean locked = src.getPolylineLocked(i, q);
+              dest.setPolylineLocked(locked, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Color strokeColor = src.getPolylineStrokeColor(i, q);
+              dest.setPolylineStrokeColor(strokeColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String dashArray = src.getPolylineStrokeDashArray(i, q);
+              dest.setPolylineStrokeDashArray(dashArray, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length strokeWidth = src.getPolylineStrokeWidth(i, q);
+              dest.setPolylineStrokeWidth(strokeWidth, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String text = src.getPolylineText(i, q);
+              dest.setPolylineText(text, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theC = src.getPolylineTheC(i, q);
+              dest.setPolylineTheC(theC, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theT = src.getPolylineTheT(i, q);
+              dest.setPolylineTheT(theT, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theZ = src.getPolylineTheZ(i, q);
+              dest.setPolylineTheZ(theZ, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              AffineTransform transform = src.getPolylineTransform(i, q);
+              dest.setPolylineTransform(transform, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Marker end = src.getPolylineMarkerEnd(i, q);
+              dest.setPolylineMarkerEnd(end, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Marker start = src.getPolylineMarkerStart(i, q);
+              dest.setPolylineMarkerStart(start, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String points = src.getPolylinePoints(i, q);
+              dest.setPolylinePoints(points, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            int shapeAnnotationRefCount = 0;
+            try {
+              shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
+            }
+            catch (NullPointerException ignored) { }
+            for (int r = 0; r < shapeAnnotationRefCount; r++) {
+              try {
+                String shapeAnnotationRef = src.getPolylineAnnotationRef(i, q, r);
+                dest.setPolylineAnnotationRef(shapeAnnotationRef, i, q, r);
+              }
+            catch (NullPointerException ignored) { }
+            }
+            break;
+          }
+          case "Rectangle": {
+            try {
+              String shapeID = src.getRectangleID(i, q);
+              dest.setRectangleID(shapeID, i, q);
+            }
+            catch (NullPointerException e) {
+              continue;
+            }
+
+            try {
+              Color fillColor = src.getRectangleFillColor(i, q);
+              dest.setRectangleFillColor(fillColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FillRule fillRule = src.getRectangleFillRule(i, q);
+              dest.setRectangleFillRule(fillRule, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontFamily fontFamily = src.getRectangleFontFamily(i, q);
+              dest.setRectangleFontFamily(fontFamily, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length fontSize = src.getRectangleFontSize(i, q);
+              dest.setRectangleFontSize(fontSize, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              FontStyle fontStyle = src.getRectangleFontStyle(i, q);
+              dest.setRectangleFontStyle(fontStyle, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Boolean locked = src.getRectangleLocked(i, q);
+              dest.setRectangleLocked(locked, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Color strokeColor = src.getRectangleStrokeColor(i, q);
+              dest.setRectangleStrokeColor(strokeColor, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String dashArray = src.getRectangleStrokeDashArray(i, q);
+              dest.setRectangleStrokeDashArray(dashArray, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Length strokeWidth = src.getRectangleStrokeWidth(i, q);
+              dest.setRectangleStrokeWidth(strokeWidth, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              String text = src.getRectangleText(i, q);
+              dest.setRectangleText(text, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theC = src.getRectangleTheC(i, q);
+              dest.setRectangleTheC(theC, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theT = src.getRectangleTheT(i, q);
+              dest.setRectangleTheT(theT, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              NonNegativeInteger theZ = src.getRectangleTheZ(i, q);
+              dest.setRectangleTheZ(theZ, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              AffineTransform transform = src.getRectangleTransform(i, q);
+              dest.setRectangleTransform(transform, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double height = src.getRectangleHeight(i, q);
+              dest.setRectangleHeight(height, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double width = src.getRectangleWidth(i, q);
+              dest.setRectangleWidth(width, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double x = src.getRectangleX(i, q);
+              dest.setRectangleX(x, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            try {
+              Double y = src.getRectangleY(i, q);
+              dest.setRectangleY(y, i, q);
+            }
+            catch (NullPointerException ignored) { }
+
+            int shapeAnnotationRefCount = 0;
+            try {
+              shapeAnnotationRefCount = src.getShapeAnnotationRefCount(i, q);
+            }
+            catch (NullPointerException ignored) { }
+            for (int r = 0; r < shapeAnnotationRefCount; r++) {
+              try {
+                String shapeAnnotationRef = src.getRectangleAnnotationRef(i, q, r);
+                dest.setRectangleAnnotationRef(shapeAnnotationRef, i, q, r);
+              }
+            catch (NullPointerException ignored) { }
+            }
+            break;
           }
         }
       }
@@ -4006,455 +4016,462 @@ public final class MetadataConverter {
 
     for (int lightSource=0; lightSource<lightSourceCount; lightSource++) {
       String type = src.getLightSourceType(instrumentIndex, lightSource);
-      if (type.equals("Arc")) {
-        try {
-          String id = src.getArcID(instrumentIndex, lightSource);
-          if (id != null && id.trim().length() > 0) {
-            lightSourceIds.add(id);
-            dest.setArcID(id, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException e) {
-          continue;
-        }
-
-        try {
-          String lotNumber = src.getArcLotNumber(instrumentIndex, lightSource);
-          if (lotNumber != null) {
-            dest.setArcLotNumber(lotNumber, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String manufacturer =
-            src.getArcManufacturer(instrumentIndex, lightSource);
-          if (manufacturer != null) {
-            dest.setArcManufacturer(manufacturer, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String model = src.getArcModel(instrumentIndex, lightSource);
-          if (model != null) {
-            dest.setArcModel(model, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Power power = src.getArcPower(instrumentIndex, lightSource);
-          if (power != null) {
-            dest.setArcPower(power, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String serialNumber =
-            src.getArcSerialNumber(instrumentIndex, lightSource);
-          if (serialNumber != null) {
-            dest.setArcSerialNumber(serialNumber, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          ArcType arcType = src.getArcType(instrumentIndex, lightSource);
-          if (arcType != null) {
-            dest.setArcType(arcType, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        int lightSourceAnnotationRefCount = 0;
-        try {
-          lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-        for (int r=0; r<lightSourceAnnotationRefCount; r++) {
+      switch (type) {
+        case "Arc": {
           try {
-            String lightSourceAnnotationRef = src.getArcAnnotationRef(instrumentIndex, lightSource, r);
-            dest.setArcAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            String id = src.getArcID(instrumentIndex, lightSource);
+            if (id != null && id.trim().length() > 0) {
+              lightSourceIds.add(id);
+              dest.setArcID(id, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException e) {
+            continue;
+          }
+
+          try {
+            String lotNumber = src.getArcLotNumber(instrumentIndex, lightSource);
+            if (lotNumber != null) {
+              dest.setArcLotNumber(lotNumber, instrumentIndex, lightSource);
+            }
           }
           catch (NullPointerException ignored) { }
-        }
-      }
-      else if (type.equals("Filament")) {
-        try {
-          String id = src.getFilamentID(instrumentIndex, lightSource);
-          if (id != null && id.trim().length() > 0) {
-            lightSourceIds.add(id);
-            dest.setFilamentID(id, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException e) {
-          continue;
-        }
 
-        try {
-          String lotNumber =
-            src.getFilamentLotNumber(instrumentIndex, lightSource);
-          if (lotNumber != null) {
-            dest.setFilamentLotNumber(lotNumber, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String manufacturer =
-            src.getFilamentManufacturer(instrumentIndex, lightSource);
-          if (manufacturer != null) {
-            dest.setFilamentManufacturer(
-              manufacturer, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String model = src.getFilamentModel(instrumentIndex, lightSource);
-          if (model != null) {
-            dest.setFilamentModel(model, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Power power = src.getFilamentPower(instrumentIndex, lightSource);
-          if (power != null) {
-            dest.setFilamentPower(power, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String serialNumber =
-            src.getFilamentSerialNumber(instrumentIndex, lightSource);
-          if (serialNumber != null) {
-            dest.setFilamentSerialNumber(
-              serialNumber, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          FilamentType filamentType =
-            src.getFilamentType(instrumentIndex, lightSource);
-          if (filamentType != null) {
-            dest.setFilamentType(filamentType, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        int lightSourceAnnotationRefCount = 0;
-        try {
-          lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-        for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
-            String lightSourceAnnotationRef = src.getFilamentAnnotationRef(instrumentIndex, lightSource, r);
-            dest.setFilamentAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            String manufacturer =
+                    src.getArcManufacturer(instrumentIndex, lightSource);
+            if (manufacturer != null) {
+              dest.setArcManufacturer(manufacturer, instrumentIndex, lightSource);
+            }
           }
           catch (NullPointerException ignored) { }
-        }
-      }
-      else if (type.equals("GenericExcitationSource")) {
-        try {
-          String id =
-            src.getGenericExcitationSourceID(instrumentIndex, lightSource);
-          if (id != null && id.trim().length() > 0) {
-            lightSourceIds.add(id);
-            dest.setGenericExcitationSourceID(id, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException e) {
-          continue;
-        }
 
-        try {
-          List<MapPair> map =
-            src.getGenericExcitationSourceMap(instrumentIndex, lightSource);
-          dest.setGenericExcitationSourceMap(map, instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String lotNumber = src.getGenericExcitationSourceLotNumber(
-            instrumentIndex, lightSource);
-          dest.setGenericExcitationSourceLotNumber(lotNumber,
-            instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String manufacturer = src.getGenericExcitationSourceManufacturer(
-            instrumentIndex, lightSource);
-          dest.setGenericExcitationSourceManufacturer(manufacturer,
-            instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String model =
-            src.getGenericExcitationSourceModel(instrumentIndex, lightSource);
-          dest.setGenericExcitationSourceModel(model,
-            instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Power power =
-            src.getGenericExcitationSourcePower(instrumentIndex, lightSource);
-          dest.setGenericExcitationSourcePower(power,
-            instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String serialNumber = src.getGenericExcitationSourceSerialNumber(
-            instrumentIndex, lightSource);
-          dest.setGenericExcitationSourceSerialNumber(serialNumber,
-            instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-
-        int lightSourceAnnotationRefCount = 0;
-        try {
-          lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-        for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
-            String lightSourceAnnotationRef = src.getGenericExcitationSourceAnnotationRef(instrumentIndex, lightSource, r);
-            dest.setGenericExcitationSourceAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            String model = src.getArcModel(instrumentIndex, lightSource);
+            if (model != null) {
+              dest.setArcModel(model, instrumentIndex, lightSource);
+            }
           }
           catch (NullPointerException ignored) { }
-        }
-      }
-      else if (type.equals("Laser")) {
-        try {
-          String id = src.getLaserID(instrumentIndex, lightSource);
-          if (id != null && id.trim().length() > 0) {
-            lightSourceIds.add(id);
-            dest.setLaserID(id, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException e) {
-          continue;
-        }
 
-        try {
-          String lotNumber =
-            src.getLaserLotNumber(instrumentIndex, lightSource);
-          if (lotNumber != null) {
-            dest.setLaserLotNumber(lotNumber, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String manufacturer =
-            src.getLaserManufacturer(instrumentIndex, lightSource);
-          if (manufacturer != null) {
-            dest.setLaserManufacturer(
-              manufacturer, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String model = src.getLaserModel(instrumentIndex, lightSource);
-          if (model != null) {
-            dest.setLaserModel(model, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Power power = src.getLaserPower(instrumentIndex, lightSource);
-          if (power != null) {
-            dest.setLaserPower(power, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String serialNumber =
-            src.getLaserSerialNumber(instrumentIndex, lightSource);
-          if (serialNumber != null) {
-            dest.setLaserSerialNumber(
-              serialNumber, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          LaserType laserType = src.getLaserType(instrumentIndex, lightSource);
-          if (laserType != null) {
-            dest.setLaserType(laserType, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          PositiveInteger frequencyMultiplication =
-            src.getLaserFrequencyMultiplication(instrumentIndex, lightSource);
-          if (frequencyMultiplication != null) {
-            dest.setLaserFrequencyMultiplication(
-              frequencyMultiplication, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          LaserMedium medium =
-            src.getLaserLaserMedium(instrumentIndex, lightSource);
-          if (medium != null) {
-            dest.setLaserLaserMedium(medium, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Boolean pockelCell =
-            src.getLaserPockelCell(instrumentIndex, lightSource);
-          if (pockelCell != null) {
-            dest.setLaserPockelCell(pockelCell, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Pulse pulse = src.getLaserPulse(instrumentIndex, lightSource);
-          if (pulse != null) {
-            dest.setLaserPulse(pulse, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String pump = src.getLaserPump(instrumentIndex, lightSource);
-          if (pump != null) {
-            dest.setLaserPump(pump, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Frequency repetitionRate =
-            src.getLaserRepetitionRate(instrumentIndex, lightSource);
-          if (repetitionRate != null) {
-            dest.setLaserRepetitionRate(
-              repetitionRate, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Boolean tuneable = src.getLaserTuneable(instrumentIndex, lightSource);
-          if (tuneable != null) {
-            dest.setLaserTuneable(tuneable, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Length wavelength =
-            src.getLaserWavelength(instrumentIndex, lightSource);
-          if (wavelength != null) {
-            dest.setLaserWavelength(wavelength, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        int lightSourceAnnotationRefCount = 0;
-        try {
-          lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-        for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
-            String lightSourceAnnotationRef = src.getLaserAnnotationRef(instrumentIndex, lightSource, r);
-            dest.setLaserAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            Power power = src.getArcPower(instrumentIndex, lightSource);
+            if (power != null) {
+              dest.setArcPower(power, instrumentIndex, lightSource);
+            }
           }
           catch (NullPointerException ignored) { }
-        }
-      }
-      else if (type.equals("LightEmittingDiode")) {
-        try {
-          String id = src.getLightEmittingDiodeID(instrumentIndex, lightSource);
-          if (id != null && id.trim().length() > 0) {
-            lightSourceIds.add(id);
-            dest.setLightEmittingDiodeID(id, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException e) {
-          continue;
-        }
 
-        try {
-          String lotNumber =
-            src.getLightEmittingDiodeLotNumber(instrumentIndex, lightSource);
-          if (lotNumber != null) {
-            dest.setLightEmittingDiodeLotNumber(
-              lotNumber, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String manufacturer =
-            src.getLightEmittingDiodeManufacturer(instrumentIndex, lightSource);
-          if (manufacturer != null) {
-            dest.setLightEmittingDiodeManufacturer(
-              manufacturer, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String model =
-            src.getLightEmittingDiodeModel(instrumentIndex, lightSource);
-          if (model != null) {
-            dest.setLightEmittingDiodeModel(
-              model, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          Power power =
-            src.getLightEmittingDiodePower(instrumentIndex, lightSource);
-          if (power != null) {
-            dest.setLightEmittingDiodePower(
-              power, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        try {
-          String serialNumber =
-            src.getLightEmittingDiodeSerialNumber(instrumentIndex, lightSource);
-          if (serialNumber != null) {
-            dest.setLightEmittingDiodeSerialNumber(
-              serialNumber, instrumentIndex, lightSource);
-          }
-        }
-        catch (NullPointerException ignored) { }
-
-        int lightSourceAnnotationRefCount = 0;
-        try {
-          lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
-        }
-        catch (NullPointerException ignored) { }
-        for (int r=0; r<lightSourceAnnotationRefCount; r++) {
           try {
-            String lightSourceAnnotationRef = src.getLightEmittingDiodeAnnotationRef(instrumentIndex, lightSource, r);
-            dest.setLightEmittingDiodeAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            String serialNumber =
+                    src.getArcSerialNumber(instrumentIndex, lightSource);
+            if (serialNumber != null) {
+              dest.setArcSerialNumber(serialNumber, instrumentIndex, lightSource);
+            }
           }
           catch (NullPointerException ignored) { }
+
+          try {
+            ArcType arcType = src.getArcType(instrumentIndex, lightSource);
+            if (arcType != null) {
+              dest.setArcType(arcType, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          int lightSourceAnnotationRefCount = 0;
+          try {
+            lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+          for (int r = 0; r < lightSourceAnnotationRefCount; r++) {
+            try {
+              String lightSourceAnnotationRef = src.getArcAnnotationRef(instrumentIndex, lightSource, r);
+              dest.setArcAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            }
+            catch (NullPointerException ignored) { }
+          }
+          break;
+        }
+        case "Filament": {
+          try {
+            String id = src.getFilamentID(instrumentIndex, lightSource);
+            if (id != null && id.trim().length() > 0) {
+              lightSourceIds.add(id);
+              dest.setFilamentID(id, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException e) {
+            continue;
+          }
+
+          try {
+            String lotNumber =
+                    src.getFilamentLotNumber(instrumentIndex, lightSource);
+            if (lotNumber != null) {
+              dest.setFilamentLotNumber(lotNumber, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String manufacturer =
+                    src.getFilamentManufacturer(instrumentIndex, lightSource);
+            if (manufacturer != null) {
+              dest.setFilamentManufacturer(
+                      manufacturer, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String model = src.getFilamentModel(instrumentIndex, lightSource);
+            if (model != null) {
+              dest.setFilamentModel(model, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Power power = src.getFilamentPower(instrumentIndex, lightSource);
+            if (power != null) {
+              dest.setFilamentPower(power, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String serialNumber =
+                    src.getFilamentSerialNumber(instrumentIndex, lightSource);
+            if (serialNumber != null) {
+              dest.setFilamentSerialNumber(
+                      serialNumber, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            FilamentType filamentType =
+                    src.getFilamentType(instrumentIndex, lightSource);
+            if (filamentType != null) {
+              dest.setFilamentType(filamentType, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          int lightSourceAnnotationRefCount = 0;
+          try {
+            lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+          for (int r = 0; r < lightSourceAnnotationRefCount; r++) {
+            try {
+              String lightSourceAnnotationRef = src.getFilamentAnnotationRef(instrumentIndex, lightSource, r);
+              dest.setFilamentAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            }
+            catch (NullPointerException ignored) { }
+          }
+          break;
+        }
+        case "GenericExcitationSource": {
+          try {
+            String id =
+                    src.getGenericExcitationSourceID(instrumentIndex, lightSource);
+            if (id != null && id.trim().length() > 0) {
+              lightSourceIds.add(id);
+              dest.setGenericExcitationSourceID(id, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException e) {
+            continue;
+          }
+
+          try {
+            List<MapPair> map =
+                    src.getGenericExcitationSourceMap(instrumentIndex, lightSource);
+            dest.setGenericExcitationSourceMap(map, instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String lotNumber = src.getGenericExcitationSourceLotNumber(
+                    instrumentIndex, lightSource);
+            dest.setGenericExcitationSourceLotNumber(lotNumber,
+                    instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String manufacturer = src.getGenericExcitationSourceManufacturer(
+                    instrumentIndex, lightSource);
+            dest.setGenericExcitationSourceManufacturer(manufacturer,
+                    instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String model =
+                    src.getGenericExcitationSourceModel(instrumentIndex, lightSource);
+            dest.setGenericExcitationSourceModel(model,
+                    instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Power power =
+                    src.getGenericExcitationSourcePower(instrumentIndex, lightSource);
+            dest.setGenericExcitationSourcePower(power,
+                    instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String serialNumber = src.getGenericExcitationSourceSerialNumber(
+                    instrumentIndex, lightSource);
+            dest.setGenericExcitationSourceSerialNumber(serialNumber,
+                    instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+
+          int lightSourceAnnotationRefCount = 0;
+          try {
+            lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+          for (int r = 0; r < lightSourceAnnotationRefCount; r++) {
+            try {
+              String lightSourceAnnotationRef = src.getGenericExcitationSourceAnnotationRef(instrumentIndex, lightSource, r);
+              dest.setGenericExcitationSourceAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            }
+            catch (NullPointerException ignored) { }
+          }
+          break;
+        }
+        case "Laser": {
+          try {
+            String id = src.getLaserID(instrumentIndex, lightSource);
+            if (id != null && id.trim().length() > 0) {
+              lightSourceIds.add(id);
+              dest.setLaserID(id, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException e) {
+            continue;
+          }
+
+          try {
+            String lotNumber =
+                    src.getLaserLotNumber(instrumentIndex, lightSource);
+            if (lotNumber != null) {
+              dest.setLaserLotNumber(lotNumber, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String manufacturer =
+                    src.getLaserManufacturer(instrumentIndex, lightSource);
+            if (manufacturer != null) {
+              dest.setLaserManufacturer(
+                      manufacturer, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String model = src.getLaserModel(instrumentIndex, lightSource);
+            if (model != null) {
+              dest.setLaserModel(model, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Power power = src.getLaserPower(instrumentIndex, lightSource);
+            if (power != null) {
+              dest.setLaserPower(power, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String serialNumber =
+                    src.getLaserSerialNumber(instrumentIndex, lightSource);
+            if (serialNumber != null) {
+              dest.setLaserSerialNumber(
+                      serialNumber, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            LaserType laserType = src.getLaserType(instrumentIndex, lightSource);
+            if (laserType != null) {
+              dest.setLaserType(laserType, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            PositiveInteger frequencyMultiplication =
+                    src.getLaserFrequencyMultiplication(instrumentIndex, lightSource);
+            if (frequencyMultiplication != null) {
+              dest.setLaserFrequencyMultiplication(
+                      frequencyMultiplication, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            LaserMedium medium =
+                    src.getLaserLaserMedium(instrumentIndex, lightSource);
+            if (medium != null) {
+              dest.setLaserLaserMedium(medium, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Boolean pockelCell =
+                    src.getLaserPockelCell(instrumentIndex, lightSource);
+            if (pockelCell != null) {
+              dest.setLaserPockelCell(pockelCell, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Pulse pulse = src.getLaserPulse(instrumentIndex, lightSource);
+            if (pulse != null) {
+              dest.setLaserPulse(pulse, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String pump = src.getLaserPump(instrumentIndex, lightSource);
+            if (pump != null) {
+              dest.setLaserPump(pump, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Frequency repetitionRate =
+                    src.getLaserRepetitionRate(instrumentIndex, lightSource);
+            if (repetitionRate != null) {
+              dest.setLaserRepetitionRate(
+                      repetitionRate, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Boolean tuneable = src.getLaserTuneable(instrumentIndex, lightSource);
+            if (tuneable != null) {
+              dest.setLaserTuneable(tuneable, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Length wavelength =
+                    src.getLaserWavelength(instrumentIndex, lightSource);
+            if (wavelength != null) {
+              dest.setLaserWavelength(wavelength, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          int lightSourceAnnotationRefCount = 0;
+          try {
+            lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+          for (int r = 0; r < lightSourceAnnotationRefCount; r++) {
+            try {
+              String lightSourceAnnotationRef = src.getLaserAnnotationRef(instrumentIndex, lightSource, r);
+              dest.setLaserAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            }
+            catch (NullPointerException ignored) { }
+          }
+          break;
+        }
+        case "LightEmittingDiode": {
+          try {
+            String id = src.getLightEmittingDiodeID(instrumentIndex, lightSource);
+            if (id != null && id.trim().length() > 0) {
+              lightSourceIds.add(id);
+              dest.setLightEmittingDiodeID(id, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException e) {
+            continue;
+          }
+
+          try {
+            String lotNumber =
+                    src.getLightEmittingDiodeLotNumber(instrumentIndex, lightSource);
+            if (lotNumber != null) {
+              dest.setLightEmittingDiodeLotNumber(
+                      lotNumber, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String manufacturer =
+                    src.getLightEmittingDiodeManufacturer(instrumentIndex, lightSource);
+            if (manufacturer != null) {
+              dest.setLightEmittingDiodeManufacturer(
+                      manufacturer, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String model =
+                    src.getLightEmittingDiodeModel(instrumentIndex, lightSource);
+            if (model != null) {
+              dest.setLightEmittingDiodeModel(
+                      model, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            Power power =
+                    src.getLightEmittingDiodePower(instrumentIndex, lightSource);
+            if (power != null) {
+              dest.setLightEmittingDiodePower(
+                      power, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          try {
+            String serialNumber =
+                    src.getLightEmittingDiodeSerialNumber(instrumentIndex, lightSource);
+            if (serialNumber != null) {
+              dest.setLightEmittingDiodeSerialNumber(
+                      serialNumber, instrumentIndex, lightSource);
+            }
+          }
+          catch (NullPointerException ignored) { }
+
+          int lightSourceAnnotationRefCount = 0;
+          try {
+            lightSourceAnnotationRefCount = src.getLightSourceAnnotationRefCount(instrumentIndex, lightSource);
+          }
+          catch (NullPointerException ignored) { }
+          for (int r = 0; r < lightSourceAnnotationRefCount; r++) {
+            try {
+              String lightSourceAnnotationRef = src.getLightEmittingDiodeAnnotationRef(instrumentIndex, lightSource, r);
+              dest.setLightEmittingDiodeAnnotationRef(lightSourceAnnotationRef, instrumentIndex, lightSource, r);
+            }
+            catch (NullPointerException ignored) { }
+          }
+          break;
         }
       }
     }

--- a/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
+++ b/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
@@ -95,7 +95,7 @@ public abstract class AbstractOMEModelObject implements OMEModelObject {
    */
   public static List<Element> getChildrenByTagName(
       Element parent, String name) {
-    List<Element> toReturn = new ArrayList<Element>();
+    List<Element> toReturn = new ArrayList<>();
     NodeList children = parent.getChildNodes();
     for (int i = 0; i < children.getLength(); i++) {
       Node child = children.item(i);

--- a/ome-xml/src/main/java/ome/xml/model/MapPair.java
+++ b/ome-xml/src/main/java/ome/xml/model/MapPair.java
@@ -101,11 +101,10 @@ public class MapPair {
         } else if (!name.equals(other.name))
             return false;
         if (value == null) {
-            if (other.value != null)
-                return false;
-        } else if (!value.equals(other.value))
-            return false;
-        return true;
+            return other.value == null;
+        } else {
+            return value.equals(other.value);
+        }
     }
 
     @Override

--- a/ome-xml/src/main/java/ome/xml/model/OMEModel.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModel.java
@@ -43,6 +43,7 @@ import java.util.Map;
  */
 public interface OMEModel {
 
+  @SuppressWarnings("UnusedReturnValue")
   OMEModelObject addModelObject(String id, OMEModelObject object);
 
   OMEModelObject removeModelObject(String id);
@@ -51,6 +52,7 @@ public interface OMEModel {
 
   Map<String, OMEModelObject> getModelObjects();
 
+  @SuppressWarnings("UnusedReturnValue")
   boolean addReference(OMEModelObject a, Reference b);
 
   Map<OMEModelObject, List<Reference>> getReferences();

--- a/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
@@ -49,10 +49,10 @@ import org.slf4j.LoggerFactory;
  */
 public class OMEModelImpl implements OMEModel {
 
-  private Map<String, OMEModelObject> modelObjects = 
+  private final Map<String, OMEModelObject> modelObjects =
     new HashMap<String, OMEModelObject>();
 
-  private Map<OMEModelObject, List<Reference>> references =
+  private final Map<OMEModelObject, List<Reference>> references =
     new HashMap<OMEModelObject, List<Reference>>();
 
   /** Logger for this class. */

--- a/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
@@ -50,10 +50,10 @@ import org.slf4j.LoggerFactory;
 public class OMEModelImpl implements OMEModel {
 
   private final Map<String, OMEModelObject> modelObjects =
-    new HashMap<String, OMEModelObject>();
+          new HashMap<>();
 
   private final Map<OMEModelObject, List<Reference>> references =
-    new HashMap<OMEModelObject, List<Reference>>();
+          new HashMap<>();
 
   /** Logger for this class. */
   private static final Logger LOGGER =
@@ -104,7 +104,7 @@ public class OMEModelImpl implements OMEModel {
     }
     List<Reference> bList = references.get(a);
     if (bList == null) {
-      bList = new ArrayList<Reference>();
+      bList = new ArrayList<>();
       references.put(a, bList);
     }
     return bList.add(b);

--- a/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
@@ -102,11 +102,7 @@ public class OMEModelImpl implements OMEModel {
     if (b == null) {
       return false;
     }
-    List<Reference> bList = references.get(a);
-    if (bList == null) {
-      bList = new ArrayList<>();
-      references.put(a, bList);
-    }
+    List<Reference> bList = references.computeIfAbsent(a, k -> new ArrayList<>());
     return bList.add(b);
   }
 

--- a/ome-xml/src/main/java/ome/xml/model/ReferenceList.java
+++ b/ome-xml/src/main/java/ome/xml/model/ReferenceList.java
@@ -44,7 +44,7 @@ import java.util.HashSet;
  */
 public class ReferenceList<T> extends ArrayList<T> {
 
-  private Set<T> backingSet = new HashSet<T>();
+  private final Set<T> backingSet = new HashSet<T>();
 
   public ReferenceList() {
     super();

--- a/ome-xml/src/main/java/ome/xml/model/ReferenceList.java
+++ b/ome-xml/src/main/java/ome/xml/model/ReferenceList.java
@@ -44,7 +44,7 @@ import java.util.HashSet;
  */
 public class ReferenceList<T> extends ArrayList<T> {
 
-  private final Set<T> backingSet = new HashSet<T>();
+  private final Set<T> backingSet = new HashSet<>();
 
   public ReferenceList() {
     super();

--- a/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeFloat.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeFloat.java
@@ -44,7 +44,7 @@ public class NonNegativeFloat extends PrimitiveType<Double> implements Primitive
 
   public NonNegativeFloat(Double value) {
     super(value);
-    if (value == null || value.doubleValue() < 0) {
+    if (value == null || value < 0) {
       throw new IllegalArgumentException(
           value + " must be neither null nor strictly negative.");
     }

--- a/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeInteger.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeInteger.java
@@ -44,7 +44,7 @@ public class NonNegativeInteger extends PrimitiveType<Integer> implements Primit
 
   public NonNegativeInteger(Integer value) {
     super(value);
-    if (value == null || value.intValue() < 0) {
+    if (value == null || value < 0) {
       throw new IllegalArgumentException(
           value + " must be neither null nor strictly negative.");
     }

--- a/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeLong.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeLong.java
@@ -44,7 +44,7 @@ public class NonNegativeLong extends PrimitiveType<Long> implements PrimitiveNum
 
   public NonNegativeLong(Long value) {
     super(value);
-    if (value == null || value.longValue() < 0) {
+    if (value == null || value < 0) {
       throw new IllegalArgumentException(
           value + " must be neither null nor strictly negative.");
     }

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PercentFraction.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PercentFraction.java
@@ -44,7 +44,7 @@ public class PercentFraction extends PrimitiveType<Float> implements PrimitiveNu
 
   public PercentFraction(Float value) {
     super(value);
-    if (value == null || value.floatValue() < 0.0 || value.floatValue() > 1.0) {
+    if (value == null || value < 0.0 || value > 1.0) {
       throw new IllegalArgumentException(
           value + " must be non-null and between 0.0 and 1.0 inclusive.");
     }

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PositiveFloat.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PositiveFloat.java
@@ -44,7 +44,7 @@ public class PositiveFloat extends NonNegativeFloat {
 
   public PositiveFloat(Double value) {
     super(value);
-    if (value == null || value.doubleValue() <= 0) {
+    if (value == null || value <= 0) {
       throw new IllegalArgumentException(
           value + " must be non-null and strictly positive.");
     }

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PositiveInteger.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PositiveInteger.java
@@ -44,7 +44,7 @@ public class PositiveInteger extends NonNegativeInteger {
 
   public PositiveInteger(Integer value) {
     super(value);
-    if (value == null || value.intValue() < 1) {
+    if (value == null || value < 1) {
       throw new IllegalArgumentException(
           value + " must be non-null and strictly positive.");
     }

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PositiveLong.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PositiveLong.java
@@ -44,7 +44,7 @@ public class PositiveLong extends NonNegativeLong {
 
   public PositiveLong(Long value) {
     super(value);
-    if (value == null || value.longValue() < 1) {
+    if (value == null || value < 1) {
       throw new IllegalArgumentException(
           value + " must be non-null and strictly positive.");
     }

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PrimitiveNumber.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PrimitiveNumber.java
@@ -40,5 +40,5 @@ package ome.xml.model.primitives;
  * @author callan
  */
 public interface PrimitiveNumber{
-  public Number getNumberValue();
+  Number getNumberValue();
 }

--- a/specification/src/main/java/ome/specification/OmeValidator.java
+++ b/specification/src/main/java/ome/specification/OmeValidator.java
@@ -256,8 +256,7 @@ public class OmeValidator
         try {
             dbf.setSchema(theSchema);
             is = new FileInputStream(file);
-            Document theDoc = builder.parse(is);
-            return theDoc;
+            return builder.parse(is);
         } catch (Exception e) {
             throw new Exception("Cannot parse the file", e);
         } finally {

--- a/specification/src/main/java/ome/specification/OmeValidator.java
+++ b/specification/src/main/java/ome/specification/OmeValidator.java
@@ -215,17 +215,13 @@ public class OmeValidator
 
         // Version - two step parse then validate (throws error as exception)
         DocumentBuilder builder = dbf.newDocumentBuilder();
-        FileInputStream is = null;
-        try {
-            is = new FileInputStream(file);
+        try (FileInputStream is = new FileInputStream(file)) {
             Document theDoc = builder.parse(is);
-            Validator validator=theSchema.newValidator();
+            Validator validator = theSchema.newValidator();
             validator.validate(new DOMSource(theDoc));
             return theDoc;
         } catch (Exception e) {
             throw new Exception("Cannot parse the file", e);
-        } finally {
-            if (is != null) is.close();
         }
     }
 

--- a/specification/src/main/java/ome/specification/SchemaResolver.java
+++ b/specification/src/main/java/ome/specification/SchemaResolver.java
@@ -198,7 +198,7 @@ public class SchemaResolver implements LSResourceResolver
      * Creates the LSInput object from the resource path
      *
      * @param theResourcePath Path to the schema in the Specification jar.
-     * @param systemId
+     * @param systemId the system identifier
      * @return The requested LSInput object.
      */
     private LSInput makeSubstutionStream(

--- a/specification/src/main/java/ome/specification/SchemaResolver.java
+++ b/specification/src/main/java/ome/specification/SchemaResolver.java
@@ -54,20 +54,20 @@ public class SchemaResolver implements LSResourceResolver
     private DOMImplementationLS theDOMImplementationLS;
 
     // the static string to strip when mapping schema locations
-    private static String GIT_MASTER_PATH  = "http://git.openmicroscopy.org/src/master/components/specification";
-    private static String GIT_DEVELOP_PATH = "http://git.openmicroscopy.org/src/develop/components/specification";
-    private static String MAIN_PATH = "http://www.openmicroscopy.org/Schemas/";
-    private static String MAIN_SEARCH_PATH = "/released-schema/";
-    private static String LEGACY_AC_PATH = "http://www.openmicroscopy.org/XMLschemas/AnalysisChain/RC1/";
-    private static String LEGACY_AM_PATH = "http://www.openmicroscopy.org/XMLschemas/AnalysisModule/RC1/";
-    private static String LEGACY_BF_PATH = "http://www.openmicroscopy.org/XMLschemas/BinaryFile/RC1/";
-    private static String LEGACY_CA_PATH = "http://www.openmicroscopy.org/XMLschemas/CA/RC1/";
-    private static String LEGACY_CL_PATH = "http://www.openmicroscopy.org/XMLschemas/CLI/RC1/";
-    private static String LEGACY_DH_PATH = "http://www.openmicroscopy.org/XMLschemas/DataHistory/IR3/";
-    private static String LEGACY_ML_PATH = "http://www.openmicroscopy.org/XMLschemas/MLI/IR2/";
-    private static String LEGACY_OM_PATH = "http://www.openmicroscopy.org/XMLschemas/OME/FC/";
-    private static String LEGACY_ST_PATH = "http://www.openmicroscopy.org/XMLschemas/STD/RC2/";
-    private static String LEGACY_SEARCH_PATH = "/released-schema/2003-FC/";
+    private static final String GIT_MASTER_PATH  = "http://git.openmicroscopy.org/src/master/components/specification";
+    private static final String GIT_DEVELOP_PATH = "http://git.openmicroscopy.org/src/develop/components/specification";
+    private static final String MAIN_PATH = "http://www.openmicroscopy.org/Schemas/";
+    private static final String MAIN_SEARCH_PATH = "/released-schema/";
+    private static final String LEGACY_AC_PATH = "http://www.openmicroscopy.org/XMLschemas/AnalysisChain/RC1/";
+    private static final String LEGACY_AM_PATH = "http://www.openmicroscopy.org/XMLschemas/AnalysisModule/RC1/";
+    private static final String LEGACY_BF_PATH = "http://www.openmicroscopy.org/XMLschemas/BinaryFile/RC1/";
+    private static final String LEGACY_CA_PATH = "http://www.openmicroscopy.org/XMLschemas/CA/RC1/";
+    private static final String LEGACY_CL_PATH = "http://www.openmicroscopy.org/XMLschemas/CLI/RC1/";
+    private static final String LEGACY_DH_PATH = "http://www.openmicroscopy.org/XMLschemas/DataHistory/IR3/";
+    private static final String LEGACY_ML_PATH = "http://www.openmicroscopy.org/XMLschemas/MLI/IR2/";
+    private static final String LEGACY_OM_PATH = "http://www.openmicroscopy.org/XMLschemas/OME/FC/";
+    private static final String LEGACY_ST_PATH = "http://www.openmicroscopy.org/XMLschemas/STD/RC2/";
+    private static final String LEGACY_SEARCH_PATH = "/released-schema/2003-FC/";
 
     public SchemaResolver() throws ClassNotFoundException, InstantiationException, IllegalAccessException
     {

--- a/specification/src/main/java/ome/specification/SchemaResolver.java
+++ b/specification/src/main/java/ome/specification/SchemaResolver.java
@@ -131,7 +131,7 @@ public class SchemaResolver implements LSResourceResolver
         String type, String namespaceURI, String publicId,
         String systemId, String baseURI)
     {
-        LSInput theResult = null;
+        LSInput theResult;
 
         // Match the requested schema locations and create the appropriate LSInput object
         if (systemId.equals("http://www.w3.org/2001/xml.xsd"))
@@ -204,7 +204,7 @@ public class SchemaResolver implements LSResourceResolver
     private LSInput makeSubstutionStream(
         String theResourcePath, String systemId)
     {
-        LSInput theResult = null;
+        LSInput theResult;
         theResult = theDOMImplementationLS.createLSInput();
         InputStream theResourcesStream = getClass().getResourceAsStream(theResourcePath);
         theResult.setByteStream(theResourcesStream);

--- a/specification/src/main/java/ome/specification/SchemaResolver.java
+++ b/specification/src/main/java/ome/specification/SchemaResolver.java
@@ -69,7 +69,7 @@ public class SchemaResolver implements LSResourceResolver
     private static final String LEGACY_ST_PATH = "http://www.openmicroscopy.org/XMLschemas/STD/RC2/";
     private static final String LEGACY_SEARCH_PATH = "/released-schema/2003-FC/";
 
-    public SchemaResolver() throws ClassNotFoundException, InstantiationException, IllegalAccessException
+    public SchemaResolver() throws InstantiationException
     {
         // Create the objects necessary to make the correct LSInput return types
         theDOMImplementationLS = null;


### PR DESCRIPTION
Following static analysis of the ome-model source tree, the following remediation of the ome-xml and specification Java components has been performed:

Both ome-xml and specification:

* Addition of missing `final` qualifiers
* Removal of inferrable types when using generics (replaced with `<>`)
* Remove unnecessary boxing and unboxing

ome-xml:

* Simplify complex conditional
* Make ignored exceptions explicit
* Replace complex sets of conditionals with switch
* Use `Map.computeIfAbsent()` to simplify list creation
* Remove `public` modifier from interface (it's public by default)
* Replace use of `StringBuilder` for performance
* Return values directly rather than using an unneeded temporary
* Add suppression for unused return values [within the ome-model source tree]
* Add suppression for same return values for functions returning constants

specification:

* Remove redundant null initialisers (when the local will always be initialised immediately after creation and before first use)
* Remove unneeded temporary values
* Use try-with-resources rather than performing manual clean-up
* Correction of Javadoc markup
* Removal of unused exception types
* Use of new-style for loops
* Use of StandardCharsets to replace string literal

No generated source changes.

Total static analysis warnings fixed: 702 (3261 before, 2559 after)

Testing:

The refactoring should not result in any behavioural changes. All unit tests and integration tests should continue to pass. There should be no compatibility changes for downstream consumers.

If you would prefer to review these changes in a more fine-grained way, it can be split out into multiple PRs without any trouble. Few of the commits depend upon each other, so can be freely cherry-picked.