### PR TITLE
Fix BinData in Mask in ROI.ome.xml

### DIFF
--- a/specification/samples/2016-06/ROI.ome.xml
+++ b/specification/samples/2016-06/ROI.ome.xml
@@ -55,7 +55,7 @@
     <Union>
       <Mask ID="Shape:7" Height="2" Width="2" X="1" Y="1">
         <Transform A00="1.00" A01="0.00" A02="2.0" A10="0.00" A11="1.00" A12="2.0"/>
-        <BinData BigEndian="true" Length="4">AOnpAA==</BinData>
+        <BinData BigEndian="true" Length="1">YA==</BinData>
       </Mask>
     </Union>
   </ROI>


### PR DESCRIPTION
As reported at https://forum.image.sc/t/prepping-and-including-roi-masks/48750/8 the Mask in the ROI.ome.xml example doesn't display in iviewer. This is because the BinData is too long (for a 2 x 2 mask), and fails to be converted into an image to view in iviewer.

To create the corrected BinData we used this approach, (based on `mask_from_binary_image` at https://github.com/ome/omero-rois/blob/4b9a388f6def81fc23689aab803479ba3e7fe28a/src/omero_rois/library.py#L94):

```
>>> import numpy as np
# start with bits for a 2 x 2 array
>>> bitarray = np.array([0, 1, 1, 0], dtype=np.bool)
>>> mask_packed = np.packbits(bitarray)
>>> mask_packed
array([96], dtype=uint8)
>>> mask_string = np.ndarray.tostring(mask_packed)
>>> mask_string
b'`'
>>> from base64 import b64encode
>>> b64encode(mask_string)
b'YA=='
```

When imported into OMERO, and viewed in iviewer the fixed `<BinData>` renders a 2 x 2 mask (although this appears misaligned a little in iviewer, probably because it's such a small image & mask).