### PR TITLE
Temporarily exclude fei.com

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -357,4 +357,5 @@ linkcheck_ignore = [
     # The PMC web site restricts access by the default Sphinx agent
     "https://www.ncbi.nlm.nih.gov/pmc/.*",
     "https://eliceirilab.org/.*", # ConnectTimeoutError
+    "https://fei.com/.*", # SSL certificate expired
 ]

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -357,5 +357,5 @@ linkcheck_ignore = [
     # The PMC web site restricts access by the default Sphinx agent
     "https://www.ncbi.nlm.nih.gov/pmc/.*",
     "https://eliceirilab.org/.*", # ConnectTimeoutError
-    "https://fei.com/.*", # SSL certificate expired
+    "https://www.fei.com/.*", # SSL certificate expired
 ]


### PR DESCRIPTION
The linkcheck has been failed since April 6th 2021 due to an expired SSL certificate.
The website owners have been contacted separately.