### PR TITLE
2008-09 to 2009-09: Move CustomAttributes transforms to top level

### DIFF
--- a/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
+++ b/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
@@ -154,6 +154,22 @@
         </xsl:element>
       </xsl:for-each>
 
+      <!-- Transform the CustomAttributes into XMLAnnotation -->
+      <xsl:if test="(count(//*[local-name() = 'CustomAttributes'])) &gt; 0">
+        <xsl:element name="StructuredAnnotations" namespace="{$newSANS}">
+          <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
+          <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
+            <xsl:if test="count(@*|node()) &gt; 0">
+              <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
+                <xsl:attribute name="ID">Annotation:1</xsl:attribute>
+                <xsl:element name="Value" namespace="{$newSANS}">
+                  <xsl:apply-templates select="@*|node()"/>
+                </xsl:element>
+              </xsl:element>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:element>
+      </xsl:if>
     </OME>
   </xsl:template>
 
@@ -849,19 +865,8 @@
     </xsl:element>
   </xsl:template>
 
-  <!-- Transform the CustomAttributes into XMLAnnotation -->
-  <xsl:template match="CA:CustomAttributes">
-    <xsl:if test="count(@*|node()) &gt; 0">
-      <xsl:element name="StructuredAnnotations" namespace="{$newSANS}">
-        <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-          <xsl:attribute name="ID">Annotation:1</xsl:attribute>
-          <xsl:element name="Value" namespace="{$newSANS}">
-            <xsl:apply-templates select="@*|node()"/>
-          </xsl:element>
-        </xsl:element>
-      </xsl:element>
-    </xsl:if>
-  </xsl:template>
+  <!-- Remove CustomAttributes -->
+  <xsl:template match="CA:CustomAttributes"/>
 
   <!--
       Remove AcquiredPixels and DefaultPixels attributes.


### PR DESCRIPTION
This is a follow up to https://github.com/ome/ome-model/issues/142 and should see the unit tests in https://github.com/ome/bioformats/pull/3695 turn green.

The issue appears to have been due to `CustomAttributes` being able to be located in 4 different locations:
- top level under OME
- under images
- under images/feature
- under dataset

The non top level `CustomAttributes` were being transformed into `XMLAnnotations` but embedded in the original element, be it Image or Dataset, this is an invalid location for it and thus it was not being recognised when converted back to an OME-Model object. This PR aims to move all `CustomAnnotations` to the top OME level before transforming them. If you have multiple `CustomAttributes` at different levels then you will get multiple `XMLAnnotations` inside a single `StructuredAnnotations`.


Fixes https://github.com/ome/ome-model/issues/142