### PR TITLE
2008-09 to 2009-09: Move CustomAttributes transforms to top level

### DIFF
--- a/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
+++ b/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
@@ -155,20 +155,22 @@
       </xsl:for-each>
 
       <!-- Transform the CustomAttributes into XMLAnnotation -->
-      <xsl:if test="(count(//*[local-name() = 'CustomAttributes'])) &gt; 0">
-        <xsl:element name="StructuredAnnotations" namespace="{$newSANS}">
-          <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
-          <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
-            <xsl:if test="count(@*|node()) &gt; 0">
-              <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-                <xsl:attribute name="ID">Annotation:1</xsl:attribute>
-                <xsl:element name="Value" namespace="{$newSANS}">
-                  <xsl:apply-templates select="@*|node()"/>
+      <xsl:if test="(count(//*[local-name() = 'StructuredAnnotations'])) = 0">
+        <xsl:if test="(count(//*[local-name() = 'CustomAttributes'])) &gt; 0">
+          <xsl:element name="StructuredAnnotations" namespace="{$newSANS}">
+            <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
+            <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
+              <xsl:if test="count(@*|node()) &gt; 0">
+                <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
+                  <xsl:attribute name="ID">Annotation:1</xsl:attribute>
+                  <xsl:element name="Value" namespace="{$newSANS}">
+                    <xsl:apply-templates select="@*|node()"/>
+                  </xsl:element>
                 </xsl:element>
-              </xsl:element>
-            </xsl:if>
-          </xsl:for-each>
-        </xsl:element>
+              </xsl:if>
+            </xsl:for-each>
+          </xsl:element>
+        </xsl:if>
       </xsl:if>
     </OME>
   </xsl:template>
@@ -194,6 +196,20 @@
   <xsl:template match="SA:*">
     <xsl:element name="{name()}" namespace="{$newSANS}">
       <xsl:apply-templates select="@*|node()"/>
+      <!-- Transform the CustomAttributes into XMLAnnotation -->
+      <xsl:if test="(count(//*[local-name() = 'CustomAttributes'])) &gt; 0">
+        <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
+        <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
+          <xsl:if test="count(@*|node()) &gt; 0">
+            <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
+              <xsl:attribute name="ID">Annotation:1</xsl:attribute>
+              <xsl:element name="Value" namespace="{$newSANS}">
+                <xsl:apply-templates select="@*|node()"/>
+              </xsl:element>
+            </xsl:element>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:if>
     </xsl:element>
   </xsl:template>
 

--- a/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
+++ b/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
@@ -161,8 +161,9 @@
             <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
             <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
               <xsl:if test="count(@*|node()) &gt; 0">
+                <xsl:variable name="annotationIndex" select="(count(//*[local-name() = 'XMLAnnotation'])) + position()" />
                 <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-                  <xsl:attribute name="ID">Annotation:1</xsl:attribute>
+                  <xsl:attribute name="ID"><xsl:value-of select="concat('Annotation:', $annotationIndex)"/></xsl:attribute>
                   <xsl:element name="Value" namespace="{$newSANS}">
                     <xsl:apply-templates select="@*|node()"/>
                   </xsl:element>
@@ -196,13 +197,20 @@
   <xsl:template match="SA:*">
     <xsl:element name="{name()}" namespace="{$newSANS}">
       <xsl:apply-templates select="@*|node()"/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="SA:StructuredAnnotations">
+    <xsl:element name="{name()}" namespace="{$newSANS}">
+      <xsl:apply-templates select="@*|node()"/>
       <!-- Transform the CustomAttributes into XMLAnnotation -->
       <xsl:if test="(count(//*[local-name() = 'CustomAttributes'])) &gt; 0">
         <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
         <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
           <xsl:if test="count(@*|node()) &gt; 0">
+          <xsl:variable name="annotationIndex" select="(count(//*[local-name() = 'XMLAnnotation'])) + position()" />
             <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-              <xsl:attribute name="ID">Annotation:1</xsl:attribute>
+              <xsl:attribute name="ID"><xsl:value-of select="concat('Annotation:', $annotationIndex)"/></xsl:attribute>
               <xsl:element name="Value" namespace="{$newSANS}">
                 <xsl:apply-templates select="@*|node()"/>
               </xsl:element>

--- a/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
+++ b/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
@@ -163,7 +163,7 @@
               <xsl:if test="count(@*|node()) &gt; 0">
                 <xsl:variable name="annotationIndex" select="position()" />
                 <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-                  <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributesAnnotation:', $annotationIndex)"/></xsl:attribute>
+                  <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributes:Annotation:', $annotationIndex)"/></xsl:attribute>
                   <xsl:element name="Value" namespace="{$newSANS}">
                     <xsl:apply-templates select="@*|node()"/>
                   </xsl:element>
@@ -210,7 +210,7 @@
           <xsl:if test="count(@*|node()) &gt; 0">
           <xsl:variable name="annotationIndex" select="position()" />
             <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-              <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributesAnnotation:', $annotationIndex)"/></xsl:attribute>
+              <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributes:Annotation:', $annotationIndex)"/></xsl:attribute>
               <xsl:element name="Value" namespace="{$newSANS}">
                 <xsl:apply-templates select="@*|node()"/>
               </xsl:element>
@@ -893,7 +893,7 @@
   <xsl:template match="CA:CustomAttributes">
     <xsl:variable name="caCount" select="count(preceding::CA:CustomAttributes | ancestor::CA:CustomAttributes) + 1"/> 
     <xsl:element name="SA:AnnotationRef" namespace="{$newSANS}">
-      <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributesAnnotation:', $caCount)"/></xsl:attribute>
+      <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributes:Annotation:', $caCount)"/></xsl:attribute>
     </xsl:element>
   </xsl:template>
 
@@ -925,7 +925,7 @@
           <xsl:when test="local-name(.) ='CustomAttributes'">
             <xsl:variable name="caCount" select="count(preceding::CA:CustomAttributes | ancestor::CA:CustomAttributes) + 1"/> 
             <xsl:element name="SA:AnnotationRef" namespace="{$newSANS}">
-              <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributesAnnotation:', $caCount)"/></xsl:attribute>
+              <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributes:Annotation:', $caCount)"/></xsl:attribute>
             </xsl:element>
           </xsl:when>
           <xsl:when test="local-name(.) ='Description'">

--- a/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
+++ b/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
@@ -163,7 +163,7 @@
               <xsl:if test="count(@*|node()) &gt; 0">
                 <xsl:variable name="annotationIndex" select="position()" />
                 <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-                  <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributes:Annotation:', $annotationIndex)"/></xsl:attribute>
+                  <xsl:attribute name="ID"><xsl:value-of select="concat('Annotation:CustomAttributes', $annotationIndex)"/></xsl:attribute>
                   <xsl:element name="Value" namespace="{$newSANS}">
                     <xsl:apply-templates select="@*|node()"/>
                   </xsl:element>
@@ -210,7 +210,7 @@
           <xsl:if test="count(@*|node()) &gt; 0">
           <xsl:variable name="annotationIndex" select="position()" />
             <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-              <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributes:Annotation:', $annotationIndex)"/></xsl:attribute>
+              <xsl:attribute name="ID"><xsl:value-of select="concat('Annotation:CustomAttributes', $annotationIndex)"/></xsl:attribute>
               <xsl:element name="Value" namespace="{$newSANS}">
                 <xsl:apply-templates select="@*|node()"/>
               </xsl:element>
@@ -893,7 +893,7 @@
   <xsl:template match="CA:CustomAttributes">
     <xsl:variable name="caCount" select="count(preceding::CA:CustomAttributes | ancestor::CA:CustomAttributes) + 1"/> 
     <xsl:element name="SA:AnnotationRef" namespace="{$newSANS}">
-      <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributes:Annotation:', $caCount)"/></xsl:attribute>
+      <xsl:attribute name="ID"><xsl:value-of select="concat('Annotation:CustomAttributes', $caCount)"/></xsl:attribute>
     </xsl:element>
   </xsl:template>
 
@@ -925,7 +925,7 @@
           <xsl:when test="local-name(.) ='CustomAttributes'">
             <xsl:variable name="caCount" select="count(preceding::CA:CustomAttributes | ancestor::CA:CustomAttributes) + 1"/> 
             <xsl:element name="SA:AnnotationRef" namespace="{$newSANS}">
-              <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributes:Annotation:', $caCount)"/></xsl:attribute>
+              <xsl:attribute name="ID"><xsl:value-of select="concat('Annotation:CustomAttributes', $caCount)"/></xsl:attribute>
             </xsl:element>
           </xsl:when>
           <xsl:when test="local-name(.) ='Description'">

--- a/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
+++ b/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
@@ -161,9 +161,9 @@
             <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
             <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
               <xsl:if test="count(@*|node()) &gt; 0">
-                <xsl:variable name="annotationIndex" select="(count(//*[local-name() = 'XMLAnnotation'])) + position()" />
+                <xsl:variable name="annotationIndex" select="position()" />
                 <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-                  <xsl:attribute name="ID"><xsl:value-of select="concat('Annotation:', $annotationIndex)"/></xsl:attribute>
+                  <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributesAnnotation:', $annotationIndex)"/></xsl:attribute>
                   <xsl:element name="Value" namespace="{$newSANS}">
                     <xsl:apply-templates select="@*|node()"/>
                   </xsl:element>
@@ -208,9 +208,9 @@
         <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
         <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
           <xsl:if test="count(@*|node()) &gt; 0">
-          <xsl:variable name="annotationIndex" select="(count(//*[local-name() = 'XMLAnnotation'])) + position()" />
+          <xsl:variable name="annotationIndex" select="position()" />
             <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-              <xsl:attribute name="ID"><xsl:value-of select="concat('Annotation:', $annotationIndex)"/></xsl:attribute>
+              <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributesAnnotation:', $annotationIndex)"/></xsl:attribute>
               <xsl:element name="Value" namespace="{$newSANS}">
                 <xsl:apply-templates select="@*|node()"/>
               </xsl:element>
@@ -890,7 +890,12 @@
   </xsl:template>
 
   <!-- Remove CustomAttributes -->
-  <xsl:template match="CA:CustomAttributes"/>
+  <xsl:template match="CA:CustomAttributes">
+    <xsl:variable name="caCount" select="count(preceding::CA:CustomAttributes | ancestor::CA:CustomAttributes) + 1"/> 
+    <xsl:element name="SA:AnnotationRef" namespace="{$newSANS}">
+      <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributesAnnotation:', $caCount)"/></xsl:attribute>
+    </xsl:element>
+  </xsl:template>
 
   <!--
       Remove AcquiredPixels and DefaultPixels attributes.
@@ -915,8 +920,14 @@
       <xsl:apply-templates
           select="@* [not(name() = 'DefaultPixels' or name() = 'AcquiredPixels')]"/>
       <xsl:for-each
-          select="* [not(local-name(.) = 'Thumbnail' or local-name(.) = 'DisplayOptions' or local-name(.) = 'Region' or local-name(.) = 'CustomAttributes' or local-name(.) = 'LogicalChannel')]">
+          select="* [not(local-name(.) = 'Thumbnail' or local-name(.) = 'DisplayOptions' or local-name(.) = 'Region' or local-name(.) = 'LogicalChannel')]">
         <xsl:choose>
+          <xsl:when test="local-name(.) ='CustomAttributes'">
+            <xsl:variable name="caCount" select="count(preceding::CA:CustomAttributes | ancestor::CA:CustomAttributes) + 1"/> 
+            <xsl:element name="SA:AnnotationRef" namespace="{$newSANS}">
+              <xsl:attribute name="ID"><xsl:value-of select="concat('CustomAttributesAnnotation:', $caCount)"/></xsl:attribute>
+            </xsl:element>
+          </xsl:when>
           <xsl:when test="local-name(.) ='Description'">
             <xsl:apply-templates select="current()"/>
           </xsl:when>

--- a/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
+++ b/specification/src/main/resources/transforms/2008-09-to-2009-09.xsl
@@ -154,6 +154,22 @@
         </xsl:element>
       </xsl:for-each>
 
+      <!-- Transform the CustomAttributes into XMLAnnotation -->
+      <xsl:if test="(count(//*[local-name() = 'CustomAttributes'])) &gt; 0">
+        <xsl:element name="StructuredAnnotations" namespace="{$newSANS}">
+          <xsl:comment>Append Custom Attributes as XMLAnnotation</xsl:comment>
+          <xsl:for-each select="//*[local-name() = 'CustomAttributes']">
+            <xsl:if test="count(@*|node()) &gt; 0">
+              <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
+                <xsl:attribute name="ID">Annotation:1</xsl:attribute>
+                <xsl:element name="Value" namespace="{$newSANS}">
+                  <xsl:apply-templates select="@*|node()"/>
+                </xsl:element>
+              </xsl:element>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:element>
+      </xsl:if>
     </OME>
   </xsl:template>
 
@@ -849,19 +865,8 @@
     </xsl:element>
   </xsl:template>
 
-  <!-- Transform the CustomAttributes into XMLAnnotation -->
-  <xsl:template match="CA:CustomAttributes">
-    <xsl:if test="count(@*|node()) &gt; 0">
-      <xsl:element name="StructuredAnnotations" namespace="{$newSANS}">
-        <xsl:element name="XMLAnnotation" namespace="{$newSANS}">
-          <xsl:attribute name="ID">Annotation:1</xsl:attribute>
-          <xsl:element name="Value" namespace="{$newSANS}">
-            <xsl:apply-templates select="@*|node()"/>
-          </xsl:element>
-        </xsl:element>
-      </xsl:element>
-    </xsl:if>
-  </xsl:template>
+  <!-- Remove CustomAttributes -->
+  <xsl:template match="CA:CustomAttributes"/>
 
   <!--
       Remove AcquiredPixels and DefaultPixels attributes.


### PR DESCRIPTION
This is a follow up to #142 and should see the unit tests in ome/bioformats#3695 turn green.

The issue appears to have been due to CustomAttributes being able to be located in 4 different locations:

top level under OME
under images
under images/feature
under dataset
The non top level CustomAttributes were being transformed into XMLAnnotations but embedded in the original element, be it Image or Dataset, this is an invalid location for it and thus it was not being recognised when converted back to an OME-Model object. This PR aims to move all CustomAnnotations to the top OME level before transforming them. If you have multiple CustomAttributes at different levels then you will get multiple XMLAnnotations inside a single StructuredAnnotations.

Fixes #142