### PR TITLE
ome_model: do not use mutable default arguments

### DIFF
--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -102,7 +102,7 @@ class Image(object):
     def __init__(self,
                  name,
                  sizeX, sizeY, sizeZ, sizeC, sizeT,
-                 tiffs=[],
+                 tiffs=None,
                  order="XYZTC",
                  type="uint16",
                  ):
@@ -123,8 +123,9 @@ class Image(object):
             'Planes': [],
         }
         Image.ID += 1
-        for tiff in tiffs:
-            self.add_tiff(tiff)
+        if tiffs:
+            for tiff in tiffs:
+                self.add_tiff(tiff)
 
     def add_channel(self, name=None, color=None, samplesPerPixel=1):
         self.data["Channels"].append(
@@ -223,12 +224,16 @@ def parse_tiff(tiff):
     return (m.group("channel"), m.group("time"), m.group("slice"))
 
 
-def create_companion(plates=[], images=[], out=None):
+def create_companion(plates=None, images=None, out=None):
     """
     Create a companion OME-XML for a given experiment.
     Assumes 2D TIFFs
     """
     root = ET.Element("OME", attrib=OME_ATTRIBUTES)
+    if not plates:
+        plates = []
+    if not images:
+        images = []
 
     for plate in plates:
         p = ET.SubElement(root, "Plate", attrib=plate.data['Plate'])

--- a/test/unit/test_plate.py
+++ b/test/unit/test_plate.py
@@ -1,0 +1,72 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+
+
+from ome_model.experimental import Plate, Image, create_companion
+import xml.etree.ElementTree as ElementTree
+
+NS = {'OME': 'http://www.openmicroscopy.org/Schemas/OME/2016-06'}
+ElementTree.register_namespace('OME', NS['OME'])
+
+
+class TestPlate(object):
+
+    def test_minimal_plate(self, tmpdir):
+        f = str(tmpdir.join('plate.companion.ome'))
+
+        p = Plate("test", 1, 1)
+        well = p.add_well(0, 0)
+        i = Image("test", 256, 512, 3, 4, 5)
+        well.add_wellsample(0, i)
+        create_companion(plates=[p], out=f)
+
+        root = ElementTree.parse(f).getroot()
+        plates = root.findall('OME:Plate', namespaces=NS)
+        assert len(plates) == 1
+        assert plates[0].attrib['Name'] == 'test'
+        wells = plates[0].findall('OME:Well', namespaces=NS)
+        assert len(wells) == 1
+        assert wells[0].attrib['Row'] == '0'
+        assert wells[0].attrib['Column'] == '0'
+        wellsamples = wells[0].findall('OME:WellSample', namespaces=NS)
+        assert len(wellsamples) == 1
+        imagerefs = wellsamples[0].findall('OME:ImageRef', namespaces=NS)
+        assert len(imagerefs) == 1
+        assert imagerefs[0].attrib['ID'] == 'Image:0'
+        images = root.findall('OME:Image', namespaces=NS)
+        assert len(images) == 1
+        assert images[0].attrib['Name'] == 'test'
+        assert images[0].attrib['ID'] == 'Image:0'
+        pixels = images[0].findall('OME:Pixels', namespaces=NS)
+        assert len(pixels) == 1
+        assert pixels[0].attrib['SizeX'] == '256'
+        assert pixels[0].attrib['SizeY'] == '512'
+        assert pixels[0].attrib['SizeZ'] == '3'
+        assert pixels[0].attrib['SizeC'] == '4'
+        assert pixels[0].attrib['SizeT'] == '5'
+        assert pixels[0].attrib['DimensionOrder'] == 'XYZTC'
+        assert pixels[0].attrib['Type'] == 'uint16'
+        channels = pixels[0].findall('OME:Channel', namespaces=NS)
+        assert len(channels) == 0


### PR DESCRIPTION
Triggered by an IDR submission, the following code exposes the issue

```python
from ome_model.experimental import Plate, Image, create_companion

for i in range(5):
    plate = Plate(str(i), 1, 1)
    well = plate.add_well(0,0)
    image = Image(
      str(i), 10, 10, 1, 2, 1,
                order="XYZCT", type="uint16")
    image.add_tiff(str(i) + '.tif')
    well.add_wellsample(0, image)
    create_companion(plates=[plate], out=str(i) + '.companion.ome')
```

While expecting this will create 4 companion OME files with 1 plate/1 well/1 well sample/1 image each, the second companion contains 2 images, the third 3...

Tracing down the source of the issue comes down to the usage of empty lists as default arguments which is a classical Python gotcha as these are mutable. At the moment, a workaround would be to explicitly pass a new empty list.

```diff
-    create_companion(plates=[plate], out=str(i) + '.companion.ome')
+    create_companion(plates=[plate], images=[], out=str(i) + '.companion.ome')
```

87f4859 updates all locations using empty lists as default to using `None` instead and handles the check within the method

All the other commits add some unit test coverage of the plate generation scenarios. The tests should be failing without 87f4859 and passing with.
