### PR TITLE
Update java-library page to point to javadoc.io

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -167,7 +167,7 @@ extlinks = {
     'bf_source' : (bf_github_root + 'blob/'+ branch + '/%s', ''),
     'bf_sourcedir' : (bf_github_root + 'tree/'+ branch + '/%s', ''),
     # API
-    'javadoc' : (downloads_root + '/latest/bio-formats/api/%s', ''),
+    'javadoc' : ("https://javadoc.io/doc/org.openmicroscopy/ome-xml/%s", ''),
     # Doc links
     'devs_doc' : (docs_root + '/contributing/%s', ''),
     'omero_doc' : (docs_root + '/latest/omero/%s', ''),

--- a/docs/sphinx/ome-xml/java-library.rst
+++ b/docs/sphinx/ome-xml/java-library.rst
@@ -10,10 +10,9 @@ metadata processing facilities form the backbone of the
 Download
 --------
 
-**ome-xml.jar** is included in **bioformats_package.jar** available to
-download from the :bf_downloads:`Bio-Formats download page <>`. Alternatively,
-the individual artifact **ome-xml.jar** is hosted at `Maven Central <http://search.maven.org/>`_ under the group ``org.openmicroscopy``. The
-license is `LGPL <http://www.gnu.org/licenses/lgpl.html>`_.
+The ``ome-xml`` artifacts are hosted on the
+`Maven Central Repository <https://search.maven.org/>`_ under the group ``org.openmicroscopy`` and distributed under the
+`2-Clause BSD license <https://opensource.org/licenses/BSD-2-Clause>`_.
 
 Installation
 ------------
@@ -39,7 +38,5 @@ Source code
 -----------
 
 The OME-XML Java library is an open source project—the source code is
-freely accessible via our Git repository. See 
-:bf_doc:`these instructions <developers/building-bioformats.html>` for details
-on accessing the code.
+freely accessible via the https://github.com/ome/ome-model Git repository.
 


### PR DESCRIPTION
Also only refer to Maven Central as the hosting platform for the artifacts

Fixes https://github.com/ome/ome-model/issues/152