### PR TITLE
Update link to TIFF standard

### DIFF
--- a/docs/sphinx/ome-tiff/specification.rst
+++ b/docs/sphinx/ome-tiff/specification.rst
@@ -1,4 +1,4 @@
-.. _TIFF: https://www.adobe.io/open/standards/TIFF.html
+.. _TIFF: https://www.loc.gov/preservation/digital/formats/fdd/fdd000022.shtml
 .. _RFC 2119: https://www.ietf.org/rfc/rfc2119.txt
 
 OME-TIFF specification


### PR DESCRIPTION
Link to the TIFF standard has been broken on the adobe site for a number of days (https://latest-ci.openmicroscopy.org/jenkins/job/OME-MODEL-linkcheck/528/console). 

See posts [Adobe & TIFF spec](https://community.adobe.com/t5/using-the-community-discussions/broken-link-to-open-standards-on-adobe-io/m-p/12753322) and ​​[second post](https://experienceleaguecommunities.adobe.com/t5/adobe-i-o-cloud-extensibility/broken-link-to-open-standards-on-adobe-io/td-p/441124).