### PR TITLE
XMLMockObjects: make artificial SHA1 schema-compliant

### DIFF
--- a/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
+++ b/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
@@ -1093,7 +1093,6 @@ public class XMLMockObjects
     plane.setTheZ(new NonNegativeInteger(z));
     plane.setTheC(new NonNegativeInteger(c));
     plane.setTheT(new NonNegativeInteger(z));
-    plane.setHashSHA1("1234567890ABCDEF1234");
     return plane;
   }
 

--- a/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
+++ b/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
@@ -1093,7 +1093,7 @@ public class XMLMockObjects
     plane.setTheZ(new NonNegativeInteger(z));
     plane.setTheC(new NonNegativeInteger(c));
     plane.setTheT(new NonNegativeInteger(z));
-    plane.setHashSHA1("1234567890ABCDEF1234567890ABCDEF12345678");
+    plane.setHashSHA1("1234567890ABCDEF1234");
     return plane;
   }
 


### PR DESCRIPTION
See https://github.com/ome/bioformats/issues/3810