### PR TITLE
Add Java 17 to the CI build matrix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,15 @@ jobs:
         java: [1.8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.7', '3.8', '3.9']
+        exclude:
+          - java: 11
+            python-version: '3.8'
+          - java: 11
+            python-version: '3.9'
+          - java: 17
+            python-version: '3.8'
+          - java: 17
+            python-version: '3.9'
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [1.8, 11]
+        java: [1.8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         java: [1.8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install


### PR DESCRIPTION
Also drop Python 3.6 (EOL) and only test different Python versions once per platform

Tests should remain green