### PR TITLE
Accelrys renaming and link update

### DIFF
--- a/docs/sphinx/ome-tiff/index.rst
+++ b/docs/sphinx/ome-tiff/index.rst
@@ -29,7 +29,7 @@ Support
 
 OME-TIFF is supported by:
 
-* `Accelrys Inc. <http://accelrys.com/>`_
+* `BIOVIA <https://www.3ds.com/products-services/biovia/>`_
 * `Bitplane AG <http://www.bitplane.com/>`_
 * `Carl Zeiss Microscopy GmbH <https://www.zeiss.com/microscopy/int/home.html>`_
 * `Cytiva <https://www.cytivalifesciences.com/>`_ (formerly GE Healthcare, Applied Precision)


### PR DESCRIPTION
The old link had been redirecting to the new location. Changing to point to the redirected location and update the company name, see below:


Previously named Accelrys, it is a wholly owned subsidiary of [Dassault Systèmes](https://en.wikipedia.org/wiki/Dassault_Syst%C3%A8mes) after an April 2014 acquisition[[1]](https://en.wikipedia.org/wiki/BIOVIA#cite_note-1) and has been renamed BIOVIA
