### PR TITLE
BBBC017: new representative OME-TIFF samples

### DIFF
--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -82,6 +82,14 @@ available from the
 
 See `Ljosa V, Sokolnicki KL, Carpenter AE (2012). Annotated high-throughput microscopy image sets for validation. Nature Methods 9(7):637 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3627348/>`__.
 
+.. note::
+
+    An OME-TIFF file representative of the same plate had been previously generated and made
+    available under :ometiff_downloads:`NIRHTa-001.ome.tiff <BBBC/NIRHTa-001.ome.tiff>`. Although
+    the file is syntactically valid, the plate layout is incorrect due to a conversion issue.
+    This file should be considered as deprecated and superseded by the two representative plate
+    examples described above.
+
 ROI
 ^^^
 

--- a/docs/sphinx/ome-tiff/data.rst
+++ b/docs/sphinx/ome-tiff/data.rst
@@ -56,9 +56,10 @@ version since their initial creation.
 Plate
 ^^^^^
 
-An OME-TIFF dataset representative of the
+Two OME-TIFF datasets representative of the
 :doc:`High Content Screening </developers/screen-plate-well>` section of the
-OME Data Model, derived from the public
+OME Data Model, derived from a 384 wells plate of the BBBC017 image set
+available from the
 `Broad Bioimage Benchmark Collection <https://data.broadinstitute.org/bbbc/>`_.
 
 .. list-table::
@@ -69,7 +70,12 @@ OME Data Model, derived from the public
      * Provenance
      * Copyright
 
-  -  * :ometiff_downloads:`NIRHTa-001.ome.tiff <BBBC/NIRHTa-001.ome.tiff>`
+  -  * :ometiff_downloads:`Single file OME-TIFF <BBBC017/single-file>`
+     * 512 × 512 × 1 × 3 × 1
+     * `BBBC017 <https://data.broadinstitute.org/bbbc/BBBC017/>`_
+     * `CC-BY-NC-SA 3.0 <https://creativecommons.org/licenses/by-nc-sa/3.0>`_
+
+  -  * :ometiff_downloads:`Multi-file OME-TIFF <BBBC017/multi-file>`
      * 512 × 512 × 1 × 3 × 1
      * `BBBC017 <https://data.broadinstitute.org/bbbc/BBBC017/>`_
      * `CC-BY-NC-SA 3.0 <https://creativecommons.org/licenses/by-nc-sa/3.0>`_


### PR DESCRIPTION
This PR updates the sample data page of the OME-TIFF specification to point at the new representative samples of the BBBC017 plate which were recently generated and published under https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/BBBC017/.

These samples are being tested by the daily CI builds and have been used for the functional testing of https://github.com/ome/bioformats/pull/3831#pullrequestreview-1100874964

A note is also added to explain why the former OME-TIFF should be considered as deprecated and its usage replaced.