### PR TITLE
GH CI maintenance upgrades

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,16 +13,16 @@ jobs:
       matrix:
         java: [8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
         exclude:
           - java: 11
-            python-version: '3.8'
+            python-version: '3.9'
           - java: 11
-            python-version: '3.9'
-          - java: 17
-            python-version: '3.8'
+            python-version: '3.10'
           - java: 17
             python-version: '3.9'
+          - java: 17
+            python-version: '3.10'
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [1.8, 11, 17]
+        java: [8, 11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.7', '3.8', '3.9']
         exclude:
@@ -27,9 +27,9 @@ jobs:
     env:
       maven_commands: install
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -37,14 +37,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: 'zulu'
+          cache: 'maven'
       - name: Build
         run: mvn ${{ env.maven_commands }}

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -7,8 +7,8 @@ jobs:
     name: Build and publish Python distribution to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - name: Build a binary wheel and a source tarball
         run: |
           python -mpip install wheel

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,7 +19,7 @@ jobs:
           - '3.9'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,10 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
-          - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- bump versions of core GitHub actions as per the deprecation warning -  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- test the code generation on Python 3.8, 3.9, 3.10 - see https://endoflife.date/python