### PR TITLE
Remove unneeded joda-time dependency

### DIFF
--- a/ome-xml/pom.xml
+++ b/ome-xml/pom.xml
@@ -50,12 +50,6 @@
     </dependency>
 
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.2</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <version>${testng.version}</version>


### PR DESCRIPTION
Following on from the dependency updates in https://github.com/ome/bioformats/issues/3970

The joda-time dependency is currently used in a number of different projects, all of which also include ome-common. Rather than managing the dependency in each individual project it could be easier to simply inherit from the upstream ome-common project.

See the conversion on https://github.com/ome/ome-common-java/pull/77