### PR TITLE
Update license headers for all Java sources of the OME-XML library

### DIFF
--- a/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
+++ b/ome-xml/src/main/java/ome/specification/XMLMockObjects.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2003 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
@@ -9,13 +9,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/ome-xml/src/main/java/ome/specification/XMLWriter.java
+++ b/ome-xml/src/main/java/ome/specification/XMLWriter.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2003 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
@@ -9,13 +9,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/ome-xml/src/main/java/ome/units/UNITS.java
+++ b/ome-xml/src/main/java/ome/units/UNITS.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
- * Copyright (C) 2014 - 2016 Open Microscopy Environment:
- *   - Board of Regents of the University of Wisconsin-Madison
- *   - Glencoe Software, Inc.
- *   - University of Dundee
+ * Copyright (C) 2006 - 2023 Open Microscopy Environment:
+ *     - Board of Regents of the University of Wisconsin-Madison
+ *     - Glencoe Software, Inc.
+ *     - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/Angle.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Angle.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/ElectricPotential.java
+++ b/ome-xml/src/main/java/ome/units/quantity/ElectricPotential.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/Frequency.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Frequency.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/Length.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Length.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/Power.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Power.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/Pressure.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Pressure.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/Quantity.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Quantity.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/Temperature.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Temperature.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/quantity/Time.java
+++ b/ome-xml/src/main/java/ome/units/quantity/Time.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/units/unit/Unit.java
+++ b/ome-xml/src/main/java/ome/units/unit/Unit.java
@@ -1,25 +1,32 @@
 /*
  * #%L
- * The OME Data Model specification
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
  *   - University of Dundee
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
  * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
  * 
- * You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/xml/meta/AbstractOMEXMLMetadata.java
+++ b/ome-xml/src/main/java/ome/xml/meta/AbstractOMEXMLMetadata.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/meta/BaseMetadata.java
+++ b/ome-xml/src/main/java/ome/xml/meta/BaseMetadata.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/meta/IMetadata.java
+++ b/ome-xml/src/main/java/ome/xml/meta/IMetadata.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2023 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/meta/MetadataRoot.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataRoot.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/meta/OMEXMLMetadata.java
+++ b/ome-xml/src/main/java/ome/xml/meta/OMEXMLMetadata.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/meta/OMEXMLMetadataRoot.java
+++ b/ome-xml/src/main/java/ome/xml/meta/OMEXMLMetadataRoot.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
+++ b/ome-xml/src/main/java/ome/xml/model/AbstractOMEModelObject.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/MapPair.java
+++ b/ome-xml/src/main/java/ome/xml/model/MapPair.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2014 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
@@ -11,13 +11,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -29,10 +29,6 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
- *
- * The views and conclusions contained in the software and documentation are
- * those of the authors and should not be interpreted as representing official
- * policies, either expressed or implied, of any organization.
  * #L%
  */
 

--- a/ome-xml/src/main/java/ome/xml/model/OMEModel.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModel.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModelImpl.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/OMEModelObject.java
+++ b/ome-xml/src/main/java/ome/xml/model/OMEModelObject.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/ReferenceList.java
+++ b/ome-xml/src/main/java/ome/xml/model/ReferenceList.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/enums/Enumeration.java
+++ b/ome-xml/src/main/java/ome/xml/model/enums/Enumeration.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/enums/EnumerationException.java
+++ b/ome-xml/src/main/java/ome/xml/model/enums/EnumerationException.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/enums/handlers/IEnumerationHandler.java
+++ b/ome-xml/src/main/java/ome/xml/model/enums/handlers/IEnumerationHandler.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/Color.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/Color.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeFloat.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeFloat.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeInteger.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeInteger.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeLong.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/NonNegativeLong.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PercentFraction.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PercentFraction.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PositiveFloat.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PositiveFloat.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PositiveInteger.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PositiveInteger.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PositiveLong.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PositiveLong.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PrimitiveNumber.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PrimitiveNumber.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/PrimitiveType.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/PrimitiveType.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/model/primitives/Timestamp.java
+++ b/ome-xml/src/main/java/ome/xml/model/primitives/Timestamp.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/main/java/ome/xml/package.html
+++ b/ome-xml/src/main/java/ome/xml/package.html
@@ -1,6 +1,6 @@
 <!--
   #%L
-  OME-XML Java library for working with OME-XML metadata structures.
+  OME XML library
   %%
   Copyright (C) 2006 - 2016 Open Microscopy Environment:
     - Massachusetts Institute of Technology

--- a/ome-xml/src/main/resources/ome/xml/model/omemodel.properties
+++ b/ome-xml/src/main/resources/ome/xml/model/omemodel.properties
@@ -1,1 +1,32 @@
+###
+# #%L
+# OME XML library
+# %%
+# Copyright (C) 2006 - 2023 Open Microscopy Environment:
+#     - Board of Regents of the University of Wisconsin-Madison
+#     - Glencoe Software, Inc.
+#     - University of Dundee
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
 schema.version = ${ome.model.schemaver}

--- a/ome-xml/src/test/java/ome/xml/utests/ColorTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/ColorTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/EnumHandlerTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/EnumHandlerTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/NonNegativeFloatTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/NonNegativeFloatTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/NonNegativeIntegerTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/NonNegativeIntegerTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/NonNegativeLongTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/NonNegativeLongTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/PercentFractionTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/PercentFractionTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/PositiveFloatTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/PositiveFloatTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/PositiveIntegerTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/PositiveIntegerTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/PositiveLongTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/PositiveLongTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/SingularBackReferenceTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/SingularBackReferenceTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/java/ome/xml/utests/TimestampTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/TimestampTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * OME-XML Java library for working with OME-XML metadata structures.
+ * OME XML library
  * %%
  * Copyright (C) 2006 - 2016 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology

--- a/ome-xml/src/test/resources/logback.xml
+++ b/ome-xml/src/test/resources/logback.xml
@@ -1,4 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  OME XML library
+  %%
+  Copyright (C) 2006 - 2023 Open Microscopy Environment:
+      - Board of Regents of the University of Wisconsin-Madison
+      - Glencoe Software, Inc.
+      - University of Dundee
+  %%
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+  #L%
+  -->
+
 <configuration>
   <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>

--- a/ome-xml/src/test/resources/testng.xml
+++ b/ome-xml/src/test/resources/testng.xml
@@ -1,6 +1,6 @@
 <!--
   #%L
-  OME-XML Java library for working with OME-XML metadata structures.
+  OME XML library
   %%
   Copyright (C) 2006 - 2016 Open Microscopy Environment:
     - Massachusetts Institute of Technology


### PR DESCRIPTION
While reviewing various boilerplate headers for BSD licensed projects, I noticed that several Java source files under the `ome-xml` component include the terms of the GNU GPL 2 license in their header which is at odds with the component license.

This is most certainly an oversight which can be traced back to the original introduction of the unit concept for the 2015-01 release of the OME Data model in https://github.com/ome/bioformats/pull/1379.

This PR commits the changes after executing `mvn license:update-file-header` under the `ome-xml` component to fix the heders.

The only other notable difference is that the project name is updated from `OME-XML Java library for working with OME-XML metadata structures.` to `OME XML library` as per the POM file. If it is preferable to keep the existing header, happy to change the `name` in `pom.xml`