### PR TITLE
Deprecate ome_model package

### DIFF
--- a/ome_model/experimental.py
+++ b/ome_model/experimental.py
@@ -4,6 +4,7 @@
 import re
 import sys
 import uuid
+import warnings
 import xml.etree.ElementTree as ET
 from . import __version__
 
@@ -24,6 +25,11 @@ TIFF_PARSER += "[Zz]_?(?P<slice>[^-_]+)"  # Z-slices
 TIFF_PARSER += ")+"  # As many of those three as needed
 TIFF_PARSER += ".*?[.].*?"  # Ignore the rest, but don't slurp the file ending
 TIFF_PARSER = re.compile(TIFF_PARSER)
+
+warnings.warn(
+    "This module is deprecated as of ome-model 6.3.7. "
+    "Use other libraries such as ome-types to generate and validate "
+    "OME-XML.", DeprecationWarning)
 
 
 class Channel(object):

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     "into OME-XML."
     ),
     classifiers=[
-          'Development Status :: 4 - Beta',
+          'Development Status :: 7 - Inactive',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: BSD License',
           'Natural Language :: English',

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,14 @@ setup(
     version=get_version(),
     packages=["ome_model"],
     name='ome-model',
-    description="Core OME model library (EXPERIMENTAL)",
-    long_description="TBD",
+    description="Core OME model library (deprecated)",
+    long_description=(
+    "This project has been deprecated. To create companion "
+    "OME files using Python, you can use other libraries such "
+    "as https://pypi.org/project/ome-types/ "
+    "to create and validate OME model objects and convert them "
+    "into OME-XML."
+    ),
     classifiers=[
           'Development Status :: 4 - Beta',
           'Intended Audience :: Developers',


### PR DESCRIPTION
See #194

This is the first step of the removal of the `ome_model` Python code from this repository. `DeprecationWarning` are added to the module and the project name and description should be amended on PyPI on the next release. Both should redirect towards other libraries like `ome-types`.

Once merged and released, we can open a follow-up PR to cleanup the code entirely. 
