### PR TITLE
Use the default encoding of Python files

### DIFF
--- a/xsd-fu/python/generateDS/process_includes.py
+++ b/xsd-fu/python/generateDS/process_includes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- mode: pymode; coding: latin1; -*-
+# -*- mode: pymode; -*-
 """
 Synopsis:
     Recusively process the include elements in an XML Schema file.

--- a/xsd-fu/xsd-fu
+++ b/xsd-fu/xsd-fu
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 """
 Generate code to process OME-XML from an OME-XML schema.
 """


### PR DESCRIPTION
The default encoding of Python 3 files is UTF-8, there is no need to specify it.

These are either plain ASCII files or already UTF-8 files.