### PR TITLE
`six` is not a direct dependency anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@
 #
 #     pip install -r requirements.txt
 #
-six
 Genshi


### PR DESCRIPTION
While `Genshi` does seem to require `six`, we should let it handle its own dependencies. That's what `pip` and other package installers are for.