### PR TITLE
Switch to utf-8 encoding for Python scripts

### DIFF
--- a/xsd-fu/python/generateDS/generateDS.html
+++ b/xsd-fu/python/generateDS/generateDS.html
@@ -2068,7 +2068,7 @@ method1 = MethodSpec(name='walk_and_update',
 <p>Then, define <tt class="docutils literal"><span class="pre">date_calcs.py</span></tt> as:</p>
 <pre class="literal-block">
 #!/usr/bin/env python
-# -*- mode: pymode; coding: latin1; -*-
+# -*- mode: pymode; coding: utf-8; -*-
 
 import datetime
 

--- a/xsd-fu/python/generateDS/process_includes.py
+++ b/xsd-fu/python/generateDS/process_includes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- mode: pymode; coding: latin1; -*-
+# -*- mode: pymode; coding: utf-8; -*-
 """
 Synopsis:
     Recursively process the include elements in an XML Schema file.


### PR DESCRIPTION
We use only the ASCII character set, so switching is straightforward.