### PR TITLE
Replace mailing lists and QA with forum.image.sc and Zenodo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ please ensure you read these.
 * Make sure you include details of the problem you are fixing and how to test
   your changes.
 * We may need you to submit some test data
-  [via our QA system](http://qa.openmicroscopy.org.uk/qa/upload/). If the
+  [via Zenodo](https://zenodo.org/communities/bio-formats/). If the
   files are particularly large (> ~2 GB), contact the
-  [mailing list](https://www.openmicroscopy.org/support/)
+  [image.sc forum](https://forum.image.sc/)
   and we will get back to you with secure upload details.
 
 ## External Contributors
@@ -56,6 +56,6 @@ style guidance from the
 [OME Documentation Repository README](https://github.com/openmicroscopy/ome-documentation/blob/develop/README.rst#conventions-used).
 
 Documentation for new supported formats is auto-generated so it is best to
-contact the [mailing list](https://www.openmicroscopy.org/support/)
+contact the [image.sc forum](https://forum.image.sc/)
 before embarking on such a change, or submit your new reader code and let one
 of the main OME team deal with the documentation for you.

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <developers>
     <developer>
       <name>The OME Team</name>
-      <email>ome-devel@lists.openmicroscopy.org.uk</email>
+      <url>https://forum.image.sc/g/ome</url>
     </developer>
   </developers>
   <contributors>
@@ -52,23 +52,6 @@
     <contributor><name>Christoph Sommer</name></contributor>
     <contributor><name>Bjoern Thiel</name></contributor>
   </contributors>
-
-  <mailingLists>
-    <mailingList>
-      <name>OME-users</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-users/</unsubscribe>
-      <post>ome-users@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-users/</archive>
-    </mailingList>
-    <mailingList>
-      <name>OME-devel</name>
-      <subscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</subscribe>
-      <unsubscribe>http://lists.openmicroscopy.org.uk/mailman/listinfo/ome-devel/</unsubscribe>
-      <post>ome-devel@lists.openmicroscopy.org.uk</post>
-      <archive>http://lists.openmicroscopy.org.uk/pipermail/ome-devel/</archive>
-    </mailingList>
-  </mailingLists>
 
   <prerequisites>
     <maven>3.0.5</maven>

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
     <url>http://github.com/ome/ome-model</url>
   </scm>
   <issueManagement>
-    <system>Trac</system>
-    <url>https://trac.openmicroscopy.org/ome</url>
+    <system>GitHub</system>
+    <url>https://github.com/ome/ome-model/issues</url>
   </issueManagement>
   <ciManagement>
     <system>Jenkins</system>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <developers>
     <developer>
       <name>The OME Team</name>
-      <url>https://forum.image.sc/g/ome</url>
+      <url>https://www.openmicroscopy.org/teams/</url>
     </developer>
   </developers>
   <contributors>


### PR DESCRIPTION
Fixes #107.

The changes to `CONTRIBUTING.md` should be straightforward, but I'm open to other ways to update `pom.xml`. There doesn't appear to be an equivalent to `mailingList` for specifying a forum, so I opted to just remove the `mailingLists` block to minimize confusion. If keeping the archive links only or doing something else is preferable, happy to do that instead. 