### PR TITLE
Update publication to use Central Portal

### DIFF
--- a/ome-xml/pom.xml
+++ b/ome-xml/pom.xml
@@ -16,11 +16,11 @@
 
   <name>OME XML library</name>
   <description>A library for working with OME-XML metadata structures.</description>
-  <url>http://www.openmicroscopy.org/site/support/ome-model/ome-xml/java-library.html</url>
+  <url>https://ome-model.readthedocs.io/en/stable/ome-xml/java-library.html</url>
   <inceptionYear>2006</inceptionYear>
   <organization>
     <name>Open Microscopy Environment</name>
-    <url>http://www.openmicroscopy.org/</url>
+    <url>https://www.openmicroscopy.org/</url>
   </organization>
   <licenses>
     <license>

--- a/pom.xml
+++ b/pom.xml
@@ -137,11 +137,12 @@
         <plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.14.0</version>
           <!-- Require the Java 8 platform. -->
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <source>8</source>
+            <target>8</target>
+            <release>8</release>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,16 +76,6 @@
     <system>Jenkins</system>
     <url>https://ci.openmicroscopy.org/</url>
   </ciManagement>
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 
   <properties>
     <!-- If two artifacts on the classpath use two different versions of the
@@ -358,24 +348,10 @@
       <id>release</id>
       <build>
         <plugins>
-          <!-- Stage releases with nexus -->
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>false</autoReleaseAfterClose>
-            </configuration>
-          </plugin>
-
-          <!-- gpg release signing -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -385,6 +361,17 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <tokenAuth>true</tokenAuth>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,11 @@
 
   <name>OME Model</name>
   <description>Contains the OME imaging metadata model specification, code generator and implementation</description>
-  <url>http://www.openmicroscopy.org/site/products/bio-formats</url>
+  <url>https://www.openmicroscopy.org/ome-file-formats/</url>
   <inceptionYear>2005</inceptionYear>
   <organization>
     <name>Open Microscopy Environment</name>
-    <url>http://www.openmicroscopy.org/</url>
+    <url>https://www.openmicroscopy.org/</url>
   </organization>
   <licenses>
     <license>
@@ -66,15 +66,15 @@
     <connection>scm:git:https://github.com/ome/ome-model</connection>
     <developerConnection>scm:git:git@github.com:ome/ome-model</developerConnection>
     <tag>HEAD</tag>
-    <url>http://github.com/ome/ome-model</url>
+    <url>https://github.com/ome/ome-model</url>
   </scm>
   <issueManagement>
     <system>GitHub</system>
     <url>https://github.com/ome/ome-model/issues</url>
   </issueManagement>
   <ciManagement>
-    <system>Jenkins</system>
-    <url>https://ci.openmicroscopy.org/</url>
+    <system>GitHub actions</system>
+    <url>https://github.com/ome/ome-model/actions</url>
   </ciManagement>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
     <logback.version>1.3.15</logback.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <ome_common.version>6.0.25</ome_common.version>
+    <ome_common.version>6.0.26</ome_common.version>
     <ome-common.version>${ome_common.version}</ome-common.version>
 
     <ome.model.schemaver>2016-06</ome.model.schemaver>

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -16,11 +16,11 @@
 
   <name>Metadata model specification</name>
   <description>The OME Data Model specification</description>
-  <url>http://www.openmicroscopy.org/site/support/ome-model/</url>
+  <url>https://ome-model.readthedocs.io/en/stable/</url>
   <inceptionYear>2003</inceptionYear>
   <organization>
     <name>Open Microscopy Environment</name>
-    <url>http://www.openmicroscopy.org/</url>
+    <url>https://www.openmicroscopy.org/</url>
   </organization>
   <licenses>
     <license>
@@ -30,7 +30,7 @@
     </license>
     <license>
       <name>Creative Commons Attribution 3.0 Unported License</name>
-      <url>http://creativecommons.org/licenses/by/3.0/</url>
+      <url>https://creativecommons.org/licenses/by/3.0/</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
See https://central.sonatype.org/news/20250326_ossrh_sunset/ for more context as well as https://github.com/ome/ome-common-java/pull/101 and https://github.com/ome/ome-contributing/pull/37

This primary adjusts the `release` profile used during the `deploy` phase to use `central-publishing-maven-plugin` instead of `nexus-staging-maven-plugin`.
The `maven-compiler-plugin` plugin is also upgraded to 3.14.0 and the release target set to 8. This should ensure release artifacts built with either version of the JDK are binary compatible with Java 8 - see https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html#usage-on-jdk-8 for more information
Other changes are primarily cosmetic - updating a few outdated sections and replacing HTTP by HTTPS
