### PR TITLE
OMEXMLMetadata: prevent IndexOutOfBoundsException when setting references

### DIFF
--- a/ome-xml/src/test/java/ome/xml/utests/ReferenceIndexingTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/ReferenceIndexingTest.java
@@ -292,17 +292,17 @@ public class ReferenceIndexingTest {
   }
 
   /**
-   * Test adding ROI references non sequentially
+   * Test adding ROI references in reverse order
    */
   @Test
-  public void testAppendImageROIRefNonSequential() {
+  public void testAppendImageROIRefReverseOrder() {
     meta.setImageID("Image:0", 0);
     meta.setROIID("ROI:0", 0);
     meta.setROIID("ROI:1", 1);
     meta.setROIID("ROI:2", 2);
     meta.setROIID("ROI:3", 3);
 
-    // Append first three in non-sequential order
+    // Append first three in reverse order
     meta.setImageROIRef("ROI:2", 0, 2);
     meta.setImageROIRef("ROI:1", 0, 1);
     meta.setImageROIRef("ROI:0", 0, 0);
@@ -323,6 +323,40 @@ public class ReferenceIndexingTest {
     assertEquals("ROI:3", meta.getImageROIRef(0, 0));
     assertEquals("ROI:2", meta.getImageROIRef(0, 1));
     assertEquals("ROI:1", meta.getImageROIRef(0, 2));
+  }
+
+  /**
+   * Test adding ROI references in non-sequential order
+   */
+  @Test
+  public void testAppendImageROIRefNonSequentialOrder() {
+    meta.setImageID("Image:0", 0);
+    meta.setROIID("ROI:0", 0);
+    meta.setROIID("ROI:1", 1);
+    meta.setROIID("ROI:2", 2);
+    meta.setROIID("ROI:3", 3);
+
+    // Append first three in non-sequential order
+    meta.setImageROIRef("ROI:1", 0, 1);
+    meta.setImageROIRef("ROI:0", 0, 0);
+    meta.setImageROIRef("ROI:2", 0, 2);
+    assertEquals(1, meta.getImageROIRefCount(0));
+    assertEquals("ROI:0", meta.getImageROIRef(0, 0));
+    // Resolve the deferred references
+    meta.resolveReferences();
+    assertEquals(3, meta.getImageROIRefCount(0));
+    assertEquals("ROI:0", meta.getImageROIRef(0, 0));
+    assertEquals("ROI:1", meta.getImageROIRef(0, 1));
+    assertEquals("ROI:2", meta.getImageROIRef(0, 2));
+
+    // Replace first
+    meta.setImageROIRef("ROI:3", 0, 0);
+    assertEquals(3, meta.getImageROIRefCount(0));
+
+    // Verify final state
+    assertEquals("ROI:3", meta.getImageROIRef(0, 0));
+    assertEquals("ROI:1", meta.getImageROIRef(0, 1));
+    assertEquals("ROI:2", meta.getImageROIRef(0, 2));
   }
 
   @Test

--- a/ome-xml/src/test/java/ome/xml/utests/ReferenceIndexingTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/ReferenceIndexingTest.java
@@ -258,10 +258,10 @@ public class ReferenceIndexingTest {
   }
 
   /**
-   * Test adding ROI references starting with a positive index
+   * Test adding ROI references starting with a positive offset
    */
   @Test
-  public void testAppendImageROIReferencesOffset() {
+  public void testAppendImageROIRefOffset() {
     meta.setImageID("Image:0", 0);
     meta.setROIID("ROI:0", 0);
     meta.setROIID("ROI:1", 1);
@@ -295,7 +295,7 @@ public class ReferenceIndexingTest {
    * Test adding ROI references non sequentially
    */
   @Test
-  public void testAppendImageROIReferencesNonSequential() {
+  public void testAppendImageROIRefNonSequential() {
     meta.setImageID("Image:0", 0);
     meta.setROIID("ROI:0", 0);
     meta.setROIID("ROI:1", 1);
@@ -323,5 +323,56 @@ public class ReferenceIndexingTest {
     assertEquals("ROI:3", meta.getImageROIRef(0, 0));
     assertEquals("ROI:2", meta.getImageROIRef(0, 1));
     assertEquals("ROI:1", meta.getImageROIRef(0, 2));
+  }
+
+  @Test
+  public void testAppendFolderFolderRef() {
+    meta.setFolderID("Folder:0", 0);
+    meta.setFolderID("Folder:1", 1);
+    meta.setFolderID("Folder:2", 2);
+    meta.setFolderFolderRef("Folder:0", 2, 0);
+    meta.setFolderFolderRef("Folder:1", 2, 1);
+
+    assertEquals(0, meta.getFolderRefCount(0));
+    assertEquals(0, meta.getFolderRefCount(1));
+    assertEquals(2, meta.getFolderRefCount(2));
+    assertEquals("Folder:0", meta.getFolderFolderRef(2, 0));
+    assertEquals("Folder:1", meta.getFolderFolderRef(2, 1));
+
+    // Replace first folder reference
+    meta.setFolderID("Folder:3", 3);
+    meta.setFolderFolderRef("Folder:3", 2, 0);
+    assertEquals("Folder:3", meta.getFolderFolderRef(2, 0));
+    assertEquals("Folder:1", meta.getFolderFolderRef(2, 1));
+  }
+
+  /**
+   * Test adding ROI references non sequentially
+   */
+  @Test
+  public void testAppendFolderFolderRefDeferred() {
+    meta.setFolderID("Folder:1", 0);
+    meta.setFolderID("Folder:2", 1);
+    meta.setFolderFolderRef("Folder:0", 1, 0);
+    meta.setFolderFolderRef("Folder:1", 1, 1);
+    meta.setFolderID("Folder:0", 2);
+
+    // Folder:0 was undefined when calling setFolderFolderRef
+    // so the reference settings should be deferred
+    assertEquals(0, meta.getFolderRefCount(0));
+    assertEquals(0, meta.getFolderRefCount(1));
+    assertEquals(0, meta.getFolderRefCount(2));
+
+    // Resolve the deferred references
+    meta.resolveReferences();
+    assertEquals(2, meta.getFolderRefCount(1));
+    assertEquals("Folder:0", meta.getFolderFolderRef(1, 0));
+    assertEquals("Folder:1", meta.getFolderFolderRef(1, 1));
+
+    // Replace first folder reference
+    meta.setFolderID("Folder:3", 3);
+    meta.setFolderFolderRef("Folder:3", 1, 0);
+    assertEquals("Folder:3", meta.getFolderFolderRef(1, 0));
+    assertEquals("Folder:1", meta.getFolderFolderRef(1, 1));
   }
 }

--- a/ome-xml/src/test/java/ome/xml/utests/ReferenceIndexingTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/ReferenceIndexingTest.java
@@ -256,4 +256,72 @@ public class ReferenceIndexingTest {
     assertEquals("ROI:1", meta.getImageROIRef(0, 1));
     assertEquals("ROI:3", meta.getImageROIRef(0, 2));
   }
+
+  /**
+   * Test adding ROI references starting with a positive index
+   */
+  @Test
+  public void testAppendImageROIReferencesOffset() {
+    meta.setImageID("Image:0", 0);
+    meta.setROIID("ROI:0", 0);
+    meta.setROIID("ROI:1", 1);
+    meta.setROIID("ROI:2", 2);
+    meta.setROIID("ROI:3", 3);
+
+    // Append first three starting with non-zero reference index
+    meta.setImageROIRef("ROI:0", 0, 2);
+    meta.setImageROIRef("ROI:1", 0, 3);
+    meta.setImageROIRef("ROI:2", 0, 4);
+    assertEquals(0, meta.getImageROIRefCount(0));
+
+    // Resolve the deferred references
+    meta.resolveReferences();
+    assertEquals(3, meta.getImageROIRefCount(0));
+    assertEquals("ROI:0", meta.getImageROIRef(0, 0));
+    assertEquals("ROI:1", meta.getImageROIRef(0, 1));
+    assertEquals("ROI:2", meta.getImageROIRef(0, 2));
+
+    // Replace first
+    meta.setImageROIRef("ROI:3", 0, 0);
+    assertEquals(3, meta.getImageROIRefCount(0));
+
+    // Verify final state
+    assertEquals("ROI:3", meta.getImageROIRef(0, 0));
+    assertEquals("ROI:1", meta.getImageROIRef(0, 1));
+    assertEquals("ROI:2", meta.getImageROIRef(0, 2));
+  }
+
+  /**
+   * Test adding ROI references non sequentially
+   */
+  @Test
+  public void testAppendImageROIReferencesNonSequential() {
+    meta.setImageID("Image:0", 0);
+    meta.setROIID("ROI:0", 0);
+    meta.setROIID("ROI:1", 1);
+    meta.setROIID("ROI:2", 2);
+    meta.setROIID("ROI:3", 3);
+
+    // Append first three in non-sequential order
+    meta.setImageROIRef("ROI:2", 0, 2);
+    meta.setImageROIRef("ROI:1", 0, 1);
+    meta.setImageROIRef("ROI:0", 0, 0);
+    assertEquals(1, meta.getImageROIRefCount(0));
+    assertEquals("ROI:0", meta.getImageROIRef(0, 0));
+    // Resolve the deferred references
+    meta.resolveReferences();
+    assertEquals(3, meta.getImageROIRefCount(0));
+    assertEquals("ROI:0", meta.getImageROIRef(0, 0));
+    assertEquals("ROI:2", meta.getImageROIRef(0, 1));
+    assertEquals("ROI:1", meta.getImageROIRef(0, 2));
+
+    // Replace first
+    meta.setImageROIRef("ROI:3", 0, 0);
+    assertEquals(3, meta.getImageROIRefCount(0));
+
+    // Verify final state
+    assertEquals("ROI:3", meta.getImageROIRef(0, 0));
+    assertEquals("ROI:2", meta.getImageROIRef(0, 1));
+    assertEquals("ROI:1", meta.getImageROIRef(0, 2));
+  }
 }

--- a/xsd-fu/templates/java/MetadataStore.template
+++ b/xsd-fu/templates/java/MetadataStore.template
@@ -14,13 +14,17 @@
   // MARKER [A-GET]
 {% end debug %}\
   /**
-   * Set the ${prop.name} property of ${o.name}.
+   * Set the ${prop.name} reference of ${o.name}.
+   *
+   * Replace the existing ${prop.name} reference if ${lang.index_signature(prop.name, 0, 0)['argname']}
+   * is smaller than the number of ${prop.name} references. Otherwise, the index is
+   * ignored and ${prop.name} is added to the list of ${prop.name} references.
    *
    * @param ${prop.argumentName} ${prop.name} to set.
 {% for param in indexes %}\
    * @param ${param['argname']} the ${param['type']} index.
 {% end for %}\
-   * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index (unused).
+   * @param ${lang.index_signature(prop.name, 0, 0)['argname']} ${prop.name} index.
    */
   void set{% if is_multi_path[o.name] %}${parent}{% end %}${obj.name}{% if not prop.hasBaseAttribute %}${prop.name}{% end %}(${prop.metadataStoreArgType} ${prop.argumentName}, ${indexes_string(indexes)}, ${index_string(prop.name)});\
 {% end %}\

--- a/xsd-fu/templates/java/OMEXMLMetadataImpl.template
+++ b/xsd-fu/templates/java/OMEXMLMetadataImpl.template
@@ -149,10 +149,16 @@
       {
         concreteObject.link${prop.methodName}(typedRef);
       }
-      else
+      else if (concreteObject.sizeOfLinked${prop.methodName}List() > ${index_name_string(prop.name)})
       {
         // Set at specific index
         concreteObject.setLinked${prop.methodName}(${index_name_string(prop.name)}, typedRef);
+      } else
+      {
+        // Deferred resolution: reference will be resolved later
+        model.addReference(
+          ${join_accessors(obj.name, parent, prop)},
+          ${prop.instanceVariableName}_reference);
       }
     }
     else


### PR DESCRIPTION
Fixes the issue detected in https://github.com/ome/bioformats/pull/4394#issuecomment-3718441504 as a follow-up of #226 

As shown in the failing tests https://github.com/ome/ome-model/blob/master/specification/samples/2016-06/folders-larger-taxonomy.ome.xml is a good way to reproduce the `IndexOutOfBoundsException` using Bio-Formats `showinf -ome-xml` and `org.openmicroscopy:ome-xml 6.5.2`.

Taking `setImageROIRef(roiReference, imageIndex, roiRefIndex)` as an example, the current logic following the changes in #226 is the following,

1. if the ROI referred by `roiReference` does not exist, the addition of the ROI reference  for image `imageIndex` is deferred under `resolveReferences` is called
2. if the ROI referred by `roiReference` exists and `roiRefIndex == getRoiRefCount`, the ROI reference is appended to the list of references  for image `imageIndex`
3. if the ROI referred by `roiReference` exists and `roiRefIndex < getRoiRefCount`, the ROI reference for image `imageIndex` at `roiRefIndex` is replaced by `roiReference`

This Pull Requests adds a fourth additional conditional  behavior allowing to restore backwards-compatibility

4. if the ROI referred by `roiReference` exists and `roiRefIndex > getRoiRefCount`, the addition of the ROI reference  for image `imageIndex` is deferred under `resolveReferences` is called

Unit tests are also added to cover the different failing scenarios found in our repository tests i.e.:
- Image ROI references added with `roiRefIndex` starting with a non-zero offset
- Folder Folder references added with a mixture of references pointing to existing and non-existing folders