### PR TITLE
Require Java 11 at runtime, build on Java 21/25

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,15 +36,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,26 @@ jobs:
       matrix:
         java: [11, 17, 21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        exclude:
+          - java: 11
+            python: 3.11
+          - java: 11
+            python: 3.12
+          - java: 11
+            python: 3.13
+          - java: 17
+            python: 3.10
+          - java: 17
+            python: 3.12
+          - java: 17
+            python: 3.13
+          - java: 25
+            python: 3.10
+          - java: 25
+            python: 3.11
+          - java: 25
+            python: 3.12
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,23 +18,23 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         exclude:
           - java: 11
-            python: 3.11
+            python-version: 3.11
           - java: 11
-            python: 3.12
+            python-version: 3.12
           - java: 11
-            python: 3.13
+            python-version: 3.13
           - java: 17
-            python: 3.10
+            python-version: 3.10
           - java: 17
-            python: 3.12
+            python-version: 3.12
           - java: 17
-            python: 3.13
+            python-version: 3.13
           - java: 25
-            python: 3.10
+            python-version: 3.10
           - java: 25
-            python: 3.11
+            python-version: 3.11
           - java: 25
-            python: 3.12
+            python-version: 3.12
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        java: [21, 25]
+        java: [11, 17, 21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,47 +13,16 @@ jobs:
       contents: read
     strategy:
       matrix:
-        java: [8, 11, 17, 21]
+        java: [21, 25]
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        exclude:
-          - java: 8
-            python-version: '3.9'
-          - java: 8
-            python-version: '3.10'
-          - java: 8
-            python-version: '3.11'
-          - java: 8
-            python-version: '3.12'
-          - java: 8
-            python-version: '3.13'
-          - java: 17
-            python-version: '3.9'
-          - java: 17
-            python-version: '3.10'
-          - java: 17
-            python-version: '3.11'
-          - java: 17
-            python-version: '3.12'
-          - java: 17
-            python-version: '3.13'
-          - java: 21
-            python-version: '3.9'
-          - java: 21
-            python-version: '3.10'
-          - java: 21
-            python-version: '3.11'
-          - java: 21
-            python-version: '3.12'
-          - java: 21
-            python-version: '3.13'
     runs-on: ${{ matrix.os }}
     env:
       maven_commands: install
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -61,7 +30,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -75,7 +44,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create a GitHub release
         run: gh release create --generate-notes "${GITHUB_REF#refs/tags/}"
         env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@v6
+      - uses: astral-sh/ruff-action@v4
       - name: Lint with Ruff
         run: ruff check --output-format=github

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v3
       - name: Lint with Ruff
         run: ruff check --output-format=github

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ following before submitting a pull request:
 
  * verify that the branch merges cleanly into ```master```
  * verify that the branch compiles using Maven
- * verify that the branch does not use syntax or API specific to Java 1.8+
+ * verify that the branch does not use syntax or API specific to Java > 11
  * internal developers only: [run the data
    tests](https://bio-formats.readthedocs.io/en/stable/developers/commit-testing.html)
    against directories corresponding to the affected format(s)

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
     <logback.version>1.3.16</logback.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <ome_common.version>6.1.1</ome_common.version>
+    <ome_common.version>6.3.0</ome_common.version>
     <ome-common.version>${ome_common.version}</ome-common.version>
     <testng.version>7.9.0</testng.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
     <slf4j.version>2.0.9</slf4j.version>
     <ome_common.version>6.1.1</ome_common.version>
     <ome-common.version>${ome_common.version}</ome-common.version>
+    <testng.version>7.9.0</testng.version>
 
     <ome.model.schemaver>2016-06</ome.model.schemaver>
     <ome.model.schemapath>specification/src/main/resources/released-schema/${ome.model.schemaver}</ome.model.schemapath>
@@ -138,11 +139,9 @@
 	  <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.14.0</version>
-          <!-- Require the Java 8 platform. -->
+          <!-- Require the Java 11 platform. -->
           <configuration>
-            <source>8</source>
-            <target>8</target>
-            <release>8</release>
+            <release>11</release>
           </configuration>
         </plugin>
 
@@ -240,11 +239,11 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <!-- NB: The same version declaration and configuration block also
                appears in the <reporting> section, and must be kept in sync. -->
-          <version>3.0.1</version>
+          <version>3.12.0</version>
           <configuration>
             <failOnError>false</failOnError>
             <links>
-              <link>http://docs.oracle.com/javase/7/docs/api/</link>
+              <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
             </links>
           </configuration>
           <executions>
@@ -376,24 +375,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jdk8-only</id>
-      <activation>
-        <jdk>(,11)</jdk>
-      </activation>
-      <properties>
-        <testng.version>7.5</testng.version>
-      </properties>
-    </profile>
-    <profile>
-      <id>jdk11+</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <properties>
-        <testng.version>7.9.0</testng.version>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
          When possible, we advise using the relevant groupId and version
          properties for your dependencies rather than hardcoding them. -->
 
-    <logback.version>1.3.16</logback.version>
+    <logback.version>1.5.34</logback.version>
     <slf4j.version>2.0.9</slf4j.version>
     <ome_common.version>6.3.0</ome_common.version>
     <ome-common.version>${ome_common.version}</ome-common.version>


### PR DESCRIPTION
See https://www.openmicroscopy.org/2026/03/24/end-of-java-8-support.html. Similar to https://github.com/ome/ome-metakit/pull/33.

The build matrix should probably be pared down again, but wasn't 100% sure what we want at this point so open to discussion.