### PR TITLE
Expose MetadataOnly through metadata APIs

### DIFF
--- a/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
+++ b/ome-xml/src/main/java/ome/xml/meta/MetadataConverter.java
@@ -1299,6 +1299,14 @@ public final class MetadataConverter {
         }
         catch (NullPointerException ignored) { }
 
+        try {
+          Boolean metadataOnly = src.getPixelsMetadataOnly(i);
+          if (metadataOnly != null) {
+            dest.setPixelsMetadataOnly(metadataOnly, i);
+          }
+        }
+        catch (NullPointerException ignored) { }
+
         int binDataCount = 0;
         try {
           binDataCount = src.getPixelsBinDataCount(i);

--- a/ome-xml/src/test/java/ome/xml/utests/MetadataOnlyTest.java
+++ b/ome-xml/src/test/java/ome/xml/utests/MetadataOnlyTest.java
@@ -1,0 +1,131 @@
+/*
+ * #%L
+ * OME XML library
+ * %%
+ * Copyright (C) 2006 - 2026 Open Microscopy Environment:
+ *   - Massachusetts Institute of Technology
+ *   - National Institutes of Health
+ *   - University of Dundee
+ *   - Board of Regents of the University of Wisconsin-Madison
+ *   - Glencoe Software, Inc.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package ome.xml.utests;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.StringReader;
+import java.net.URL;
+import java.util.Arrays;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.SchemaFactory;
+
+import ome.xml.meta.AggregateMetadata;
+import ome.xml.meta.BaseMetadata;
+import ome.xml.meta.DummyMetadata;
+import ome.xml.meta.FilterMetadata;
+import ome.xml.meta.MetadataConverter;
+import ome.xml.meta.OMEXMLMetadataImpl;
+import ome.xml.model.enums.DimensionOrder;
+import ome.xml.model.enums.PixelType;
+import ome.xml.model.primitives.PositiveInteger;
+
+import org.testng.annotations.Test;
+
+/** Tests for MetadataOnly marker access and conversion. */
+public class MetadataOnlyTest {
+
+  @Test
+  public void testMarkerPresence() {
+    OMEXMLMetadataImpl metadata = createMetadata();
+
+    assertFalse(metadata.getPixelsMetadataOnly(0));
+    metadata.setPixelsMetadataOnly(true, 0);
+    assertTrue(metadata.getPixelsMetadataOnly(0));
+    assertTrue(metadata.dumpXML().contains("<MetadataOnly"));
+
+    metadata.setPixelsMetadataOnly(false, 0);
+    assertFalse(metadata.getPixelsMetadataOnly(0));
+    assertFalse(metadata.dumpXML().contains("<MetadataOnly"));
+
+    metadata.setPixelsMetadataOnly(null, 0);
+    assertFalse(metadata.getPixelsMetadataOnly(0));
+  }
+
+  @Test
+  public void testMarkerConversion() throws Exception {
+    OMEXMLMetadataImpl source = createMetadata();
+    source.setPixelsMetadataOnly(true, 0);
+
+    OMEXMLMetadataImpl destination = new OMEXMLMetadataImpl();
+    MetadataConverter.convertMetadata(source, destination);
+
+    assertTrue(destination.getPixelsMetadataOnly(0));
+    String xml = destination.dumpXML();
+    assertTrue(xml.contains("<MetadataOnly"));
+    URL schema = getClass().getResource("/released-schema/2016-06/ome.xsd");
+    SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+      .newSchema(schema).newValidator()
+      .validate(new StreamSource(new StringReader(xml)));
+  }
+
+  @Test
+  public void testMetadataWrappers() {
+    DummyMetadata unsupported = new DummyMetadata();
+    assertNull(unsupported.getPixelsMetadataOnly(0));
+    unsupported.setPixelsMetadataOnly(true, 0);
+
+    OMEXMLMetadataImpl source = createMetadata();
+    source.setPixelsMetadataOnly(true, 0);
+    AggregateMetadata aggregate = new AggregateMetadata(
+      Arrays.<BaseMetadata>asList(unsupported, source));
+    assertEquals(aggregate.getPixelsMetadataOnly(0), Boolean.TRUE);
+
+    OMEXMLMetadataImpl destination = new OMEXMLMetadataImpl();
+    FilterMetadata filter = new FilterMetadata(destination, true);
+    filter.setPixelsMetadataOnly(true, 0);
+    assertTrue(destination.getPixelsMetadataOnly(0));
+  }
+
+  private OMEXMLMetadataImpl createMetadata() {
+    OMEXMLMetadataImpl metadata = new OMEXMLMetadataImpl();
+    PositiveInteger one = new PositiveInteger(1);
+    metadata.setImageID("Image:0", 0);
+    metadata.setPixelsID("Pixels:0", 0);
+    metadata.setPixelsDimensionOrder(DimensionOrder.XYZCT, 0);
+    metadata.setPixelsType(PixelType.UINT8, 0);
+    metadata.setPixelsSizeX(one, 0);
+    metadata.setPixelsSizeY(one, 0);
+    metadata.setPixelsSizeZ(one, 0);
+    metadata.setPixelsSizeC(one, 0);
+    metadata.setPixelsSizeT(one, 0);
+    return metadata;
+  }
+}

--- a/xsd-fu/templates/java/AggregateMetadata.template
+++ b/xsd-fu/templates/java/AggregateMetadata.template
@@ -547,6 +547,21 @@ ${counter(k, o, v)}\
     return null;
   }
 
+  /** Gets whether the Pixels element contains a MetadataOnly marker. */
+  public Boolean getPixelsMetadataOnly(int imageIndex)
+  {
+    for (Object o : delegates)
+    {
+      if (o instanceof MetadataRetrieve)
+      {
+        MetadataRetrieve retrieve = (MetadataRetrieve) o;
+        Boolean result = retrieve.getPixelsMetadataOnly(imageIndex);
+        if (result != null) return result;
+      }
+    }
+    return null;
+  }
+
   /** Gets the Map value associated with this annotation */
   public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
   {
@@ -702,6 +717,18 @@ ${getter(k, o, prop, v)}\
       if (o instanceof MetadataStore)
       {
         ((MetadataStore) o).setCreator(creator);
+      }
+    }
+  }
+
+  /** Sets whether the Pixels element contains a MetadataOnly marker. */
+  public void setPixelsMetadataOnly(Boolean metadataOnly, int imageIndex)
+  {
+    for (Object o : delegates)
+    {
+      if (o instanceof MetadataStore)
+      {
+        ((MetadataStore) o).setPixelsMetadataOnly(metadataOnly, imageIndex);
       }
     }
   }

--- a/xsd-fu/templates/java/FilterMetadata.template
+++ b/xsd-fu/templates/java/FilterMetadata.template
@@ -220,6 +220,12 @@ public class FilterMetadata implements MetadataStore
     store.setCreator(creator);
   }
 
+  /* @see MetadataStore#setPixelsMetadataOnly(Boolean, int) */
+  public void setPixelsMetadataOnly(Boolean metadataOnly, int imageIndex)
+  {
+    store.setPixelsMetadataOnly(metadataOnly, imageIndex);
+  }
+
   // -- AggregateMetadata API methods --
 
   // -- Entity storage (manual definitions) --

--- a/xsd-fu/templates/java/MetadataRetrieve.template
+++ b/xsd-fu/templates/java/MetadataRetrieve.template
@@ -390,6 +390,18 @@ public interface MetadataRetrieve extends BaseMetadata {
     return null;
   }
 
+  /**
+   * Get whether the Pixels element contains a MetadataOnly marker.
+   *
+   * @param imageIndex the Image index.
+   * @return true if the marker is present, false if it is absent, or null if
+   *   this metadata implementation cannot determine its presence.
+   */
+  default Boolean getPixelsMetadataOnly(int imageIndex)
+  {
+    return null;
+  }
+
   // -- Entity retrieval (code generated definitions) --
 
 {% for o in sorted(model.objects.values(), key=lambda x: x.name) %}\

--- a/xsd-fu/templates/java/MetadataStore.template
+++ b/xsd-fu/templates/java/MetadataStore.template
@@ -239,6 +239,16 @@ public interface MetadataStore extends BaseMetadata
   {
   }
 
+  /**
+   * Set whether the Pixels element contains a MetadataOnly marker.
+   *
+   * @param metadataOnly true to add the marker, false or null to remove it.
+   * @param imageIndex the Image index.
+   */
+  default void setPixelsMetadataOnly(Boolean metadataOnly, int imageIndex)
+  {
+  }
+
 {% for o in sorted(model.objects.values(), key=lambda x: x.name) %}\
 {% if o.name not in fu.METADATA_OBJECT_IGNORE %}\
 {% if o.langBaseType != 'Object' %}\

--- a/xsd-fu/templates/java/OMEXMLMetadataImpl.template
+++ b/xsd-fu/templates/java/OMEXMLMetadataImpl.template
@@ -524,6 +524,12 @@ ${counter(k, o, v)}\
     return root.getCreator();
   }
 
+  /** Gets whether the Pixels element contains a MetadataOnly marker. */
+  public Boolean getPixelsMetadataOnly(int imageIndex)
+  {
+    return root.getImage(imageIndex).getPixels().getMetadataOnly() != null;
+  }
+
   /** Gets the Map value associated with this annotation */
   public List<MapPair> getMapAnnotationValue(int mapAnnotationIndex)
   {
@@ -634,6 +640,24 @@ ${getter(k, o, prop, v)}\
   public void setCreator(String creator)
   {
     root.setCreator(creator);
+  }
+
+  /** Sets whether the Pixels element contains a MetadataOnly marker. */
+  public void setPixelsMetadataOnly(Boolean metadataOnly, int imageIndex)
+  {
+    OME o0 = root;
+    if (o0.sizeOfImageList() == imageIndex)
+    {
+      o0.addImage(new Image());
+    }
+    Image o1 = o0.getImage(imageIndex);
+    if (o1.getPixels() == null)
+    {
+      o1.setPixels(new Pixels());
+    }
+    Pixels o2 = o1.getPixels();
+    o2.setMetadataOnly(Boolean.TRUE.equals(metadataOnly) ?
+      new MetadataOnly() : null);
   }
 
   /** Sets the Map value associated with this annotation */


### PR DESCRIPTION
Hej,

While testing Bio-Formats memoization and diagnosing some other memoization problems which came up due to testing Java 25 build of ome/bioformats#4450 and its use of `MetadataOnly`, the OME-XML schema failed validation after active memoization.
The failure was initially addressed haphazardly by me in ome/bioformats#4459, but I traced the underlying conversion problem to `ome.xml.meta.MetadataConverter`, making this an `ome-model` issue rather than a Bioformats-Memoizer-specific problem.

OME 2016-06 requires each `Pixels` element to contain one of `BinData`, `TiffData`, or `MetadataOnly`.

Unlike the other alternatives, `MetadataOnly` is an empty marker element. The metadata code generator exposes values, attributes, references, and repeated entities through `MetadataRetrieve` and `MetadataStore`, but it previously generated no API for this marker.

Consequently, `MetadataConverter` could copy every ordinary `Pixels` property while silently dropping `MetadataOnly`. The resulting OME-XML contained a `Pixels` element without any member of the required schema choice and was therefore invalid.

## Changes

Add generated presence accessors for the marker:

- `MetadataRetrieve#getPixelsMetadataOnly(int)`
- `MetadataStore#setPixelsMetadataOnly(Boolean, int)`

The getter returns:

- `true` when the marker is present
- `false` when it is absent
- `null` when an implementation cannot determine its presence

Both methods are interface defaults so existing third-party metadata
implementations remain compatible. The default getter returns `null`, and the
default setter is a no-op.

Implement the accessors in:

- `OMEXMLMetadataImpl`
- `AggregateMetadata`
- `FilterMetadata`

`OMEXMLMetadataImpl` creates or removes the concrete marker according to the
Boolean value. `MetadataConverter` now copies the marker exclusively through
the metadata interfaces, without depending on concrete OME model classes.

## Tests

Add focused coverage for:

- creating and removing the marker
- nullable compatibility defaults
- aggregate and filtering metadata wrappers
- generic metadata conversion
- validation of converted XML against the bundled OME 2016-06 schema

The branch passes all local tests.